### PR TITLE
Fix async auth bearer return type

### DIFF
--- a/daiv/chat/api/security.py
+++ b/daiv/chat/api/security.py
@@ -1,6 +1,3 @@
-from collections.abc import Coroutine
-from typing import Any
-
 from asgiref.sync import sync_to_async
 from ninja.security import HttpBearer
 
@@ -25,9 +22,7 @@ class AuthBearer(HttpBearer):
 
 
 class AsyncAuthBearer(AuthBearer):
-    """
-    Async authentication class for the API using API keys.
-    """
+    """Async authentication class for the API using API keys."""
 
-    async def authenticate(self, request, key: str | None) -> Coroutine[Any, Any, User | None]:
+    async def authenticate(self, request, key: str | None) -> User | None:
         return await sync_to_async(super().authenticate)(request, key)


### PR DESCRIPTION
## Summary
- fix return type of `AsyncAuthBearer.authenticate`

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684049f7fe0c8330b921909899e5e020