### PR TITLE
improve documentation clarity for MCP tools, slash commands, and LLM …

### DIFF
--- a/docs/customization/mcp-tools.md
+++ b/docs/customization/mcp-tools.md
@@ -51,7 +51,9 @@ Context7 credentials (`CONTEXT7_API_KEY`) are consumed by the `mcp-context7` con
 
 ## User-defined MCP servers
 
-You can connect additional MCP servers by providing a JSON config file following the [Claude Code `.mcp.json` standard](https://docs.anthropic.com/en/docs/claude-code/mcp). Set the file path via the `MCP_SERVERS_CONFIG_FILE` environment variable.
+DAIV can connect to any MCP server that implements the [Model Context Protocol](https://modelcontextprotocol.io/). If you need to build a custom server, see the [MCP server documentation](https://modelcontextprotocol.io/docs/concepts/servers). This section covers how to connect an existing server to DAIV.
+
+Provide a JSON config file following the [Claude Code `.mcp.json` standard](https://docs.anthropic.com/en/docs/claude-code/mcp). Set the file path via the `MCP_SERVERS_CONFIG_FILE` environment variable.
 
 Only `sse` and `http` (streamable HTTP) transport types are supported, since user MCP servers must be network-accessible.
 

--- a/docs/features/slash-commands.md
+++ b/docs/features/slash-commands.md
@@ -105,14 +105,13 @@ Analyzes the repository structure and generates an `AGENTS.md` file with guidanc
 
 Walks you through creating a new custom skill for your repository. See [Agent Skills](../customization/agent-skills.md) for more on custom skills.
 
-## Custom skills
+## Custom commands (skills)
 
-You can create your own skills by adding them to your repository. Custom skills appear alongside built-in ones in `/help` and are invoked the same way.
+Custom slash commands are implemented as **skills**. Creating a skill automatically registers it as a command — there is no separate registration step.
 
-Skills live in one of these directories:
+To create a custom command like `/my-command`:
 
-- `.agents/skills/`
-- `.cursor/skills/`
-- `.claude/skills/`
+1. Create `.agents/skills/my-command/SKILL.md` with YAML frontmatter
+2. Invoke it with `@daiv /my-command`
 
-For details on creating custom skills, see [Agent Skills](../customization/agent-skills.md).
+Custom commands appear alongside built-in ones in `/help` and are invoked the same way. For the full guide on creating skills, see [Agent Skills](../customization/agent-skills.md).

--- a/docs/getting-started/llm-providers.md
+++ b/docs/getting-started/llm-providers.md
@@ -56,6 +56,14 @@ openrouter:anthropic/claude-sonnet-4.6
 openrouter:openai/gpt-5.3-codex
 ```
 
+**Per-repository override** (`.daiv.yml`):
+
+```yaml
+models:
+  agent:
+    model: "openrouter:anthropic/claude-sonnet-4.6"
+```
+
 ---
 
 ## OpenAI
@@ -77,6 +85,14 @@ gpt-5.3-codex
 o4-mini
 ```
 
+**Per-repository override** (`.daiv.yml`):
+
+```yaml
+models:
+  agent:
+    model: "gpt-5.3-codex"
+```
+
 ---
 
 ## Anthropic
@@ -96,6 +112,14 @@ Use the [model name from Anthropic](https://docs.anthropic.com/en/docs/about-cla
 ```
 claude-sonnet-4.6
 claude-opus-4.6
+```
+
+**Per-repository override** (`.daiv.yml`):
+
+```yaml
+models:
+  agent:
+    model: "claude-sonnet-4.6"
 ```
 
 !!! warning
@@ -121,4 +145,12 @@ Use the [model name from Gemini](https://ai.google.dev/gemini-api/docs/models) d
 ```
 gemini-2.5-pro-preview-05-06
 gemini-2.4-flash-preview-04-17
+```
+
+**Per-repository override** (`.daiv.yml`):
+
+```yaml
+models:
+  agent:
+    model: "gemini-2.5-pro-preview-05-06"
 ```


### PR DESCRIPTION
…providers

- Clarify that DAIV consumes MCP servers and link to MCP docs for building custom ones
- Make explicit that custom slash commands are skills with no separate registration
- Add per-repository .daiv.yml override snippets to each LLM provider section