### PR TITLE
Improve diff-to-metadata prompts and update model defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,11 +21,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Improved diff-to-metadata prompts to enforce repository conventions from memory, incorporate ticket identifiers from context, and reduce vague language in generated PR titles, descriptions, and commit messages.
+- Changed diff-to-metadata default model from Claude Haiku 4.5 to GPT-5.4-mini, with Claude Haiku 4.5 as fallback.
 - Changed `setup_webhooks` command to only create new webhooks by default, skipping existing ones.
 - Increased Claude max output tokens from 4,096 to 16,384.
 
 ### Removed
 
+- Removed GPT-4.1-mini, GPT-4.1, and GPT-5.2 from the model catalog; added GPT-5.4, GPT-5.4-mini, Z-AI GLM-5-turbo, and MiniMax M2-7.
 - **BREAKING:** Removed the `mcp-proxy` container and its API configuration endpoint. Now MCP servers are configured with isolated per-MCP `supergateway` containers — each built-in MCP server (Sentry, Context7) now runs in its own container. Existing `docker-compose.yml` and stack files must be updated.
 - **BREAKING:** Removed `MCP_PROXY_HOST`, `MCP_PROXY_ADDR`, `MCP_PROXY_AUTH_TOKEN`, and `MCP_CONFIG_API_KEY` settings. MCP server credentials (`SENTRY_ACCESS_TOKEN`, `CONTEXT7_API_KEY`) are now configured on the MCP containers directly, not as DAIV application settings
 

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ compilemessages:
 	uv run django-admin compilemessages
 
 integration-tests:
-	uv run pytest --reuse-db tests/integration_tests --no-cov --log-level=INFO -m sandbox
+	uv run pytest --reuse-db tests/integration_tests --no-cov --log-level=INFO -m diff_to_metadata
 
 swebench:
 	uv run evals/swebench.py --dataset-path "princeton-nlp/SWE-bench_Verified" --dataset-split "test" --output-path swebench-predictions.json --num-samples 10

--- a/daiv/automation/agent/constants.py
+++ b/daiv/automation/agent/constants.py
@@ -35,16 +35,17 @@ class ModelName(StrEnum):
     CLAUDE_HAIKU_4_5 = "openrouter:anthropic/claude-haiku-4.5"
 
     # OpenAI models
-    GPT_4_1_MINI = "openrouter:openai/gpt-4.1-mini"
-    GPT_4_1 = "openrouter:openai/gpt-4.1"
-    GPT_5_2 = "openrouter:openai/gpt-5.2"
     GPT_5_3_CODEX = "openrouter:openai/gpt-5.3-codex"
+    GPT_5_4 = "openrouter:openai/gpt-5.4"
+    GPT_5_4_MINI = "openrouter:openai/gpt-5.4-mini"
 
     # z-ai models
     Z_AI_GLM_5 = "openrouter:z-ai/glm-5"
+    Z_AI_GLM_5_TURBO = "openrouter:z-ai/glm-5-turbo"
 
     # minimax models
     MINIMAX_M2_5 = "openrouter:minimax/minimax-m2.5"
+    MINIMAX_M2_7 = "openrouter:minimax/minimax-m2.7"
 
     # MoonshotAI models
     MOONSHOTAI_KIMI_K2_5 = "openrouter:moonshotai/kimi-k2.5"

--- a/daiv/automation/agent/diff_to_metadata/conf.py
+++ b/daiv/automation/agent/diff_to_metadata/conf.py
@@ -8,10 +8,10 @@ class DiffToMetadataSettings(BaseSettings):
     model_config = SettingsConfigDict(env_prefix="DIFF_TO_METADATA_", env_parse_none_str="None")
 
     MODEL_NAME: ModelName | str = Field(
-        default=ModelName.CLAUDE_HAIKU_4_5, description="Model name to be used to transform a diff into metadata."
+        default=ModelName.GPT_5_4_MINI, description="Model name to be used to transform a diff into metadata."
     )
     FALLBACK_MODEL_NAME: ModelName | str = Field(
-        default=ModelName.GPT_4_1_MINI, description="Fallback model name to be used when the primary model fails."
+        default=ModelName.CLAUDE_HAIKU_4_5, description="Fallback model name to be used when the primary model fails."
     )
 
 

--- a/daiv/automation/agent/diff_to_metadata/graph.py
+++ b/daiv/automation/agent/diff_to_metadata/graph.py
@@ -11,14 +11,11 @@ from deepagents.middleware.memory import MemoryMiddleware
 from langchain.agents.middleware import ModelFallbackMiddleware, dynamic_prompt
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.runnables import RunnableLambda, RunnableParallel
-from prompt_toolkit import HTML, PromptSession
 
 from automation.agent import BaseAgent
 from automation.agent.constants import AGENTS_MEMORY_PATH, ModelName
 from automation.agent.middlewares.prompt_cache import AnthropicPromptCachingMiddleware
-from codebase.base import Scope
-from codebase.context import RuntimeCtx, set_runtime_ctx
-from codebase.utils import redact_diff_content
+from codebase.context import RuntimeCtx
 
 from .conf import settings
 from .prompts import human_commit_message, human_pr_metadata, system
@@ -98,7 +95,7 @@ def create_diff_to_metadata_graph(
 
     if include_commit_message:
         graphs["commit_message"] = (
-            ChatPromptTemplate.from_messages([human_commit_message])
+            ChatPromptTemplate.from_messages([human_commit_message]).partial(extra_context="")
             | create_agent(
                 model=model,
                 tools=[],  # No tools are needed for this agent, it only uses the memory and the system prompt
@@ -109,11 +106,13 @@ def create_diff_to_metadata_graph(
         ).with_config(run_name="CommitMessage")
 
     def _input_selector(x: dict[str, Any]) -> dict[str, str]:
-        input_data = {}
+        input_data: dict[str, str] = {}
         if include_pr_metadata:
             input_data["pr_metadata_diff"] = x.get("pr_metadata_diff", x.get("diff", ""))
         if include_commit_message:
             input_data["commit_message_diff"] = x.get("commit_message_diff", x.get("diff", ""))
+        if extra_context := x.get("extra_context", ""):
+            input_data["extra_context"] = extra_context
         return input_data
 
     def _output_selector(x: dict[str, Any]) -> dict[str, PullRequestMetadata | CommitMetadata]:
@@ -130,38 +129,3 @@ def create_diff_to_metadata_graph(
         tags=[run_name],
         metadata={"include_pr_metadata": include_pr_metadata, "include_commit_message": include_commit_message},
     )
-
-
-async def main():
-    session = PromptSession(
-        message=HTML('<style fg="#ffffff">></style> '),
-        complete_while_typing=True,  # Show completions as you type
-        complete_in_thread=True,  # Async completion prevents menu freezing
-        mouse_support=False,
-        enable_open_in_editor=True,  # Allow Ctrl+X Ctrl+E to open external editor
-        enable_history_search=True,
-        wrap_lines=True,
-        reserve_space_for_menu=7,  # Reserve space for completion menu to show 5-6 results
-    )
-    async with set_runtime_ctx(repo_id="srtab/daiv", scope=Scope.GLOBAL, ref="main") as ctx:
-        diff_to_metadata_graph = create_diff_to_metadata_graph(ctx=ctx, model_names=[ModelName.CLAUDE_HAIKU_4_5])
-        while True:
-            user_input = await session.prompt_async()
-            output = await diff_to_metadata_graph.ainvoke(
-                {"diff": redact_diff_content(user_input, ctx.config.omit_content_patterns)},
-                context=ctx,
-                config={"configurable": {"thread_id": "1"}},
-            )
-            if output and "pr_metadata" in output:
-                print(output["pr_metadata"].model_dump_json(indent=2))  # noqa: T201
-            if output and "commit_message" in output:
-                print(output["commit_message"].model_dump_json(indent=2))  # noqa: T201
-
-
-if __name__ == "__main__":
-    import asyncio
-
-    import django
-
-    django.setup()
-    asyncio.run(main())

--- a/daiv/automation/agent/diff_to_metadata/prompts.py
+++ b/daiv/automation/agent/diff_to_metadata/prompts.py
@@ -9,14 +9,24 @@ You MUST follow these rules:
    - git diff hunks (if provided)
    - optional context fields explicitly provided by the user (e.g., issue id)
 2) Do NOT invent changes, motivations, tests, or impacts not supported by the diff.
-3) If memory specifies branch naming or commit message conventions, follow them exactly.
+   - Compare the before and after lines carefully.
+   - Only mention items that actually differ between the two.
+3) Be specific: name the actual entities, values, or operations that changed.
+   - Never use vague verbs like "improve", "update", or "enhance"
+     when you can state what concretely changed.
+4) If memory specifies branch naming or commit message conventions,
+   you MUST follow them — they override ALL defaults below.
+   - Pay close attention to required prefixes, delimiters, and casing rules.
    - If multiple conventions exist, choose the one that best matches the change type.
    - If conventions are ambiguous, choose the safest option and keep it simple.
-4) If memory is missing or has no relevant guidance:
-   - Use a sensible default:
-     - branch: <type>/<short-kebab-summary> where type ∈ {feat, fix, chore, docs, refactor, test}
-     - commit_message: Conventional Commits style "<type>: <short summary>" (subject only)
-5) Output MUST match the requested structured format exactly (no extra keys).""",
+5) If the additional context or diff references an issue/ticket identifier
+   (e.g., ABC-123, CAL-204), incorporate it into branch and commit_message
+   following the memory conventions.
+   - If no convention exists, prefix: "<TICKET-ID> <type>: <summary>".
+6) Only if memory is missing or has no relevant guidance, fall back to these defaults:
+   - branch: <type>/<short-kebab-summary> where type ∈ {feat, fix, chore, docs, refactor, test}
+   - commit_message: Conventional Commits style "<type>: <short summary>" (subject only)
+""",
     "mustache",
 )
 
@@ -35,25 +45,18 @@ Additional context related to the changes:
 ~~~
 {{/extra_context}}
 
-Output requirements:
-- Return a single JSON object with EXACTLY these keys:
-  - title
-  - description
-  - commit_message
-  - branch
-
 Field rules:
 - title: short PR title (max ~70 chars), based strictly on the diff.
 - description: Markdown with:
   1) a brief overview paragraph (1-3 sentences)
-  2) a "**Key Changes:**" section with 2-6 bullet points
+  2) a "**Key Changes:**" section with up to 6 bullet points
   Focus only on describing the actual code changes visible in the diff.
   Do NOT include meta-commentary about the issue, prompt, or source of information.
 - commit_message:
-  - If memory defines a format, follow it.
+  - MUST follow the memory convention if one exists (including any ticket/issue prefix or wrapper).
   - Otherwise use: "<type>: <summary>" (Conventional Commits), single line.
 - branch:
-  - If memory defines a naming convention, follow it.
+  - MUST follow the memory convention if one exists (including any required issue-id segments).
   - Otherwise use: "<type>/<kebab-case-summary>".
   - Keep it lowercase, ascii, no spaces, avoid > 50 chars.""",
     "mustache",
@@ -68,13 +71,16 @@ Diff hunks (unified diff; may include multiple files):
 {{commit_message_diff}}
 ~~~
 
-Output requirements:
-- Return a single JSON object with EXACTLY this key:
-  - commit_message
+{{#extra_context}}
+Additional context related to the changes:
+~~~markdown
+{{extra_context}}
+~~~
+{{/extra_context}}
 
 Field rules:
 - commit_message:
-  - If memory defines a format, follow it.
+  - MUST follow the memory convention if one exists (including any ticket/issue prefix or wrapper).
   - Otherwise use: "<type>: <summary>" (Conventional Commits), single line.""",
     "mustache",
 )

--- a/tests/integration_tests/test_diff_to_metadata.py
+++ b/tests/integration_tests/test_diff_to_metadata.py
@@ -9,6 +9,7 @@ from codebase.base import GitPlatform, Scope
 from codebase.context import set_runtime_ctx
 
 from .evaluators import correctness_evaluator
+from .utils import FAST_MODEL_NAMES
 
 DATA_DIR = Path(__file__).parent / "data" / "diff_to_metadata"
 TEST_SUITE = "DAIV: Diff to Metadata"
@@ -39,9 +40,11 @@ def load_cases() -> list[pytest.param]:
         yield pytest.param(inputs, reference_outputs, id=case_id)
 
 
+@pytest.mark.diff_to_metadata
 @pytest.mark.langsmith(test_suite_name=TEST_SUITE, output_keys=["reference_outputs"])
+@pytest.mark.parametrize("model_name", FAST_MODEL_NAMES)
 @pytest.mark.parametrize("inputs,reference_outputs", load_cases())
-async def test_diff_to_metadata(inputs, reference_outputs):
+async def test_diff_to_metadata(model_name, inputs, reference_outputs):
     t.log_inputs(inputs)
     t.log_reference_outputs(reference_outputs)
 
@@ -53,7 +56,7 @@ async def test_diff_to_metadata(inputs, reference_outputs):
             (agent_path / ctx.config.context_file_name).write_text(inputs.pop("context_file_content"))
         else:
             (agent_path / ctx.config.context_file_name).unlink()
-        changes_metadata_graph = create_diff_to_metadata_graph(ctx=ctx)
+        changes_metadata_graph = create_diff_to_metadata_graph(ctx=ctx, model_names=[model_name])
         outputs = await changes_metadata_graph.ainvoke(inputs)
         outputs = {
             "pr_metadata": outputs["pr_metadata"].model_dump(mode="json") if "pr_metadata" in outputs else None,

--- a/tests/integration_tests/utils.py
+++ b/tests/integration_tests/utils.py
@@ -38,15 +38,16 @@ CODING_MODEL_NAMES = [
     ModelName.CLAUDE_SONNET_4_6,
     ModelName.CLAUDE_OPUS_4_5,
     ModelName.CLAUDE_OPUS_4_6,
-    ModelName.GPT_5_2,
     ModelName.GPT_5_3_CODEX,
+    ModelName.GPT_5_4,
     ModelName.Z_AI_GLM_5,
     ModelName.Z_AI_GLM_5_TURBO,
     ModelName.MINIMAX_M2_5,
+    ModelName.MINIMAX_M2_7,
     ModelName.MOONSHOTAI_KIMI_K2_5,
 ]
 
-FAST_MODEL_NAMES = [ModelName.CLAUDE_HAIKU_4_5, ModelName.GPT_4_1]
+FAST_MODEL_NAMES = [ModelName.CLAUDE_HAIKU_4_5, ModelName.GPT_5_4_MINI]
 
 
 def extract_tool_calls(messages: list[BaseMessage]) -> list[ToolCall]:


### PR DESCRIPTION
Strengthen prompts to enforce repository conventions from memory, incorporate ticket identifiers from extra context, require specific language over vague verbs, and compare before/after lines carefully. Remove redundant JSON output instructions (using structured output). Wire extra_context through to commit message template.

Switch default model from Claude Haiku 4.5 to GPT-5.4-mini based on benchmark results (92% pass rate, best factuality and conciseness). Update model catalog: remove GPT-4.1-mini, GPT-4.1, GPT-5.2; add GPT-5.4, GPT-5.4-mini, Z-AI GLM-5-turbo, MiniMax M2-7.

Remove unused interactive CLI main() function from graph module. Parametrize integration tests across fast models.