### PR TITLE
fix(redis): Reduce checkpoint TTL and use volatile-ttl eviction policy

### DIFF
--- a/daiv/codebase/managers/base.py
+++ b/daiv/codebase/managers/base.py
@@ -9,9 +9,6 @@ if TYPE_CHECKING:
     from codebase.context import RuntimeCtx
 
 
-CHECKPOINT_TTL_MINUTES = 60 * 24 * 90  # 90 days
-
-
 class BaseManager:
     """
     Base class for all managers.

--- a/daiv/codebase/managers/issue_addressor.py
+++ b/daiv/codebase/managers/issue_addressor.py
@@ -15,7 +15,7 @@ from codebase.base import GitPlatform
 from core.constants import BOT_NAME
 from core.utils import generate_uuid
 
-from .base import CHECKPOINT_TTL_MINUTES, BaseManager
+from .base import BaseManager
 
 if TYPE_CHECKING:
     from codebase.base import Issue
@@ -86,7 +86,8 @@ class IssueAddressorManager(BaseManager):
             )
 
         async with AsyncRedisSaver.from_conn_string(
-            django_settings.DJANGO_REDIS_CHECKPOINT_URL, ttl={"default_ttl": CHECKPOINT_TTL_MINUTES}
+            django_settings.DJANGO_REDIS_CHECKPOINT_URL,
+            ttl={"default_ttl": django_settings.DJANGO_REDIS_CHECKPOINT_TTL_MINUTES},
         ) as checkpointer:
             daiv_agent = await create_daiv_agent(
                 ctx=self.ctx,

--- a/daiv/codebase/managers/review_addressor.py
+++ b/daiv/codebase/managers/review_addressor.py
@@ -19,7 +19,7 @@ from codebase.base import GitPlatform, MergeRequest, Note, NoteDiffPosition, Not
 from core.constants import BOT_NAME
 from core.utils import generate_uuid
 
-from .base import CHECKPOINT_TTL_MINUTES, BaseManager
+from .base import BaseManager
 
 if TYPE_CHECKING:
     from codebase.context import RuntimeCtx
@@ -225,7 +225,8 @@ class CommentsAddressorManager(BaseManager):
         )
 
         async with AsyncRedisSaver.from_conn_string(
-            django_settings.DJANGO_REDIS_CHECKPOINT_URL, ttl={"default_ttl": CHECKPOINT_TTL_MINUTES}
+            django_settings.DJANGO_REDIS_CHECKPOINT_URL,
+            ttl={"default_ttl": django_settings.DJANGO_REDIS_CHECKPOINT_TTL_MINUTES},
         ) as checkpointer:
             daiv_agent = await create_daiv_agent(
                 ctx=self.ctx,

--- a/daiv/daiv/settings/components/redis.py
+++ b/daiv/daiv/settings/components/redis.py
@@ -1,8 +1,10 @@
+from decouple import config
 from get_docker_secret import get_docker_secret
 
 DJANGO_REDIS_URL = get_docker_secret("DJANGO_REDIS_URL")
 DJANGO_REDIS_SESSION_URL = get_docker_secret("DJANGO_REDIS_SESSION_URL", default=DJANGO_REDIS_URL)
 DJANGO_REDIS_CHECKPOINT_URL = get_docker_secret("DJANGO_REDIS_CHECKPOINT_URL", default=DJANGO_REDIS_URL)
+DJANGO_REDIS_CHECKPOINT_TTL_MINUTES = config("DJANGO_REDIS_CHECKPOINT_TTL_MINUTES", default=60 * 24 * 7, cast=int)
 
 _REDIS_OPTIONS = {
     "socket_connect_timeout": 5,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,7 @@ services:
 
   redis:
     image: redis:8.6-alpine
-    command: redis-server --save "" --appendonly yes --dir /data --maxmemory 512mb --maxmemory-policy noeviction
+    command: redis-server --save "" --appendonly yes --dir /data --maxmemory 512mb --maxmemory-policy volatile-ttl
     restart: unless-stopped
     container_name: daiv-redis
     healthcheck:

--- a/docs/reference/env-variables.md
+++ b/docs/reference/env-variables.md
@@ -52,6 +52,7 @@ Variables marked with:
 | :material-asterisk: `DJANGO_REDIS_URL`  :material-lock: | Redis connection URL for cache (DB 0) | *(none)* | `redis://redis:6379/0` |
 | `DJANGO_REDIS_SESSION_URL`  :material-lock: | Redis connection URL for sessions (DB 1) | Value of `DJANGO_REDIS_URL` | `redis://redis:6379/1` |
 | `DJANGO_REDIS_CHECKPOINT_URL`  :material-lock: | Redis connection URL for LangGraph checkpoints (DB 2) | Value of `DJANGO_REDIS_URL` | `redis://redis:6379/2` |
+| `DJANGO_REDIS_CHECKPOINT_TTL_MINUTES` | TTL in minutes for LangGraph checkpoint data | `10080` (7 days) | `1440` |
 
 
 ### Sentry


### PR DESCRIPTION
Checkpoint data with a 90-day TTL was filling the 512MB Redis instance with noeviction policy, causing OutOfMemoryError on all writes (DAIV-6T). Make the TTL configurable via DJANGO_REDIS_CHECKPOINT_TTL_MINUTES with a 7-day default and switch Redis to volatile-ttl eviction.