### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,5 +1,8 @@
 name: Documentation
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:
@@ -47,6 +50,8 @@ jobs:
     if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout current branch


### PR DESCRIPTION
Potential fix for [https://github.com/srtab/daiv/security/code-scanning/5](https://github.com/srtab/daiv/security/code-scanning/5)

To fix the issue, we will add a `permissions` block to the workflow. At the workflow level, we will set `contents: read` as the default permission. For the `publish` job, which requires write access to the repository contents, we will override the default permissions and explicitly grant `contents: write`. This ensures that the `build` job and other parts of the workflow have minimal permissions, while the `publish` job has the necessary permissions to perform its tasks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
