### PR TITLE
Improve agent harness prompts based on trace analysis

### DIFF
--- a/daiv/automation/agent/middlewares/prompt_cache.py
+++ b/daiv/automation/agent/middlewares/prompt_cache.py
@@ -57,10 +57,10 @@ class AnthropicPromptCachingMiddleware(AnthropicPromptCachingMiddlewareV0):
         Apply cache control to the request.
         """
         if self._is_openrouter_anthropic_model(request.model) and self._should_apply_caching(request):
-            model_settings = request.model_settings
+            existing_extra_body = request.model_settings.get("extra_body", {})
             new_model_settings = {
-                **model_settings,
-                "extra_body": {"cache_control": {"type": self.type, "ttl": self.ttl}},
+                **request.model_settings,
+                "extra_body": {**existing_extra_body, "cache_control": {"type": self.type, "ttl": self.ttl}},
             }
             return await handler(request.override(model_settings=new_model_settings))
         return await super().awrap_model_call(request, handler)

--- a/daiv/automation/agent/middlewares/sandbox.py
+++ b/daiv/automation/agent/middlewares/sandbox.py
@@ -127,7 +127,8 @@ Dedicated-tool failure policy:
 
 Environment awareness:
 - The sandbox is a minimal container. Common tools (test runners, package managers, linters) may not be installed.
-- If a command fails with "command not found", do NOT search for the binary (e.g., with `which`, `find`, or `type`). Accept it is unavailable and adapt your approach or inform the user.
+- If a command fails with "command not found", do NOT search for the binary (e.g., with `which`, `find`, or `type`) or retry with a different package manager or runner (e.g., switching from `uv` to `pipenv` to raw `python`). Accept the tool is unavailable and verify your changes using other means (linting, type-checking, code review).
+- If a command runs but fails due to missing infrastructure (database connection refused, environment variables, ModuleNotFoundError after dependency install), do not retry with a different approach. The sandbox lacks the required runtime environment — fall back to static verification instead.
 
 Safety / boundaries (never do these):
 - Do not access or print secrets/credentials.

--- a/daiv/automation/agent/prompts.py
+++ b/daiv/automation/agent/prompts.py
@@ -27,7 +27,7 @@ The user will primarily request you perform software engineering tasks. This inc
 
 ## Verification & Testing
 
-- After making changes, always run the relevant tests to verify correctness.
+- After making changes, run the relevant tests to verify correctness. If the test environment is unavailable (e.g., sandbox lacks dependencies or database), fall back to linting, type-checking, and code review.
 - If any test fails after your changes, determine whether the failure is **pre-existing** or **introduced by your changes**. You can do this by checking git status/diff or by reasoning about whether the failing test exercises code you modified.
 - You MUST fix all test failures that your changes introduced. Do not present your work as complete while tests you broke are still failing.
 - Pre-existing test failures unrelated to your changes should be reported to the user but do not block your task.
@@ -45,6 +45,7 @@ Prioritize technical accuracy and truthfulness over validating the user's belief
 ## Using your tools
 
 - Use the `task` tool with specialized agents when the task at hand matches the agent's description. Subagents are valuable for parallelizing independent queries or for protecting the main context window from excessive results, but they should not be used excessively when not needed. Importantly, avoid duplicating work that subagents are already doing - if you delegate research to a subagent, do not also perform the same searches yourself.
+  - Trust subagent results for research and analysis: if a subagent returns file contents or search results, use that information directly without re-reading the same files. Only re-read if the subagent's output was truncated, you need a different section not covered, or you are about to edit the file and need the current content.
 - For broader codebase exploration and deep research, use the `task` tool with subagent_type=explore. This is slower than calling `glob` or `grep` directly so use this only when a simple, directed search proves to be insufficient or when your task will clearly require more than 3 queries.
 - You can call multiple tools in a single response. If you intend to call multiple tools and there are no dependencies between them, make all independent tool calls in parallel. Maximize use of parallel tool calls where possible to increase efficiency. However, if some tool calls depend on previous calls to inform dependent values, do NOT call these tools in parallel and instead call them sequentially. For instance, if one operation must complete before another starts, run these operations sequentially instead.
 - Never paste filesystem tool outputs verbatim into user-visible messages; always rewrite paths to repo-relative form.

--- a/daiv/automation/agent/skills/code-review/SKILL.md
+++ b/daiv/automation/agent/skills/code-review/SKILL.md
@@ -8,6 +8,7 @@ description: This skill should be used when a user asks for a code review, feedb
 
 ## Establish scope and inputs
 
+- If you already reviewed this merge/pull request earlier in this conversation, do not start from scratch. Identify what changed since your last review (new commits, force-pushed changes) by comparing the current diff against what you previously reviewed, and focus only on the delta. Do not re-fetch MR metadata or re-explore unchanged files.
 - Identify whether the request targets a merge/pull request, a local diff, or specific files.
 - If a merge/pull request is referenced:
   1. fetch merge/pull request to determine the source branch and target branch using the available tools;


### PR DESCRIPTION
- Sandbox: replace vague "adapt your approach" with explicit no-retry guidance for command-not-found and infrastructure failures
- Prompts: qualify test verification with sandbox fallback, add subagent trust guidance to reduce redundant file re-reads
- Code-review skill: add incremental re-review for repeated invocations
- Prompt cache: preserve existing extra_body keys when adding cache control