### PR TITLE
feat(skills): add support for custom global skills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added user-defined MCP server support via a JSON config file (`MCP_SERVERS_CONFIG_FILE`) following the Claude Code `.mcp.json` standard. Supports `sse` and `http` transport types with environment variable expansion.
 - Added automatic suggestion to add an `AGENTS.md` file when DAIV creates a merge request for a repository that doesn't have one. The suggestion includes a one-click link to create a pre-filled issue. Can be disabled globally via `AUTOMATION_SUGGEST_CONTEXT_FILE_ENABLED=False` or per-repository by setting `context_file_name: null` in `.daiv.yml`.
 - Added support for custom subagents defined per-repository. Place markdown files in `.agents/subagents/` with YAML frontmatter (`name`, `description`, optional `model`) and a body that becomes the subagent's system prompt. Custom subagents have the same capabilities as the built-in general-purpose subagent.
+- Added support for custom global skills available across all repositories. Mount skill directories to `/home/daiv/data/skills/` (configurable via `DAIV_AGENT_CUSTOM_SKILLS_PATH`). Custom global skills follow the same format as built-in skills and can override them.
 
 ### Fixed
 

--- a/daiv/automation/agent/conf.py
+++ b/daiv/automation/agent/conf.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -40,6 +42,10 @@ class DAIVAgentSettings(BaseSettings):
     EXPLORE_MODEL_NAME: ModelName | str = Field(
         default=ModelName.CLAUDE_HAIKU_4_5,
         description="Model for the explore subagent, a fast model with capabilities to call tools.",
+    )
+    CUSTOM_SKILLS_PATH: Path | None = Field(
+        default=Path.home() / "data" / "skills",
+        description="Path to custom global skills directory. Set to None to disable.",
     )
 
 

--- a/daiv/automation/agent/middlewares/skills.py
+++ b/daiv/automation/agent/middlewares/skills.py
@@ -15,6 +15,7 @@ from langchain_core.prompts import PromptTemplate
 from langgraph.runtime import Runtime  # noqa: TC002
 from langgraph.types import Command
 
+from automation.agent.conf import settings as agent_settings
 from automation.agent.constants import AGENTS_SKILLS_PATH, BUILTIN_SKILLS_PATH
 from automation.agent.utils import extract_body_from_frontmatter, extract_text_content
 from codebase.context import RuntimeCtx  # noqa: TC001
@@ -94,6 +95,9 @@ AVAILABLE_SKILLS_TEMPLATE = PromptTemplate.from_template(
     {{#metadata.is_builtin}}
     <builtin>true</builtin>
     {{/metadata.is_builtin}}
+    {{#metadata.is_global}}
+    <global>true</global>
+    {{/metadata.is_global}}
   </skill>
   {{/skills_list}}
 </available_skills>""",
@@ -129,21 +133,29 @@ class SkillsMiddleware(DeepAgentsSkillsMiddleware):
         if clear_skill_mode:
             logger.info("[%s] Clearing active skill mode '%s' on user follow-up", self.name, state["active_skill_mode"])
 
-        # We need to always copy builtin skills before calling the super method to make them available in the filesystem
-        # not just to be captured and registered in "skills_metadata" on first run, but also to be available in the
-        # filesystem so that the agent can use them using the `skill` tool, otherwise a not_found error will be raised.
-        builtin_skills = await self._copy_builtin_skills(agent_path=Path(runtime.context.gitrepo.working_dir))
+        # We need to always copy builtin and custom global skills before calling the super method to make them available
+        # in the filesystem not just to be captured and registered in "skills_metadata" on first run, but also to be
+        # available in the filesystem so that the agent can use them using the `skill` tool, otherwise a not_found error
+        # will be raised.
+        builtin_skills, custom_global_skills = await self._copy_global_skills(
+            agent_path=Path(runtime.context.gitrepo.working_dir)
+        )
 
         skills_update = await super().abefore_agent(state, runtime, config)
 
-        # Mark builtin skills as builtin. Unmark non-builtin skills. This is necessary because the builtin skills can
-        # be rewritten to the project skills directory by the user and they should not be marked as builtin anymore.
+        # Mark skills based on their origin. Custom global skills take precedence over built-in skills with the same
+        # name. Per-repository skills (not in either list) get both flags removed.
         if skills_update is not None:
             for skill in skills_update["skills_metadata"]:
-                if skill["name"] in builtin_skills:
+                if skill["name"] in custom_global_skills:
+                    skill["metadata"]["is_global"] = True
+                    skill["metadata"].pop("is_builtin", None)
+                elif skill["name"] in builtin_skills:
                     skill["metadata"]["is_builtin"] = True
+                    skill["metadata"].pop("is_global", None)
                 else:
                     skill["metadata"].pop("is_builtin", None)
+                    skill["metadata"].pop("is_global", None)
 
         # If the super method returns None, it means that the skills metadata was already captured and registered in
         # the state.
@@ -165,51 +177,78 @@ class SkillsMiddleware(DeepAgentsSkillsMiddleware):
 
         return skills_update
 
-    async def _copy_builtin_skills(self, agent_path: Path) -> list[str]:
+    async def _copy_global_skills(self, agent_path: Path) -> tuple[list[str], list[str]]:
         """
-        Copy builtin skills to the project skills directory if they don't exist.
+        Copy builtin and custom global skills to the project skills directory if they don't exist.
 
-        This allows the agent to find built-in skills and execute scripts bundled with them as if they were project
-        skills, even if the project skills directory is not set up. The copied skills folder includes a .gitignore file
-        to prevent the skills from being committed to the repository.
+        This allows the agent to find built-in and custom global skills and execute scripts bundled with them as if they
+        were project skills, even if the project skills directory is not set up. The copied skills folder includes a
+        .gitignore file to prevent the skills from being committed to the repository.
 
-        Users can override built-in skills by creating them with the same name in the project skills directory and
-        committing them to the repository.
+        Custom global skills override built-in skills with the same name. Users can override both by creating skills
+        with the same name in the project skills directory and committing them to the repository.
 
         Args:
             agent_path: The path to the agent's repository.
 
         Returns:
-            A list of builtin skill names.
+            A tuple of (builtin skill names, custom global skill names).
         """
-        builtin_skills = []
-        files_to_upload = []
+        files_to_upload: list[tuple[str, bytes]] = []
         project_skills_path = Path(f"/{agent_path.name}/{AGENTS_SKILLS_PATH}")
 
-        for builtin_skill_dir in BUILTIN_SKILLS_PATH.iterdir():
-            if not builtin_skill_dir.is_dir() or builtin_skill_dir.name == "__pycache__":
+        builtin_skills = self._collect_skill_files(BUILTIN_SKILLS_PATH, project_skills_path, files_to_upload)
+
+        custom_global_skills: list[str] = []
+        custom_skills_path = agent_settings.CUSTOM_SKILLS_PATH
+        if custom_skills_path is not None and custom_skills_path.is_dir():
+            try:
+                custom_global_skills = self._collect_skill_files(
+                    custom_skills_path, project_skills_path, files_to_upload
+                )
+            except OSError:
+                logger.exception("Failed to read custom global skills from '%s', skipping", custom_skills_path)
+        elif custom_skills_path is not None:
+            logger.warning("Custom global skills path '%s' does not exist or is not a directory", custom_skills_path)
+
+        for response in await self._backend.aupload_files(files_to_upload):
+            if response.error:
+                raise RuntimeError(f"Failed to upload skill: {response.error}")
+        return builtin_skills, custom_global_skills
+
+    @staticmethod
+    def _collect_skill_files(
+        source_root: Path, project_skills_path: Path, files_to_upload: list[tuple[str, bytes]]
+    ) -> list[str]:
+        """
+        Walk skill directories under ``source_root`` and append files to ``files_to_upload``.
+
+        Returns the list of skill names found.
+        """
+        skill_names: list[str] = []
+        for skill_dir in source_root.iterdir():
+            if not skill_dir.is_dir() or skill_dir.name == "__pycache__":
                 continue
 
-            builtin_skills.append(builtin_skill_dir.name)
+            skill_names.append(skill_dir.name)
 
-            for root, dirs, files in builtin_skill_dir.walk():
-                # Modifying dirs in-place will prune the (subsequent) files
+            for root, dirs, files in skill_dir.walk():
                 dirs[:] = [d for d in dirs if d != "__pycache__"]
                 for file in files:
                     source_path = Path(root) / Path(file)
                     if source_path.suffix == ".pyc":
                         continue
-                    dest_path = project_skills_path / source_path.relative_to(BUILTIN_SKILLS_PATH)
+                    dest_path = project_skills_path / source_path.relative_to(source_root)
                     if not dest_path.exists():
-                        files_to_upload.append((str(dest_path), source_path.read_bytes()))
+                        try:
+                            files_to_upload.append((str(dest_path), source_path.read_bytes()))
+                        except OSError:
+                            logger.warning("Failed to read skill file '%s', skipping", source_path)
 
-            dest_path = project_skills_path / builtin_skill_dir.relative_to(BUILTIN_SKILLS_PATH)
+            dest_path = project_skills_path / skill_dir.relative_to(source_root)
             files_to_upload.append((str(dest_path / ".gitignore"), b"*"))
 
-        for response in await self._backend.aupload_files(files_to_upload):
-            if response.error:
-                raise RuntimeError(f"Failed to upload builtin skill: {response.error}")
-        return builtin_skills
+        return skill_names
 
     @override
     def _format_skills_list(self, skills: list[SkillMetadata]) -> str:

--- a/docs/customization/agent-skills.md
+++ b/docs/customization/agent-skills.md
@@ -39,6 +39,50 @@ your-repository/
 
 Built-in skills are automatically copied to `.agents/skills/` at agent startup with a `.gitignore` to prevent them from being committed. You can override any built-in skill by creating one with the same name and committing it to the repository.
 
+## Custom global skills
+
+Custom global skills are user-defined skills that are available across **all repositories**, unlike per-repository skills. They follow the same directory format as built-in skills (a directory containing a `SKILL.md` file) and are loaded from a configurable path on the host filesystem.
+
+### Setup
+
+1. Create a directory with your custom skills on the host machine:
+
+    ```
+    custom-skills/
+    ├── my-workflow/
+    │   ├── SKILL.md
+    │   └── scripts/
+    │       └── helper.py
+    └── team-review/
+        └── SKILL.md
+    ```
+
+2. Mount it as a Docker volume into the DAIV worker container at `/home/daiv/data/skills/`:
+
+    ```yaml
+    # In your docker-compose.yml or stack.yml
+    worker:
+      volumes:
+        - ./custom-skills:/home/daiv/data/skills:ro
+    ```
+
+    The path inside the container is configurable via the `DAIV_AGENT_CUSTOM_SKILLS_PATH` environment variable (see [Environment Variables](../reference/env-variables.md#daiv-agent)).
+
+### Override priority
+
+Skills are resolved in this order (highest priority wins):
+
+1. **Per-repository skills** — committed in the repository's `.agents/skills/`, `.cursor/skills/`, or `.claude/skills/`
+2. **Custom global skills** — mounted via Docker volume
+3. **Built-in skills** — shipped with DAIV
+
+This means custom global skills override built-in skills with the same name, and per-repository skills override both.
+
+### Notes
+
+- Skills are copied at each agent invocation, so changes to the mounted volume take effect on the next task without a container restart.
+- Custom global skills are marked with a `<global>` tag in the agent's system prompt so the LLM can distinguish them from built-in and per-repository skills.
+
 ## Creating a skill
 
 ### SKILL.md format

--- a/docs/getting-started/deployment.md
+++ b/docs/getting-started/deployment.md
@@ -169,6 +169,8 @@ services:
       - openrouter_api_key
     networks:
       - internal
+    # volumes:  (16)
+    #   - ./custom-skills:/home/daiv/data/skills:ro
     healthcheck:
       test: grep -q 'db_worker' /proc/*/cmdline 2>/dev/null
       interval: 30s
@@ -294,6 +296,7 @@ secrets:
 8.   **Optional**: Remove this volume if you don't need private registry access
 9.   The Sentry access token is read from the Docker secret at runtime via `--access-token`. Set `SENTRY_HOST` for self-hosted Sentry instances. These MCP services are optional — remove them if not needed
 10.  **Scaling**: Increase `replicas` to handle more concurrent tasks (e.g., `replicas: 3`). Each worker processes tasks independently from the shared queue, so adding replicas scales DAIV's throughput with no architecture changes
+16.  **Optional**: Uncomment to mount [custom global skills](../customization/agent-skills.md#custom-global-skills) that are available across all repositories
 
 ### Step 3: Deploy the stack
 
@@ -416,6 +419,8 @@ services:
   worker:
     <<: *x_app_default
     command: sh /home/daiv/start-worker
+    # volumes:  (17)
+    #   - ./custom-skills:/home/daiv/data/skills:ro
     healthcheck:
       test: ["CMD-SHELL", "grep -q 'db_worker' /proc/*/cmdline 2>/dev/null"]
       interval: 30s
@@ -516,6 +521,7 @@ volumes:
 13.  **Add the docker group** to the sandbox container (`stat -c '%g' /var/run/docker.sock`)
 14.  **Add MCP credentials** (`SENTRY_ACCESS_TOKEN`, `CONTEXT7_API_KEY`) to your env file. These MCP services are optional — remove them if not needed
 15.  **Scaling**: Increase `replicas` to handle more concurrent tasks (e.g., `replicas: 3`). Each worker processes tasks independently from the shared queue, so adding replicas scales DAIV's throughput with no architecture changes
+17.  **Optional**: Uncomment to mount [custom global skills](../customization/agent-skills.md#custom-global-skills) that are available across all repositories
 
 ### Step 2: Run the compose file
 

--- a/docs/reference/env-variables.md
+++ b/docs/reference/env-variables.md
@@ -260,6 +260,7 @@ The main agent used for issue addressing, pull request assistance, and all inter
 | `DAIV_AGENT_MAX_MODEL_NAME` | Model used when the `daiv-max` label is present | `claude-opus-4-6` |
 | `DAIV_AGENT_MAX_THINKING_LEVEL` | Thinking level for `daiv-max` tasks | `high` |
 | `DAIV_AGENT_EXPLORE_MODEL_NAME` | Model for the explore subagent (fast, read-only) | `claude-haiku-4-5` |
+| `DAIV_AGENT_CUSTOM_SKILLS_PATH` | Path to custom global skills directory. Set to `None` to disable. | `~/data/skills` |
 
 ### Diff to Metadata
 

--- a/tests/unit_tests/automation/agent/middlewares/test_skills.py
+++ b/tests/unit_tests/automation/agent/middlewares/test_skills.py
@@ -128,7 +128,7 @@ class TestSkillsMiddleware:
         middleware = SkillsMiddleware(backend=backend, sources=[f"/{repo_name}/{AGENTS_SKILLS_PATH}"])
 
         with patch("automation.agent.middlewares.skills.BUILTIN_SKILLS_PATH", builtin):
-            await middleware._copy_builtin_skills(agent_path=tmp_path / repo_name)
+            await middleware._copy_global_skills(agent_path=tmp_path / repo_name)
 
         project_skills = tmp_path / repo_name / AGENTS_SKILLS_PATH
         assert (project_skills / "skill-one" / "SKILL.md").read_text() == _make_skill_md(
@@ -172,7 +172,7 @@ class TestSkillsMiddleware:
             patch("automation.agent.middlewares.skills.BUILTIN_SKILLS_PATH", builtin),
             patch("pathlib.Path.exists", new=fake_exists),
         ):
-            await middleware._copy_builtin_skills(agent_path=tmp_path / repo_name)
+            await middleware._copy_global_skills(agent_path=tmp_path / repo_name)
 
         # SKILL.md should not be overwritten, but other files should still be uploaded.
         assert project_skill_md.read_text() == _make_skill_md(name="skill-one", description="existing")
@@ -192,11 +192,11 @@ class TestSkillsMiddleware:
 
         with (
             patch("automation.agent.middlewares.skills.BUILTIN_SKILLS_PATH", builtin),
-            pytest.raises(RuntimeError, match="Failed to upload builtin skill: boom"),
+            pytest.raises(RuntimeError, match="Failed to upload skill: boom"),
         ):
-            await middleware._copy_builtin_skills(agent_path=tmp_path / "repoX")
+            await middleware._copy_global_skills(agent_path=tmp_path / "repoX")
 
-    def test_format_skills_list_marks_builtin(self):
+    def test_format_skills_list_marks_builtin_and_global(self):
         middleware = SkillsMiddleware(backend=Mock(), sources=["/skills"])
         formatted = middleware._format_skills_list([
             {
@@ -204,6 +204,12 @@ class TestSkillsMiddleware:
                 "description": "does one",
                 "path": "/skills/skill-one/SKILL.md",
                 "metadata": {"is_builtin": True},
+            },
+            {
+                "name": "global-skill",
+                "description": "does global",
+                "path": "/skills/global-skill/SKILL.md",
+                "metadata": {"is_global": True},
             },
             {
                 "name": "custom-skill",
@@ -215,10 +221,10 @@ class TestSkillsMiddleware:
 
         assert formatted.startswith("<available_skills>")
         assert "<name>skill-one</name>" in formatted
-        assert "<description>does one</description>" in formatted
+        assert "<name>global-skill</name>" in formatted
         assert "<name>custom-skill</name>" in formatted
-        assert "<description>does custom</description>" in formatted
         assert formatted.count("<builtin>true</builtin>") == 1
+        assert formatted.count("<global>true</global>") == 1
 
     def test_format_skills_list_returns_empty_hint(self):
         middleware = SkillsMiddleware(backend=Mock(), sources=["/skills", "/extra/skills"])
@@ -479,3 +485,173 @@ class TestSkillsMiddleware:
         assert "is_builtin" not in skills["agents-skill"]["metadata"]
         assert skills["cursor-skill"]["description"] == "from cursor"
         assert "is_builtin" not in skills["cursor-skill"]["metadata"]
+
+
+class TestCustomGlobalSkills:
+    """Tests for custom global skills support."""
+
+    async def test_copies_custom_global_skills(self, tmp_path: Path):
+        from deepagents.backends.filesystem import FilesystemBackend
+
+        repo_name = "repoX"
+        builtin = tmp_path / "builtin_skills"
+        (builtin / "skill-one").mkdir(parents=True)
+        (builtin / "skill-one" / "SKILL.md").write_text(_make_skill_md(name="skill-one", description="builtin one"))
+
+        custom_global = tmp_path / "custom_skills"
+        (custom_global / "my-global-skill").mkdir(parents=True)
+        (custom_global / "my-global-skill" / "SKILL.md").write_text(
+            _make_skill_md(name="my-global-skill", description="a global skill")
+        )
+
+        backend = FilesystemBackend(root_dir=tmp_path, virtual_mode=True)
+        middleware = SkillsMiddleware(backend=backend, sources=[f"/{repo_name}/{AGENTS_SKILLS_PATH}"])
+        runtime = _make_runtime(repo_working_dir=str(tmp_path / repo_name))
+
+        with (
+            patch("automation.agent.middlewares.skills.BUILTIN_SKILLS_PATH", builtin),
+            patch("automation.agent.middlewares.skills.agent_settings.CUSTOM_SKILLS_PATH", custom_global),
+        ):
+            result = await middleware.abefore_agent({"messages": [HumanMessage(content="hello")]}, runtime, Mock())
+
+        assert result is not None
+        skills = {skill["name"]: skill for skill in result["skills_metadata"]}
+        assert set(skills) == {"skill-one", "my-global-skill"}
+        assert skills["my-global-skill"]["description"] == "a global skill"
+        assert skills["my-global-skill"]["metadata"].get("is_global") is True
+        assert skills["skill-one"]["metadata"].get("is_builtin") is True
+
+    async def test_custom_global_skill_overrides_builtin(self, tmp_path: Path):
+        from deepagents.backends.filesystem import FilesystemBackend
+
+        repo_name = "repoX"
+        builtin = tmp_path / "builtin_skills"
+        (builtin / "plan").mkdir(parents=True)
+        (builtin / "plan" / "SKILL.md").write_text(_make_skill_md(name="plan", description="builtin plan"))
+
+        custom_global = tmp_path / "custom_skills"
+        (custom_global / "plan").mkdir(parents=True)
+        (custom_global / "plan" / "SKILL.md").write_text(_make_skill_md(name="plan", description="custom plan"))
+
+        backend = FilesystemBackend(root_dir=tmp_path, virtual_mode=True)
+        middleware = SkillsMiddleware(backend=backend, sources=[f"/{repo_name}/{AGENTS_SKILLS_PATH}"])
+        runtime = _make_runtime(repo_working_dir=str(tmp_path / repo_name))
+
+        with (
+            patch("automation.agent.middlewares.skills.BUILTIN_SKILLS_PATH", builtin),
+            patch("automation.agent.middlewares.skills.agent_settings.CUSTOM_SKILLS_PATH", custom_global),
+        ):
+            result = await middleware.abefore_agent({"messages": [HumanMessage(content="hello")]}, runtime, Mock())
+
+        assert result is not None
+        skills = {skill["name"]: skill for skill in result["skills_metadata"]}
+        assert skills["plan"]["description"] == "custom plan"
+        assert skills["plan"]["metadata"].get("is_global") is True
+        assert "is_builtin" not in skills["plan"]["metadata"]
+
+    async def test_custom_global_skill_marked_as_global(self, tmp_path: Path):
+        from deepagents.backends.filesystem import FilesystemBackend
+
+        repo_name = "repoX"
+        builtin = tmp_path / "builtin_skills"
+        builtin.mkdir(parents=True)
+
+        custom_global = tmp_path / "custom_skills"
+        (custom_global / "global-skill").mkdir(parents=True)
+        (custom_global / "global-skill" / "SKILL.md").write_text(
+            _make_skill_md(name="global-skill", description="a global skill")
+        )
+
+        backend = FilesystemBackend(root_dir=tmp_path, virtual_mode=True)
+        middleware = SkillsMiddleware(backend=backend, sources=[f"/{repo_name}/{AGENTS_SKILLS_PATH}"])
+
+        with (
+            patch("automation.agent.middlewares.skills.BUILTIN_SKILLS_PATH", builtin),
+            patch("automation.agent.middlewares.skills.agent_settings.CUSTOM_SKILLS_PATH", custom_global),
+        ):
+            builtin_names, custom_global_names = await middleware._copy_global_skills(agent_path=tmp_path / repo_name)
+
+        assert "global-skill" in custom_global_names
+        assert "global-skill" not in builtin_names
+
+    async def test_per_repo_skill_overrides_custom_global(self, tmp_path: Path):
+        from deepagents.backends.filesystem import FilesystemBackend
+
+        repo_name = "repoX"
+        builtin = tmp_path / "builtin_skills"
+        builtin.mkdir(parents=True)
+
+        custom_global = tmp_path / "custom_skills"
+        (custom_global / "shared-skill").mkdir(parents=True)
+        (custom_global / "shared-skill" / "SKILL.md").write_text(
+            _make_skill_md(name="shared-skill", description="global version")
+        )
+
+        # Per-repo skill already exists in the repo
+        repo_skill = tmp_path / repo_name / AGENTS_SKILLS_PATH / "shared-skill"
+        repo_skill.mkdir(parents=True)
+        (repo_skill / "SKILL.md").write_text(_make_skill_md(name="shared-skill", description="repo version"))
+
+        original_exists = Path.exists
+
+        def fake_exists(self: Path) -> bool:
+            if str(self).startswith(f"/{repo_name}/"):
+                mapped = tmp_path / str(self).lstrip("/")
+                return original_exists(mapped)
+            return original_exists(self)
+
+        backend = FilesystemBackend(root_dir=tmp_path, virtual_mode=True)
+        middleware = SkillsMiddleware(backend=backend, sources=[f"/{repo_name}/{AGENTS_SKILLS_PATH}"])
+        runtime = _make_runtime(repo_working_dir=str(tmp_path / repo_name))
+
+        with (
+            patch("automation.agent.middlewares.skills.BUILTIN_SKILLS_PATH", builtin),
+            patch("automation.agent.middlewares.skills.agent_settings.CUSTOM_SKILLS_PATH", custom_global),
+            patch("pathlib.Path.exists", new=fake_exists),
+        ):
+            result = await middleware.abefore_agent({"messages": [HumanMessage(content="hello")]}, runtime, Mock())
+
+        assert result is not None
+        skills = {skill["name"]: skill for skill in result["skills_metadata"]}
+        # Per-repo version should win since dest_path.exists() returns True
+        assert skills["shared-skill"]["description"] == "repo version"
+
+    async def test_custom_global_skills_disabled_when_path_is_none(self, tmp_path: Path):
+        from deepagents.backends.filesystem import FilesystemBackend
+
+        repo_name = "repoX"
+        builtin = tmp_path / "builtin_skills"
+        (builtin / "skill-one").mkdir(parents=True)
+        (builtin / "skill-one" / "SKILL.md").write_text(_make_skill_md(name="skill-one", description="builtin one"))
+
+        backend = FilesystemBackend(root_dir=tmp_path, virtual_mode=True)
+        middleware = SkillsMiddleware(backend=backend, sources=[f"/{repo_name}/{AGENTS_SKILLS_PATH}"])
+
+        with (
+            patch("automation.agent.middlewares.skills.BUILTIN_SKILLS_PATH", builtin),
+            patch("automation.agent.middlewares.skills.agent_settings.CUSTOM_SKILLS_PATH", None),
+        ):
+            builtin_names, custom_global_names = await middleware._copy_global_skills(agent_path=tmp_path / repo_name)
+
+        assert builtin_names == ["skill-one"]
+        assert custom_global_names == []
+
+    async def test_custom_global_skills_skipped_when_path_not_exists(self, tmp_path: Path):
+        from deepagents.backends.filesystem import FilesystemBackend
+
+        repo_name = "repoX"
+        builtin = tmp_path / "builtin_skills"
+        (builtin / "skill-one").mkdir(parents=True)
+        (builtin / "skill-one" / "SKILL.md").write_text(_make_skill_md(name="skill-one", description="builtin one"))
+
+        backend = FilesystemBackend(root_dir=tmp_path, virtual_mode=True)
+        middleware = SkillsMiddleware(backend=backend, sources=[f"/{repo_name}/{AGENTS_SKILLS_PATH}"])
+
+        with (
+            patch("automation.agent.middlewares.skills.BUILTIN_SKILLS_PATH", builtin),
+            patch("automation.agent.middlewares.skills.agent_settings.CUSTOM_SKILLS_PATH", tmp_path / "nonexistent"),
+        ):
+            builtin_names, custom_global_names = await middleware._copy_global_skills(agent_path=tmp_path / repo_name)
+
+        assert builtin_names == ["skill-one"]
+        assert custom_global_names == []


### PR DESCRIPTION
Add custom global skills that are available across all repositories. Users mount skill directories via Docker volume to /home/daiv/data/skills/ (configurable via DAIV_AGENT_CUSTOM_SKILLS_PATH).

Custom global skills override built-in skills with the same name, and per-repository skills override both. Skills are copied at each agent invocation so changes take effect without container restart.