### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,6 +10,10 @@ on:
       - 'uv.lock'
       - '.github/workflows/docker.yml'
 
+permissions:
+  contents: read
+  packages: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/srtab/daiv/security/code-scanning/2](https://github.com/srtab/daiv/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow to define the least privileges required for the tasks. Based on the workflow's steps:
- The `contents: read` permission is needed to access repository contents.
- The `packages: write` permission is required to push Docker images to the GitHub Container Registry.

We will add these permissions to the workflow to ensure it operates securely while adhering to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
