### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/srtab/daiv/security/code-scanning/4](https://github.com/srtab/daiv/security/code-scanning/4)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow only performs tasks like installing dependencies, running linters, and executing tests, it does not require write permissions. The minimal required permission is `contents: read`. We will add this permission at the workflow level to apply it to all jobs (`lint` and `tests`).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
