### PR TITLE
Add per-repository allowed_usernames to restrict who can trigger DAIV

### DIFF
--- a/.daiv.yml
+++ b/.daiv.yml
@@ -1,2 +1,5 @@
+allowed_usernames:
+  - srtab
+
 sandbox:
   base_image: "ghcr.io/astral-sh/uv:python3.14-bookworm"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `EnsureNonEmptyResponseMiddleware` to detect and recover from empty LLM responses by injecting a no-op tool call that prompts the model to retry.
 - Added `--update` flag to `setup_webhooks` command to update existing webhooks on demand.
 - Added `--repo-id` option to `setup_webhooks` command to restrict setup to a specific repository.
+- Added `allowed_usernames` option to `.daiv.yml` to restrict which users can interact with DAIV on a per-repository basis. Useful for public repositories where you want to limit who can trigger DAIV.
 
 ### Changed
 

--- a/daiv/codebase/clients/github/api/callbacks.py
+++ b/daiv/codebase/clients/github/api/callbacks.py
@@ -10,7 +10,7 @@ from codebase.tasks import address_issue_task, address_mr_comments_task
 from codebase.utils import note_mentions_daiv
 from core.constants import BOT_AUTO_LABEL, BOT_LABEL, BOT_MAX_LABEL
 
-from .models import Comment, Issue, Label, Repository  # noqa: TC001
+from .models import Comment, Issue, Label, Repository, User  # noqa: TC001
 
 logger = logging.getLogger("daiv.webhooks")
 
@@ -31,6 +31,7 @@ class IssueCallback(GitHubCallback):
     action: Literal["opened", "edited", "reopened", "labeled", "closed"]
     issue: Issue
     label: Label | None = None
+    sender: User
 
     def model_post_init(self, __context: Any):
         self._repo_config = RepositoryConfig.get_config(self.repository.full_name)
@@ -43,6 +44,16 @@ class IssueCallback(GitHubCallback):
             and self.issue.state == "open"
             and self.action in ["opened", "reopened", "labeled"]
         ):
+            return False
+
+        # Check if user is allowed to interact with DAIV
+        if not self._repo_config.is_user_allowed(self.sender.username):
+            logger.info(
+                "Rejecting issue %s#%s: user '%s' is not in the allowed usernames list",
+                self.repository.full_name,
+                self.issue.number,
+                self.sender.username,
+            )
             return False
 
         # Check if DAIV has already reacted to the issue (prevents re-launching when label is removed and re-added)
@@ -98,6 +109,16 @@ class IssueCommentCallback(GitHubCallback):
             or self.issue.state != "open"
             or self.comment.user.id == self._client.current_user.id
         ):
+            return False
+
+        # Check if user is allowed to interact with DAIV
+        if not self._repo_config.is_user_allowed(self.comment.user.username):
+            logger.info(
+                "Rejecting comment on %s#%s: user '%s' is not in the allowed usernames list",
+                self.repository.full_name,
+                self.issue.number,
+                self.comment.user.username,
+            )
             return False
 
         return bool(self._is_issue_comment or self._is_merge_request_review)

--- a/daiv/codebase/clients/gitlab/api/callbacks.py
+++ b/daiv/codebase/clients/gitlab/api/callbacks.py
@@ -10,7 +10,17 @@ from codebase.tasks import address_issue_task, address_mr_comments_task
 from codebase.utils import note_mentions_daiv
 from core.constants import BOT_AUTO_LABEL, BOT_LABEL, BOT_MAX_LABEL
 
-from .models import Issue, IssueAction, IssueChanges, MergeRequest, Note, NoteableType, NoteAction, Project, User
+from .models import (  # noqa: TC001
+    Issue,
+    IssueAction,
+    IssueChanges,
+    MergeRequest,
+    Note,
+    NoteableType,
+    NoteAction,
+    Project,
+    User,
+)
 
 logger = logging.getLogger("daiv.webhooks")
 
@@ -22,6 +32,7 @@ class IssueCallback(BaseCallback):
 
     object_kind: Literal["issue", "work_item"]
     project: Project
+    user: User
     object_attributes: Issue
     changes: IssueChanges | None = None
 
@@ -38,6 +49,16 @@ class IssueCallback(BaseCallback):
             and self.object_attributes.state == "opened"
             and self.object_attributes.action in [IssueAction.OPEN, IssueAction.UPDATE]
         ):
+            return False
+
+        # Check if user is allowed to interact with DAIV
+        if not self._repo_config.is_user_allowed(self.user.username):
+            logger.info(
+                "Rejecting issue %s#%s: user '%s' is not in the allowed usernames list",
+                self.project.path_with_namespace,
+                self.object_attributes.iid,
+                self.user.username,
+            )
             return False
 
         # Check if DAIV has already reacted to the issue (prevents re-launching when label is removed and re-added)
@@ -109,6 +130,15 @@ class NoteCallback(BaseCallback):
             or self.object_attributes.system
             or self.user.id == self._client.current_user.id
         ):
+            return False
+
+        # Check if user is allowed to interact with DAIV
+        if not self._repo_config.is_user_allowed(self.user.username):
+            logger.info(
+                "Rejecting note on project %s: user '%s' is not in the allowed usernames list",
+                self.project.path_with_namespace,
+                self.user.username,
+            )
             return False
 
         return bool(self._is_issue_comment or self._is_merge_request_comment)

--- a/daiv/codebase/repo_config.py
+++ b/daiv/codebase/repo_config.py
@@ -184,6 +184,15 @@ class RepositoryConfig(BaseModel):
     Configuration for a repository.
     """
 
+    allowed_usernames: tuple[str, ...] = Field(
+        default_factory=tuple,
+        description=(
+            "List of usernames allowed to interact with DAIV on this repository. "
+            "When empty, all users are allowed. "
+            "Useful for public repositories where you want to restrict who can trigger DAIV."
+        ),
+    )
+
     default_branch: str | None = Field(
         default=None,
         description=(
@@ -222,6 +231,15 @@ class RepositoryConfig(BaseModel):
         default_factory=Sandbox, description="Configure the daiv-sandbox instance to be used to execute commands."
     )
     models: Models = Field(default_factory=Models, description="Configure model settings for agents.")
+
+    def is_user_allowed(self, username: str) -> bool:
+        """
+        Check if a user is allowed to interact with DAIV on this repository.
+        When the allowlist is empty, all users are allowed.
+        """
+        if not self.allowed_usernames:
+            return True
+        return username.lower() in {u.lower() for u in self.allowed_usernames}
 
     @staticmethod
     def get_config(repo_id: str, *, repository: Repository | None = None, offline: bool = False) -> RepositoryConfig:

--- a/docs/customization/repository-config.md
+++ b/docs/customization/repository-config.md
@@ -9,6 +9,11 @@ Customize DAIV's behavior per repository using a `.daiv.yml` file in the root of
 default_branch: main
 context_file_name: "AGENTS.md"
 
+# Access control
+allowed_usernames:
+  - alice
+  - bob
+
 # Files the agent can see but won't read
 omit_content_patterns:
   - "*.min.js"
@@ -56,6 +61,26 @@ models:
 
 !!! tip
     The `AGENTS.md` file helps DAIV understand your repository's structure, conventions, and constraints. You can generate one using the `/init` skill — see [Slash Commands & Skills](../features/slash-commands.md#init).
+
+## Access control
+
+Restrict which users can interact with DAIV on this repository. This is particularly useful for **public repositories** where you want to prevent arbitrary users from triggering DAIV.
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `allowed_usernames` | `list[str]` | `[]` | Usernames allowed to interact with DAIV. When empty, all users are allowed. |
+
+```yaml
+allowed_usernames:
+  - alice
+  - bob
+  - charlie
+```
+
+When the list is empty or omitted, **all users** can interact with DAIV (default behavior). When populated, only the listed users can trigger DAIV through issues, comments, and merge request reviews. Username matching is case-insensitive.
+
+!!! tip
+    Push events (e.g., configuration cache invalidation) are not affected by the allowlist — they are system-level operations tied to the webhook, not to individual users.
 
 ## File access
 

--- a/tests/unit_tests/codebase/clients/github/api/test_callbacks.py
+++ b/tests/unit_tests/codebase/clients/github/api/test_callbacks.py
@@ -2,8 +2,8 @@ from unittest.mock import Mock
 
 import pytest
 
-from codebase.clients.github.api.callbacks import IssueCallback
-from codebase.clients.github.api.models import Issue, Label, Repository
+from codebase.clients.github.api.callbacks import IssueCallback, IssueCommentCallback
+from codebase.clients.github.api.models import Comment, Issue, Label, Repository, User
 from codebase.repo_config import RepositoryConfig
 
 
@@ -33,7 +33,11 @@ def monkeypatch_dependencies(monkeypatch, mock_repo_client, mock_repo_config):
 
 
 def create_issue_callback(
-    action: str, issue_labels: list[dict], issue_state: str = "open", label: Label | None = None
+    action: str,
+    issue_labels: list[dict],
+    issue_state: str = "open",
+    label: Label | None = None,
+    sender_username: str = "testuser",
 ) -> IssueCallback:
     """Helper to create an IssueCallback instance."""
     return IssueCallback(
@@ -41,6 +45,7 @@ def create_issue_callback(
         repository=Repository(id=1, full_name="owner/repo", default_branch="main"),
         issue=Issue(id=100, number=42, title="Test Issue", state=issue_state, labels=issue_labels),
         label=label,
+        sender=User(**{"id": 10, "login": sender_username}),
     )
 
 
@@ -125,5 +130,63 @@ class TestIssueCallback:
         """Test that label checking is case-insensitive."""
         callback = create_issue_callback(
             action="labeled", issue_labels=[{"name": "DAIV"}], label=Label(id=1, name="DAIV")
+        )
+        assert callback.accept_callback() is True
+
+    def test_reject_callback_user_not_in_allowlist(self, monkeypatch_dependencies, mock_repo_config):
+        """Test that callback is rejected when user is not in the allowed usernames list."""
+        mock_repo_config.allowed_usernames = ("alice", "bob")
+
+        callback = create_issue_callback(action="opened", issue_labels=[{"name": "daiv"}], sender_username="mallory")
+        assert callback.accept_callback() is False
+
+    def test_accept_callback_user_in_allowlist(self, monkeypatch_dependencies, mock_repo_config):
+        """Test that callback is accepted when user is in the allowed usernames list."""
+        mock_repo_config.allowed_usernames = ("alice", "bob")
+
+        callback = create_issue_callback(action="opened", issue_labels=[{"name": "daiv"}], sender_username="alice")
+        assert callback.accept_callback() is True
+
+    def test_accept_callback_empty_allowlist(self, monkeypatch_dependencies, mock_repo_config):
+        """Test that callback is accepted when allowlist is empty (all users allowed)."""
+        mock_repo_config.allowed_usernames = ()
+
+        callback = create_issue_callback(action="opened", issue_labels=[{"name": "daiv"}])
+        assert callback.accept_callback() is True
+
+    def test_allowlist_case_insensitive(self, monkeypatch_dependencies, mock_repo_config):
+        """Test that allowlist check is case-insensitive."""
+        mock_repo_config.allowed_usernames = ("Alice",)
+
+        callback = create_issue_callback(action="opened", issue_labels=[{"name": "daiv"}], sender_username="alice")
+        assert callback.accept_callback() is True
+
+
+class TestIssueCommentCallbackAllowlist:
+    """Tests for GitHub IssueCommentCallback allowlist."""
+
+    def test_reject_comment_user_not_in_allowlist(self, monkeypatch_dependencies, mock_repo_config, mock_repo_client):
+        """Test that comment callback is rejected when user is not in the allowed usernames list."""
+        mock_repo_config.allowed_usernames = ("alice",)
+        mock_repo_client.current_user = User(**{"id": 999, "login": "daiv-bot"})
+
+        callback = IssueCommentCallback(
+            action="created",
+            repository=Repository(id=1, full_name="owner/repo", default_branch="main"),
+            issue=Issue(id=100, number=42, title="Test Issue", state="open", labels=[{"name": "daiv"}]),
+            comment=Comment(id=200, body="@daiv-bot help", user=User(**{"id": 10, "login": "mallory"})),
+        )
+        assert callback.accept_callback() is False
+
+    def test_accept_comment_user_in_allowlist(self, monkeypatch_dependencies, mock_repo_config, mock_repo_client):
+        """Test that comment callback is accepted when user is in the allowed usernames list."""
+        mock_repo_config.allowed_usernames = ("alice",)
+        mock_repo_client.current_user = User(**{"id": 999, "login": "daiv-bot"})
+
+        callback = IssueCommentCallback(
+            action="created",
+            repository=Repository(id=1, full_name="owner/repo", default_branch="main"),
+            issue=Issue(id=100, number=42, title="Test Issue", state="open", labels=[{"name": "daiv"}]),
+            comment=Comment(id=200, body="@daiv-bot help", user=User(**{"id": 10, "login": "alice"})),
         )
         assert callback.accept_callback() is True

--- a/tests/unit_tests/codebase/clients/gitlab/api/test_callbacks.py
+++ b/tests/unit_tests/codebase/clients/gitlab/api/test_callbacks.py
@@ -48,20 +48,26 @@ def stub_client():
 
 
 @pytest.fixture
-def monkeypatch_dependencies(monkeypatch, stub_client):
+def repo_config():
+    """Mutable RepositoryConfig instance."""
+    return RepositoryConfig()
+
+
+@pytest.fixture
+def monkeypatch_dependencies(monkeypatch, stub_client, repo_config):
     """Monkeypatch RepoClient and RepositoryConfig for testing."""
     monkeypatch.setattr("codebase.clients.gitlab.api.callbacks.RepoClient.create_instance", lambda: stub_client)
     monkeypatch.setattr(
-        "codebase.clients.gitlab.api.callbacks.RepositoryConfig.get_config", lambda *args, **kwargs: RepositoryConfig()
+        "codebase.clients.gitlab.api.callbacks.RepositoryConfig.get_config", lambda *args, **kwargs: repo_config
     )
 
 
-def create_note_callback(note_body: str) -> NoteCallback:
+def create_note_callback(note_body: str, username: str = "reviewer") -> NoteCallback:
     """Helper to create a minimal NoteCallback instance."""
     return NoteCallback(
         object_kind="note",
         project=Project(id=1, path_with_namespace="group/repo", default_branch="main"),
-        user=User(id=2, username="reviewer", name="Reviewer", email="reviewer@example.com"),
+        user=User(id=2, username=username, name="Reviewer", email=f"{username}@example.com"),
         merge_request=MergeRequest(
             id=10,
             iid=1,
@@ -225,12 +231,17 @@ def test_reject_when_system_note(monkeypatch_dependencies, stub_client):
 
 
 def create_issue_callback(
-    action: IssueAction, issue_labels: list[Label], issue_state: str = "opened", changes: IssueChanges | None = None
+    action: IssueAction,
+    issue_labels: list[Label],
+    issue_state: str = "opened",
+    changes: IssueChanges | None = None,
+    username: str = "testuser",
 ) -> IssueCallback:
     """Helper to create an IssueCallback instance."""
     return IssueCallback(
         object_kind="issue",
         project=Project(id=1, path_with_namespace="group/repo", default_branch="main"),
+        user=User(id=10, username=username, name="Test User", email=f"{username}@example.com"),
         object_attributes=Issue(
             id=100,
             iid=42,
@@ -318,6 +329,7 @@ class TestIssueCallback:
         IssueCallback(
             object_kind="work_item",
             project=Project(id=1, path_with_namespace="group/repo", default_branch="main"),
+            user=User(id=10, username="testuser", name="Test User", email="testuser@example.com"),
             object_attributes=Issue(
                 id=100,
                 iid=42,
@@ -335,4 +347,50 @@ class TestIssueCallback:
         """Test that label checking is case-insensitive."""
         changes = IssueChanges(labels=LabelChange(previous=[], current=[Label(title="DAIV")]))
         callback = create_issue_callback(action=IssueAction.UPDATE, issue_labels=[Label(title="DAIV")], changes=changes)
+        assert callback.accept_callback() is True
+
+    def test_reject_callback_user_not_in_allowlist(self, monkeypatch_dependencies, repo_config):
+        """Test that callback is rejected when user is not in the allowed usernames list."""
+        repo_config.allowed_usernames = ("alice", "bob")
+
+        callback = create_issue_callback(
+            action=IssueAction.OPEN, issue_labels=[Label(title="daiv")], username="mallory"
+        )
+        assert callback.accept_callback() is False
+
+    def test_accept_callback_user_in_allowlist(self, monkeypatch_dependencies, repo_config):
+        """Test that callback is accepted when user is in the allowed usernames list."""
+        repo_config.allowed_usernames = ("alice", "bob")
+
+        callback = create_issue_callback(action=IssueAction.OPEN, issue_labels=[Label(title="daiv")], username="alice")
+        assert callback.accept_callback() is True
+
+    def test_accept_callback_empty_allowlist(self, monkeypatch_dependencies):
+        """Test that callback is accepted when allowlist is empty (all users allowed)."""
+        callback = create_issue_callback(action=IssueAction.OPEN, issue_labels=[Label(title="daiv")])
+        assert callback.accept_callback() is True
+
+    def test_allowlist_case_insensitive(self, monkeypatch_dependencies, repo_config):
+        """Test that allowlist check is case-insensitive."""
+        repo_config.allowed_usernames = ("Alice",)
+
+        callback = create_issue_callback(action=IssueAction.OPEN, issue_labels=[Label(title="daiv")], username="alice")
+        assert callback.accept_callback() is True
+
+
+class TestNoteCallbackAllowlist:
+    """Tests for GitLab NoteCallback allowlist."""
+
+    def test_reject_note_user_not_in_allowlist(self, monkeypatch_dependencies, repo_config):
+        """Test that note callback is rejected when user is not in the allowed usernames list."""
+        repo_config.allowed_usernames = ("alice",)
+
+        callback = create_note_callback("@daiv please review this code", username="mallory")
+        assert callback.accept_callback() is False
+
+    def test_accept_note_user_in_allowlist(self, monkeypatch_dependencies, repo_config):
+        """Test that note callback is accepted when user is in the allowed usernames list."""
+        repo_config.allowed_usernames = ("reviewer",)
+
+        callback = create_note_callback("@daiv please review this code")
         assert callback.accept_callback() is True


### PR DESCRIPTION
For public repositories, anyone with access could interact with DAIV. This adds an `allowed_usernames` option to `.daiv.yml` that lets repository owners restrict which users can trigger DAIV through issues, comments, and merge request reviews. An empty list (default) allows all users, preserving backwards compatibility.