### PR TITLE
Added default assignee when creating MR based on Issue.

### DIFF
--- a/daiv/codebase/clients.py
+++ b/daiv/codebase/clients.py
@@ -484,6 +484,7 @@ class GitLabClient(RepoClient):
         title: str,
         description: str,
         labels: list[str] | None = None,
+        assignee_id: int | None = None,
     ) -> int | str | None:
         """
         Create a merge request in a repository or update an existing one if it already exists.
@@ -495,6 +496,7 @@ class GitLabClient(RepoClient):
             title: The title of the merge request.
             description: The description of the merge request.
             labels: The list of labels.
+            assignee_id: The assignee ID.
 
         Returns:
             The merge request ID.
@@ -507,6 +509,7 @@ class GitLabClient(RepoClient):
                 "title": title,
                 "description": description,
                 "labels": labels or [],
+                "assignee_id": assignee_id,
             }).get_id()
         except GitlabCreateError as e:
             if e.response_code != 409:
@@ -518,6 +521,7 @@ class GitLabClient(RepoClient):
                 merge_request.title = title
                 merge_request.description = description
                 merge_request.labels = labels or []
+                merge_request.assignee_id = assignee_id
                 merge_request.save()
                 return merge_request.get_id()
             raise e

--- a/daiv/codebase/managers/issue_addressor.py
+++ b/daiv/codebase/managers/issue_addressor.py
@@ -186,6 +186,7 @@ class IssueAddressorManager(BaseManager):
             target_branch=self.ref,
             labels=[BOT_LABEL],
             title=changes_description.title,
+            assignee_id=issue.assignee.id if issue.assignee else None,
             description=jinja2_formatter(
                 ISSUE_MERGE_REQUEST_TEMPLATE,
                 description=changes_description.description,


### PR DESCRIPTION
This pull request includes changes to the `daiv/codebase/clients.py` and `daiv/codebase/managers/issue_addressor.py` files to add support for assigning an assignee to merge requests. The most important changes include adding the `assignee_id` parameter to the `update_or_create_merge_request` method and updating the `_commit_changes` method to set the assignee ID from the issue.

Enhancements to merge request assignment:

* [`daiv/codebase/clients.py`](diffhunk://#diff-c28077e59ee528bf52c88c8fb861743f7cbb63a004f34d6472ef3045ea6a14c7R487): Added `assignee_id` parameter to the `update_or_create_merge_request` method, updated the method's docstring, and included `assignee_id` in the request payload for both creating and updating merge requests. [[1]](diffhunk://#diff-c28077e59ee528bf52c88c8fb861743f7cbb63a004f34d6472ef3045ea6a14c7R487) [[2]](diffhunk://#diff-c28077e59ee528bf52c88c8fb861743f7cbb63a004f34d6472ef3045ea6a14c7R499) [[3]](diffhunk://#diff-c28077e59ee528bf52c88c8fb861743f7cbb63a004f34d6472ef3045ea6a14c7R512) [[4]](diffhunk://#diff-c28077e59ee528bf52c88c8fb861743f7cbb63a004f34d6472ef3045ea6a14c7R524)

* [`daiv/codebase/managers/issue_addressor.py`](diffhunk://#diff-ba153b86bce9dc75dbd43b94135a5b91eec9c27fd108590d648146c75feed1e7R189): Updated the `_commit_changes` method to set the `assignee_id` from the issue's assignee if available.