### PR TITLE
Fixed repositories access level.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.1.0-alpha.4] - 2024-12-06
+
+### Fixed
+
+- Fixed the access level for the maintainer role when listing repositories to only include repositories that the authenticated user is a member of.
+
 ## [0.1.0-alpha.3] - 2024-12-06
 
 ### Fixed
@@ -41,7 +47,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release of the `daiv` project.
 
-[Unreleased]: https://github.com/srtab/daiv/compare/v0.1.0-alpha.3...HEAD
+[Unreleased]: https://github.com/srtab/daiv/compare/v0.1.0-alpha.4...HEAD
+[0.1.0-alpha.4]: https://github.com/srtab/daiv/compare/v0.1.0-alpha.3...v0.1.0-alpha.4
 [0.1.0-alpha.3]: https://github.com/srtab/daiv/compare/v0.1.0-alpha.2...v0.1.0-alpha.3
 [0.1.0-alpha.2]: https://github.com/srtab/daiv/compare/v0.1.0-alpha.1...v0.1.0-alpha.2
 [0.1.0-alpha.1]: https://github.com/srtab/daiv/compare/v0.1.0-alpha...v0.1.0-alpha.1

--- a/daiv/codebase/clients.py
+++ b/daiv/codebase/clients.py
@@ -252,7 +252,13 @@ class GitLabClient(RepoClient):
                 topics=project.topics,
             )
             for project in self.client.projects.list(
-                all=load_all, iterator=True, archived=False, simple=True, **optional_kwargs
+                all=load_all,
+                iterator=True,
+                archived=False,
+                simple=True,
+                membership=True,
+                min_access_level=40,  # 40 is the access level for the maintainer role
+                **optional_kwargs,
             )
         ]
 

--- a/daiv/daiv/__init__.py
+++ b/daiv/daiv/__init__.py
@@ -2,6 +2,6 @@
 # Django starts so that shared_task will use this app.
 from .celeryapp import app as celery_app
 
-__version__ = "0.1.0-alpha.3"
+__version__ = "0.1.0-alpha.4"
 
 __all__ = ("celery_app",)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "daiv"
-version = "0.1.0-alpha.3"
+version = "0.1.0-alpha.4"
 description = "Developer assistant automating code issues, reviews, and pipeline fixes using AI Agents."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -422,7 +422,7 @@ wheels = [
 
 [[package]]
 name = "daiv"
-version = "0.1.0a3"
+version = "0.1.0a4"
 source = { virtual = "." }
 dependencies = [
     { name = "celery", extra = ["redis"] },


### PR DESCRIPTION
This pull request includes updates for the `daiv` project, primarily focused on upgrading the version to `0.1.0-alpha.4` and fixing access level issues for the maintainer role when listing repositories.

Version updates:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L3-R3): Updated the project version to `0.1.0-alpha.4`.
* [`daiv/daiv/__init__.py`](diffhunk://#diff-285390e47efa82d1710748e8b549b74bb69b1294f4b242323bed6a7919aa5a3bL5-R5): Updated the `__version__` variable to `0.1.0-alpha.4`.

Changelog updates:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10-R15): Added a new section for `0.1.0-alpha.4`, detailing the fixed access level for the maintainer role.
* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edL44-R51): Updated the comparison links to include `0.1.0-alpha.4`.

Bug fixes:

* [`daiv/codebase/clients.py`](diffhunk://#diff-c28077e59ee528bf52c88c8fb861743f7cbb63a004f34d6472ef3045ea6a14c7L255-R261): Fixed the access level for the maintainer role when listing repositories to only include repositories that the authenticated user is a member of.