### PR TITLE
Added feature to review discussion notes too.

### DIFF
--- a/daiv/automation/agents/pr_describer/schemas.py
+++ b/daiv/automation/agents/pr_describer/schemas.py
@@ -4,7 +4,13 @@ from pydantic import BaseModel, Field
 class PullRequestDescriberOutput(BaseModel):
     branch: str = Field(description=("The branch name associated with the changes."))
     title: str = Field(description="Title with no more than 10 words and concise description of the changes.")
-    description: str = Field(description=("Description of the functional changes."))
+    description: str = Field(
+        description=(
+            "Description of the functional changes. Refer always to the changes and not to the pull request, example: "
+            "`The changes add a new function to calculate the area of a rectangle.` not "
+            "`The pull request adds a new function to calculate the area of a rectangle.`"
+        )
+    )
     summary: list[str] = Field(
         description=(
             "Concise bulleted description of the pull request."

--- a/daiv/codebase/managers/review_addressor.py
+++ b/daiv/codebase/managers/review_addressor.py
@@ -43,14 +43,6 @@ class DiscussionReviewContext:
     diff: str | None = None
 
 
-class DiffProcessor:
-    """Abstract base class for processing diffs."""
-
-    def process_diff(self, diff_content: bytes) -> PatchedFile:
-        patch_set = PatchSet.from_string(diff_content, encoding="utf-8")
-        return patch_set[0] if patch_set else None
-
-
 class NoteProcessor:
     """
     Processes text-based diff notes.
@@ -139,12 +131,13 @@ class ReviewAddressorManager:
     Manages the code review process.
     """
 
-    def __init__(self, client: AllRepoClient, repo_id: str, merge_request_source_branch: str):
+    def __init__(self, client: AllRepoClient, repo_id: str, merge_request_id: int, merge_request_source_branch: str):
         self.client = client
         self.repo_id = repo_id
+        self.merge_request_id = merge_request_id
         self.merge_request_source_branch = merge_request_source_branch
+        self.thread_id = f"{repo_id}!{merge_request_source_branch}#{merge_request_id}"
         self.repo_config = RepositoryConfig.get_config(repo_id=repo_id)
-        self.diff_processor = DiffProcessor()
         self.note_processor = NoteProcessor()
 
     @classmethod
@@ -153,15 +146,13 @@ class ReviewAddressorManager:
         Process code review for merge request.
         """
         client = RepoClient.create_instance()
-        manager = cls(client, repo_id, merge_request_source_branch)
+        manager = cls(client, repo_id, merge_request_id, merge_request_source_branch)
         manager._process_review(merge_request_id)
 
     def _process_review(self, merge_request_id: int):
         merge_request_patches = self._extract_merge_request_diffs(merge_request_id)
         for context in self._process_discussions(merge_request_id, merge_request_patches):
-            config = RunnableConfig(
-                configurable={"thread_id": f"{self.repo_id}!{merge_request_id}#{context.discussion.id}"}
-            )
+            config = RunnableConfig(configurable={"thread_id": f"{self.thread_id}#{context.discussion.id}"})
 
             with (
                 PostgresSaver.from_conn_string(settings.DB_URI) as checkpointer,
@@ -219,11 +210,15 @@ class ReviewAddressorManager:
         Extract patch files from merge request.
         """
         merge_request_patches: dict[str, PatchedFile] = {}
+        patch_set_all = PatchSet([])
 
         for mr_diff in self.client.get_merge_request_diff(self.repo_id, merge_request_id):
             if mr_diff.diff:
                 patch_set = PatchSet.from_string(mr_diff.diff, encoding="utf-8")
                 merge_request_patches[patch_set[0].path] = patch_set[0]
+                patch_set_all.append(patch_set[0])
+
+        merge_request_patches["__all__"] = patch_set_all
 
         return merge_request_patches
 
@@ -236,7 +231,7 @@ class ReviewAddressorManager:
         discussions = []
 
         for discussion in self.client.get_merge_request_discussions(
-            self.repo_id, merge_request_id, note_type=NoteType.DIFF_NOTE
+            self.repo_id, merge_request_id, note_types=[NoteType.DIFF_NOTE, NoteType.DISCUSSION_NOTE]
         ):
             if discussion.notes[-1].author.id == self.client.current_user.id:
                 logger.debug("Ignoring discussion, DAIV is the current user: %s", discussion.id)
@@ -245,20 +240,24 @@ class ReviewAddressorManager:
             context = DiscussionReviewContext(discussion=discussion)
 
             for note in discussion.notes:
-                if not note.position:
-                    logger.warning("Ignoring note, no position defined: %s", note.id)
-                    continue
+                if note.type == NoteType.DISCUSSION_NOTE:
+                    context.diff = merge_request_patches["__all__"].__str__()
 
-                path = note.position.new_path or note.position.old_path
+                elif note.type == NoteType.DIFF_NOTE:
+                    if not note.position:
+                        logger.warning("Ignoring note, no position defined: %s", note.id)
+                        continue
 
-                if path not in merge_request_patches:
-                    logger.warning("Ignoring note, path not found in patches: %s", note.id)
-                    continue
+                    path = note.position.new_path or note.position.old_path
 
-                if context.patch_file is None:
-                    # This logic assumes that all notes will have the same patch file and
-                    context.patch_file = merge_request_patches[path]
-                    context.diff = self.note_processor.extract_diff(note, context.patch_file)
+                    if path not in merge_request_patches:
+                        logger.warning("Ignoring note, path not found in patches: %s", note.id)
+                        continue
+
+                    if context.patch_file is None:
+                        # This logic assumes that all notes will have the same patch file and
+                        context.patch_file = merge_request_patches[path]
+                        context.diff = self.note_processor.extract_diff(note, context.patch_file)
 
                 context.notes.append(note)
 
@@ -271,10 +270,10 @@ class ReviewAddressorManager:
         Commit changes to the merge request.
         """
         pr_describer = PullRequestDescriberAgent()
-        changes_description = pr_describer.agent.invoke({
-            "changes": file_changes,
-            "branch_name_convention": self.repo_config.branch_name_convention,
-        })
+        changes_description = pr_describer.agent.invoke(
+            {"changes": file_changes, "branch_name_convention": self.repo_config.branch_name_convention},
+            config=RunnableConfig(configurable={"thread_id": f"{self.thread_id}#{discussion_id}"}),
+        )
 
         self.client.create_merge_request_discussion_note(
             self.repo_id, merge_request_id, discussion_id, changes_description.description


### PR DESCRIPTION
This pull request includes several changes to improve the handling of discussions and notes in the codebase, as well as some refactoring to streamline the review process. The most important changes include updates to the `PullRequestDescriberOutput` schema, modifications to methods handling discussions and notes, and refactoring in the `review_addressor` module.

Closes: #37 

### Schema Updates:
* [`daiv/automation/agents/pr_describer/schemas.py`](diffhunk://#diff-87abeff670c3195549b17b36762b65d8840fbfd0337070e11c4b21d95d56724eL7-R13): Enhanced the `description` field in the `PullRequestDescriberOutput` class to provide clearer guidelines on how to describe functional changes.

### Method Updates:
* [`daiv/codebase/clients.py`](diffhunk://#diff-c28077e59ee528bf52c88c8fb861743f7cbb63a004f34d6472ef3045ea6a14c7L151-R151): Updated methods to handle a list of `NoteType` instead of a single `NoteType`, improving flexibility in filtering discussions and notes. [[1]](diffhunk://#diff-c28077e59ee528bf52c88c8fb861743f7cbb63a004f34d6472ef3045ea6a14c7L151-R151) [[2]](diffhunk://#diff-c28077e59ee528bf52c88c8fb861743f7cbb63a004f34d6472ef3045ea6a14c7L785-R787) [[3]](diffhunk://#diff-c28077e59ee528bf52c88c8fb861743f7cbb63a004f34d6472ef3045ea6a14c7L803-R805) [[4]](diffhunk://#diff-c28077e59ee528bf52c88c8fb861743f7cbb63a004f34d6472ef3045ea6a14c7L886-R888) [[5]](diffhunk://#diff-c28077e59ee528bf52c88c8fb861743f7cbb63a004f34d6472ef3045ea6a14c7L905-R916) [[6]](diffhunk://#diff-c28077e59ee528bf52c88c8fb861743f7cbb63a004f34d6472ef3045ea6a14c7L962-R964)

### Refactoring:
* [`daiv/codebase/managers/review_addressor.py`](diffhunk://#diff-911dbc673cbf46c243ea7ec119230710c8a03819d059d18cd4925f7abc69cc11L46-L53): Removed the `DiffProcessor` class and associated code, and updated the `ReviewAddressorManager` to use a more streamlined approach for handling merge request diffs and discussions. [[1]](diffhunk://#diff-911dbc673cbf46c243ea7ec119230710c8a03819d059d18cd4925f7abc69cc11L46-L53) [[2]](diffhunk://#diff-911dbc673cbf46c243ea7ec119230710c8a03819d059d18cd4925f7abc69cc11L142-L147) [[3]](diffhunk://#diff-911dbc673cbf46c243ea7ec119230710c8a03819d059d18cd4925f7abc69cc11L156-R155) [[4]](diffhunk://#diff-911dbc673cbf46c243ea7ec119230710c8a03819d059d18cd4925f7abc69cc11R213-R221) [[5]](diffhunk://#diff-911dbc673cbf46c243ea7ec119230710c8a03819d059d18cd4925f7abc69cc11L239-R234) [[6]](diffhunk://#diff-911dbc673cbf46c243ea7ec119230710c8a03819d059d18cd4925f7abc69cc11R243-R246) [[7]](diffhunk://#diff-911dbc673cbf46c243ea7ec119230710c8a03819d059d18cd4925f7abc69cc11L274-R276)