### PR TITLE
feat(agent): Add local/ACP runtime mode support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,223 +1,51 @@
-# Project Overview
+# AGENTS.md
 
-DAIV is an AI-powered development assistant built on Django with Django Tasks for async task processing, LangChain/LangGraph for LLM integration, and includes `daiv-sandbox` for sandboxed command execution. It integrates with GitLab and GitHub to automate issue resolution, code reviews, and CI/CD pipeline repairs.
+This file provides guidance to agents when working with code in this repository.
 
-## Project Structure
-
-* `daiv/` - Django project with all the application code.
-    * `automation/` - Automation module with all the agents logic and tools.
-    * `codebase/` - Codebase module with all the repository interaction and related logic.
-    * `chat/` - Chat module with the OpenAI compatible API.
-    * `core/` - Core module with common logic.
-    * `slash_commands/` - Slash commands module.
-    * `daiv/` - Main logic of the Django project: settings, urls, wsgi, asgi, tasks, etc.
-* `docker/` - Dockerfiles and configurations for local and production deployments.
-* `docs/` - Documentation for the project.
-* `evals/` - Evaluation suite for the project (openevals + langsmith + pytest).
-* `tests/` - Test suite for the project (pytest).
-
-## Build, Lint, and Test Commands
-
-### Testing
-```bash
-make test                                      # run all unit tests with coverage
-uv run pytest tests/automation/test_utils.py   # run a specific test file
-uv run pytest tests/automation/test_utils.py::TestFileReadFunctions::test_register_file_read  # run a single test
-uv run pytest tests/ -k "test_notes"           # run tests matching pattern
-uv run pytest tests/ -v                        # verbose output
-```
-
-### Linting & Formatting
-```bash
-make lint-fix       # check and fix linting and formatting issues (recommended)
-make lint           # check linting and formatting without fixing
-make lint-check     # run ruff linter check only
-make lint-format    # check code formatting only
-make lint-typing    # run type checking with mypy
-```
-
-**IMPORTANT**: Always run `make lint-fix` instead of `make lint` to automatically fix issues. Only manually fix issues that cannot be auto-fixed by `make lint-fix`.
-
-### Building Documentation
-```bash
-make docs-serve     # serve documentation locally at localhost:4000
-```
-
-## Code Style Guidelines
-
-### Formatting
-- Line length: 120 characters maximum
-- Use double quotes for strings
-- No trailing commas in function calls (skip-magic-trailing-comma enabled)
-- Use type hints for all function parameters and return types
-
-### Naming Conventions
-- Functions/variables: `snake_case`
-- Classes: `PascalCase`
-- Constants: `UPPER_SNAKE_CASE`
-- Private methods/attributes: prefix with single underscore `_private_method`
-- Django models: use verbose names with `gettext_lazy` for i18n
-
-### Type Annotations
-- Always provide type hints for function parameters and return values
-- Use `str | None` instead of `Optional[str]` (Python 3.10+ union syntax)
-- Use `list[Type]` instead of `List[Type]` (built-in generics)
-- Use `dict[str, Any]` instead of `Dict[str, Any]`
-- Annotate class attributes in Django models when needed
-
-Example:
-```python
-def commit_changes(self, commit_message: str, *, branch_name: str, skip_ci: bool = False) -> str:
-    """Commit changes to the repository."""
-    ...
-```
-
-### Docstrings
-- Use Google-style docstrings for all public functions and classes
-- Include Args, Returns, and Raises sections as needed
-- Keep descriptions concise but informative
-
-Example:
-```python
-def get_repo_ref(repo: Repo) -> str:
-    """
-    Get the current reference (branch name or commit SHA) from a repository.
-
-    When HEAD is attached to a branch, returns the branch name.
-    When HEAD is detached (e.g., checking out a specific commit), returns the commit SHA.
-
-    Args:
-        repo: The Git repository object.
-
-    Returns:
-        The branch name if HEAD is attached, or the commit SHA if HEAD is detached.
-    """
-```
-
-### Error Handling
-- Raise `ValueError` for invalid arguments
-- Raise `RuntimeError` for operation failures
-- Use `contextlib.suppress()` for expected, ignorable exceptions
-- Log warnings with `logger.warning()` for non-critical issues
-- Chain exceptions with `raise ... from e` to preserve context
-
-Example:
-```python
-try:
-    self.repo.git.apply(*diff_args, tmp_path)
-except GitCommandError as e:
-    raise RuntimeError("git apply failed. The patch is not valid.") from e
-```
-
-### Async Code
-- Use `async`/`await` for async functions
-- Use `asyncio.gather()` for concurrent operations
-
-## Tool State Updates
-
-**CRITICAL**: Tools CANNOT directly modify `runtime.state`. To update state, tools must return a `Command` object from `langgraph.types`:
-
-```python
-from langgraph.types import Command
-from langchain_core.messages import ToolMessage
-
-
-@tool("my_tool")
-async def my_tool(param: str, runtime: ToolRuntime) -> str | Command:
-    # Simple case: just return output as string
-    if not needs_state_update:
-        return "output"
-
-    # When state update is needed: return Command with ToolMessage
-    output = "tool output"
-    state_update = {"key": "value", "messages": [ToolMessage(content=output, tool_call_id=runtime.tool_call_id)]}
-    return Command(update=state_update)
-```
-
-**Examples**:
-- ❌ `runtime.state["key"] = "value"` - WRONG! Direct state modification doesn't work
-- ❌ `return Command(update={"key": "value"}, resume=output)` - WRONG! Output should be in ToolMessage
-- ✅ `return Command(update={"key": "value", "messages": [ToolMessage(content=output, tool_call_id=runtime.tool_call_id)]})` - CORRECT!
-
-**Note**: When a tool needs to both return output and update state, the output MUST be included as a `ToolMessage` in the `messages` key of the state update. The `tool_call_id` must match `runtime.tool_call_id`.
-
-**Testing Command returns**: In unit tests, when calling a tool directly (not through the agent framework), you must manually handle Command returns:
-```python
-result = await tool.coroutine(params, runtime=runtime)
-if isinstance(result, Command):
-    # Extract output from ToolMessage
-    messages = result.update.get("messages", [])
-    output = messages[0].content if messages else None
-    
-    # Apply state updates (excluding messages which are handled by framework)
-    state_updates = {k: v for k, v in result.update.items() if k != "messages"}
-    runtime.state.update(state_updates)
-else:
-    output = result
-```
-
-## Dependency Management
-
-Use `uv` to manage dependencies. All dependencies are defined in `pyproject.toml`.
-
-**IMPORTANT**: Never edit `pyproject.toml` directly. Use `uv` commands and pin dependencies to exact versions with `==`.
+## Commands (verified)
 
 ```bash
-uv sync --all-groups                    # install all dependencies
-uv sync --only-group=dev                # install only dev dependencies
-uv add <package>==<version>             # add a new dependency with exact version
-uv remove <package>                     # remove a dependency
-uv lock                                 # update the lock file
+make test                        # run all unit tests with coverage
+make lint-fix                    # auto-fix linting + formatting (always prefer over make lint)
+make lint-typing                 # type-check with ty (not mypy)
+make docs-serve                  # preview docs at localhost:4000
+
+# Targeted test runs
+uv run pytest tests/unit_tests/path/to/test_file.py          # single file
+uv run pytest tests/unit_tests/path/to/test_file.py::test_fn # single test
+uv run pytest tests/unit_tests -k "pattern"                  # by keyword
 ```
 
-## Testing Guidelines
+- All unit tests live under `tests/unit_tests/`, mirroring the `daiv/` structure.
+- Never edit `pyproject.toml` directly — use `uv add <pkg>==<version>` / `uv remove <pkg>`.
 
-- Use `pytest` with `pytest-asyncio` for async tests
-- Organize tests in functions.
-- Use descriptive test names: `test_<what_it_does>`
-- Use fixtures for common setup (e.g., `@pytest.fixture`)
-- Mock external dependencies for unit tests with `unittest.mock` or `pytest-mock` or `pytest-httpx`.
-- All unit tests should be in the `tests/unit_tests/` directory mirroring the `daiv/` structure
-- All integration tests should be in the `tests/integration_tests/` directory.
+## Repo map (non-obvious)
 
-## Documentation
+- `daiv/automation/` — all agent logic: `agent/` (graph, skills, subagents, toolkits, middlewares, MCP/ACP)
+- `daiv/codebase/` — Git platform clients (GitHub/GitLab), repo managers, code search, chunking
+- `daiv/chat/` — OpenAI-compatible chat API
+- `daiv/core/` — shared utilities, sandbox client, task backends
+- `daiv/daiv/` — Django project core: settings, urls, wsgi/asgi, tasks
+- `daiv/slash_commands/` — slash command handlers
+- `evals/` — LangSmith + openevals evaluation suite (separate from `tests/`)
+- `tests/unit_tests/` / `tests/integration_tests/` — pytest suites
 
-- Use `mkdocs` for documentation (Material theme)
-- Documentation is located in `docs/` directory
-- Add/update docs when adding new features or making significant changes
-- Run `make docs-serve` to preview documentation locally
+## Invariants / footguns
 
-## Changelog
+- **Tool state updates**: Tools cannot mutate `runtime.state` directly. Return a `Command` object with a `ToolMessage` in `messages`:
+  ```python
+  return Command(update={"key": val, "messages": [ToolMessage(content=out, tool_call_id=runtime.tool_call_id)]})
+  ```
+- **Testing `Command` returns**: In unit tests, unwrap manually — check `isinstance(result, Command)` and extract `.update["messages"][0].content`.
+- **Type checker is `ty`**, not mypy — `make lint-typing` runs `ty check daiv`.
+- **Python 3.14** — use `str | None`, `list[T]`, `dict[K, V]` (no `Optional`, no `List`, no `Dict`).
+- **Changelog**: Always update `CHANGELOG.md` after changes.
+- **Commits**: Conventional Commits format — `feat:`, `fix:`, `chore:`, etc., lowercase, ≤72 chars.
+- **Branches**: `feat/`, `fix/`, or `chore/` prefix + kebab summary.
 
-**ALWAYS** update `CHANGELOG.md` after making changes to the project using the `changelog-curator` subagent.
+## Where changes usually go
 
-## Translations
-
-Translations are in `locale/` directories with subdirectories for each language.
-
-```bash
-make makemessages       # generate translation files
-# Edit *.po files with translations
-make compilemessages    # compile translations
-```
-
-## Repository Conventions
-
-### Branch Naming
-Format: `<prefix>/<short-kebab-summary>`
-
-Prefixes:
-- `feat/` - new features (e.g., `feat/add-github-integration`)
-- `fix/` - bug fixes (e.g., `fix/resolve-memory-leak`)
-- `chore/` - maintenance tasks (e.g., `chore/update-dependencies`)
-
-### Commit Messages
-Follow [Conventional Commits](https://www.conventionalcommits.org/):
-- Format: `<type>: <short summary>`
-- Types: `feat`, `fix`, `chore`, `docs`, `refactor`, `test`, `style`, `perf`, `ci`, `build`
-- Summary: lowercase, no period, max 72 characters
-
-Examples:
-- `feat: add gitlab webhook support`
-- `fix: resolve race condition in task queue`
-- `docs: update installation instructions`
+- New agent tools → `daiv/automation/agent/toolkits.py` or a new file under `daiv/automation/agent/`
+- New skills → `daiv/automation/agent/skills/`
+- Git platform logic → `daiv/codebase/clients/`
+- Shared utilities → `daiv/core/`

--- a/daiv-acp.sh
+++ b/daiv-acp.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+cd /home/sfr/work/personal/daiv/daiv
+PYTHONFAULTHANDLER=1 exec /home/sfr/work/personal/daiv/.venv/bin/python -u -m automation.agent.acp 2>/tmp/daiv-acp.log

--- a/daiv/automation/agent/acp/__init__.py
+++ b/daiv/automation/agent/acp/__init__.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from automation.agent.graph import create_daiv_agent
+from codebase.context import LocalRuntimeCtx, create_local_runtime_ctx
+
+if TYPE_CHECKING:
+    from langgraph.graph.state import CompiledStateGraph
+
+
+async def _build_agent(cwd: Path) -> tuple[CompiledStateGraph, LocalRuntimeCtx]:
+    """Build a DAIV agent and return both the graph and its context."""
+    ctx = create_local_runtime_ctx(cwd)
+    agent = await create_daiv_agent(
+        ctx=ctx,
+        auto_commit_changes=False,
+        # Sandbox requires the daiv-sandbox service which isn't available in standalone/ACP mode.
+        # Users can override via .daiv.yml if they have a sandbox running.
+        sandbox_enabled=False,
+    )
+    return agent, ctx
+
+
+def create_acp_server():
+    """
+    Create an AgentServerACP instance configured with the DAIV agent factory.
+
+    Uses a subclass that:
+    - Supports async factory functions (create_daiv_agent is async)
+    - Injects LocalRuntimeCtx as the `context` kwarg on agent invocations,
+      since the upstream AgentServerACP doesn't pass it to astream()
+    """
+    from deepagents_acp.server import AgentServerACP
+
+    class DAIVAgentServerACP(AgentServerACP):
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+            self._session_ctx: dict[str, LocalRuntimeCtx] = {}
+            self._logger = __import__("logging").getLogger("daiv.acp")
+
+        async def list_sessions(self, cursor=None, cwd=None, **kwargs):
+            from acp.schema import ListSessionsResponse
+
+            self._logger.info("list_sessions called")
+            return ListSessionsResponse(sessions=[])
+
+        async def load_session(self, cwd, session_id, mcp_servers=None, **kwargs):
+            self._logger.info("load_session called: session_id=%s", session_id)
+            return None
+
+        async def close_session(self, session_id, **kwargs):
+            self._logger.info("close_session: session_id=%s", session_id)
+            self._session_ctx.pop(session_id, None)
+            return None
+
+        async def new_session(self, cwd, mcp_servers=None, **kwargs):
+            self._logger.info("new_session called: cwd=%s", cwd)
+            return await super().new_session(cwd, mcp_servers or [], **kwargs)
+
+        async def set_session_mode(self, mode_id, session_id, **kwargs):
+            self._logger.info("set_session_mode: mode=%s session=%s", mode_id, session_id)
+            return await super().set_session_mode(mode_id, session_id, **kwargs)
+
+        async def set_config_option(self, *args, **kwargs):
+            self._logger.info("set_config_option: args=%s kwargs=%s", args, kwargs)
+            try:
+                return await super().set_config_option(*args, **kwargs)
+            except Exception:
+                self._logger.exception("set_config_option failed")
+                raise
+
+        async def prompt(self, prompt, session_id, **kwargs):
+            if self._agent is None:
+                cwd = self._session_cwds.get(session_id)
+                if cwd is not None:
+                    self._cwd = cwd
+
+                agent, ctx = await _build_agent(Path(self._cwd) if self._cwd else Path.cwd())
+                self._agent = agent
+                self._session_ctx[session_id] = ctx
+
+                from langgraph.checkpoint.memory import MemorySaver
+
+                if getattr(self._agent, "checkpointer", None) is None:
+                    self._agent.checkpointer = MemorySaver()
+
+            # Wrap the agent to inject context= into astream/ainvoke calls
+            ctx = self._session_ctx.get(session_id)
+            if ctx is not None:
+                self._agent = _ContextInjectingAgent(self._agent, ctx)
+
+            try:
+                return await super().prompt(prompt, session_id, **kwargs)
+            except Exception:
+                import logging
+
+                logging.getLogger("daiv.acp").exception("Error in prompt handler")
+                raise
+            finally:
+                # Unwrap so the real agent is stored for next call
+                if isinstance(self._agent, _ContextInjectingAgent):
+                    self._agent = self._agent._agent
+
+    # Dummy factory — never actually called since we override prompt()
+    return DAIVAgentServerACP(agent=lambda ctx: None)
+
+
+class _ContextInjectingAgent:
+    """Wraps a CompiledStateGraph to inject `context=` into astream/ainvoke calls."""
+
+    def __init__(self, agent: CompiledStateGraph, ctx: LocalRuntimeCtx):
+        self._agent = agent
+        self._ctx = ctx
+
+    def astream(self, *args: Any, **kwargs: Any):
+        kwargs.setdefault("context", self._ctx)
+        return self._agent.astream(*args, **kwargs)
+
+    async def aget_state(self, *args: Any, **kwargs: Any):
+        return await self._agent.aget_state(*args, **kwargs)
+
+    async def aupdate_state(self, *args: Any, **kwargs: Any):
+        return await self._agent.aupdate_state(*args, **kwargs)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._agent, name)

--- a/daiv/automation/agent/acp/__main__.py
+++ b/daiv/automation/agent/acp/__main__.py
@@ -1,0 +1,76 @@
+"""
+Standalone DAIV ACP server entry point.
+
+Runs the DAIV agent over the Agent Client Protocol (ACP) via stdio,
+without requiring Django or any external infrastructure (database, Redis).
+
+Usage:
+    python -m automation.agent.acp
+
+The only required environment variables are the LLM API keys, e.g.:
+    AUTOMATION_ANTHROPIC_API_KEY=sk-...
+    AUTOMATION_OPENROUTER_API_KEY=sk-...
+"""
+
+import asyncio
+import logging
+import sys
+
+
+def _patch_acp_schema():
+    """
+    Patch the ACP SDK schema for compatibility with newer clients like Zed.
+
+    - Accept string protocol versions (e.g., "0.11.2") in addition to integers.
+      Zed sends semver strings, but agent-client-protocol<=0.9.0 only accepts int.
+    - Make mcp_servers optional in NewSessionRequest (Zed may omit it).
+    """
+    from acp import schema
+
+    for model in (schema.InitializeRequest, schema.InitializeResponse):
+        field = model.model_fields["protocol_version"]
+        if field.annotation is int:
+            field.annotation = int | str
+            field.metadata = [m for m in field.metadata if not hasattr(m, "ge") and not hasattr(m, "le")]
+            model.model_rebuild(force=True)
+
+    mcp_field = schema.NewSessionRequest.model_fields.get("mcp_servers")
+    if mcp_field and mcp_field.is_required():
+        mcp_field.default = []
+        schema.NewSessionRequest.model_rebuild(force=True)
+
+
+def _patch_acp_error_logging():
+    """Patch the ACP router to log original exceptions before they're wrapped."""
+    import acp.router as router_mod
+
+    _original_route = router_mod.Route
+
+    class LoggingRoute(_original_route):
+        async def handle(self, params):
+            try:
+                return await super().handle(params)
+            except Exception:
+                logging.getLogger("daiv.acp").exception("ACP route error")
+                raise
+
+    router_mod.Route = LoggingRoute
+
+
+def main():
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s", stream=sys.stderr)
+
+    _patch_acp_schema()
+    _patch_acp_error_logging()
+
+    from acp import run_agent as run_acp_agent
+
+    from automation.agent.acp import create_acp_server
+
+    server = create_acp_server()
+    logging.getLogger("daiv.acp").info("Starting DAIV ACP server over stdio")
+    asyncio.run(run_acp_agent(server))
+
+
+if __name__ == "__main__":
+    main()

--- a/daiv/automation/agent/graph.py
+++ b/daiv/automation/agent/graph.py
@@ -1,7 +1,6 @@
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
-
-from django.utils import timezone
 
 from deepagents.backends.filesystem import FilesystemBackend
 from deepagents.middleware.memory import MemoryMiddleware
@@ -37,7 +36,7 @@ from automation.agent.prompts import DAIV_SYSTEM_PROMPT, REPO_RELATIVE_SYSTEM_RE
 from automation.agent.subagents import create_explore_subagent, create_general_purpose_subagent, load_custom_subagents
 from automation.conf import settings as automation_settings
 from codebase.base import GitPlatform
-from codebase.context import RuntimeCtx
+from codebase.context import AgentCtx, LocalRuntimeCtx, RuntimeCtx
 from codebase.utils import get_repo_ref
 from core.constants import BOT_NAME
 
@@ -71,33 +70,45 @@ async def dynamic_daiv_system_prompt(request: ModelRequest) -> str:
     Returns:
         str: The dynamic prompt for the DAIV system.
     """
-    context = cast("RuntimeCtx", request.runtime.context)
-    agent_path = Path(context.gitrepo.working_dir)
+    context: AgentCtx = request.runtime.context
+    is_local = isinstance(context, LocalRuntimeCtx)
 
-    daiv_system_prompt = await DAIV_SYSTEM_PROMPT.aformat(
-        current_date=timezone.now().strftime("%d %B, %Y"),
-        bot_name=BOT_NAME,
-        bot_username=context.bot_username,
-        repository_url=context.repository.html_url,
-        gitlab_platform=context.git_platform == GitPlatform.GITLAB,
-        github_platform=context.git_platform == GitPlatform.GITHUB,
-        bash_tool_enabled=BASH_TOOL_NAME in [tool.name for tool in request.tools],
-        working_directory=f"/{agent_path.name}/",
-        current_branch=get_repo_ref(context.gitrepo),
-    )
+    # Build shared template kwargs, then extend with mode-specific ones
+    kwargs: dict = {
+        "current_date": datetime.now(UTC).strftime("%d %B, %Y"),
+        "bot_name": BOT_NAME,
+        "bot_username": context.bot_username,
+        "bash_tool_enabled": BASH_TOOL_NAME in {tool.name for tool in request.tools},
+        "local_mode": is_local,
+    }
+
+    if is_local:
+        kwargs["working_directory"] = str(context.working_dir)
+        kwargs["current_branch"] = get_repo_ref(context.gitrepo) if context.gitrepo else ""
+    else:
+        context = cast("RuntimeCtx", context)
+        agent_path = Path(context.gitrepo.working_dir)
+        kwargs["working_directory"] = f"/{agent_path.name}/"
+        kwargs["current_branch"] = get_repo_ref(context.gitrepo)
+        kwargs["repository_url"] = context.repository.html_url
+        kwargs["gitlab_platform"] = context.git_platform == GitPlatform.GITLAB
+        kwargs["github_platform"] = context.git_platform == GitPlatform.GITHUB
+
+    daiv_system_prompt = await DAIV_SYSTEM_PROMPT.aformat(**kwargs)
 
     inherited_system_prompt = ""
     if request.system_prompt:
         inherited_system_prompt = request.system_prompt + "\n\n"
 
-    return (
-        OUTPUT_INVARIANTS_SYSTEM_PROMPT
-        + "\n\n"
-        + cast("str", daiv_system_prompt.content).strip()
-        + "\n\n"
-        + inherited_system_prompt
-        + REPO_RELATIVE_SYSTEM_REMINDER
-    )
+    prompt_parts = [cast("str", daiv_system_prompt.content).strip()]
+
+    if not is_local:
+        prompt_parts.insert(0, OUTPUT_INVARIANTS_SYSTEM_PROMPT)
+        prompt_parts.append(inherited_system_prompt + REPO_RELATIVE_SYSTEM_REMINDER)
+    elif inherited_system_prompt:
+        prompt_parts.append(inherited_system_prompt.rstrip())
+
+    return "\n\n".join(prompt_parts)
 
 
 def dynamic_write_todos_system_prompt(bash_tool_enabled: bool) -> str:
@@ -111,7 +122,7 @@ async def create_daiv_agent(
     model_names: Sequence[ModelName | str] = (settings.MODEL_NAME, settings.FALLBACK_MODEL_NAME),
     thinking_level: ThinkingLevel | None = settings.THINKING_LEVEL,
     *,
-    ctx: RuntimeCtx,
+    ctx: AgentCtx,
     auto_commit_changes: bool = True,
     checkpointer: BaseCheckpointSaver | None = None,
     store: BaseStore | None = None,
@@ -128,7 +139,7 @@ async def create_daiv_agent(
     Args:
         model_names: The model names to use for the agent.
         thinking_level: The thinking level to use for the agent.
-        ctx: The runtime context.
+        ctx: The runtime context (platform or local).
         auto_commit_changes: Whether to commit the changes to the repository when the agent finishes.
         checkpointer: The checkpointer to use for the agent.
         store: The store to use for the agent.
@@ -141,6 +152,7 @@ async def create_daiv_agent(
     Returns:
         The DAIV agent.
     """
+    is_local = isinstance(ctx, LocalRuntimeCtx)
 
     model = BaseAgent.get_model(model=model_names[0], thinking_level=thinking_level)
     fallback_models = [
@@ -154,8 +166,17 @@ async def create_daiv_agent(
         web_search_enabled if web_search_enabled is not None else automation_settings.WEB_SEARCH_ENABLED
     )
 
-    agent_path = Path(ctx.gitrepo.working_dir)
-    backend = FilesystemBackend(root_dir=agent_path.parent, virtual_mode=True)
+    if is_local:
+        agent_path = ctx.working_dir
+        backend = FilesystemBackend(root_dir=agent_path, virtual_mode=True)
+    else:
+        agent_path = Path(ctx.gitrepo.working_dir)
+        backend = FilesystemBackend(root_dir=agent_path.parent, virtual_mode=True)
+
+    # Build path prefix for filesystem sources
+    # For platform mode: /repo/ (agent_path.name inside the parent root)
+    # For local mode: / (the cwd itself is the root)
+    path_prefix = f"/{agent_path.name}" if not is_local else ""
 
     # Create subagents list to be shared between middlewares
     subagents = [
@@ -175,7 +196,7 @@ async def create_daiv_agent(
         model=model,
         backend=backend,
         runtime=ctx,
-        sources=[f"/{agent_path.name}/{source}" for source in SUBAGENTS_SOURCES],
+        sources=[f"{path_prefix}/{source}" for source in SUBAGENTS_SOURCES],
         sandbox_enabled=_sandbox_enabled,
         web_search_enabled=_web_search_enabled,
         web_fetch_enabled=_web_fetch_enabled,
@@ -199,16 +220,22 @@ async def create_daiv_agent(
         TodoListMiddleware(system_prompt=dynamic_write_todos_system_prompt(bash_tool_enabled=_sandbox_enabled)),
         MemoryMiddleware(
             backend=backend,
-            sources=[f"/{agent_path.name}/{ctx.config.context_file_name}", f"/{agent_path.name}/{AGENTS_MEMORY_PATH}"],
+            sources=[f"{path_prefix}/{ctx.config.context_file_name}", f"{path_prefix}/{AGENTS_MEMORY_PATH}"],
         ),
         SkillsMiddleware(
-            backend=backend, sources=[f"/{agent_path.name}/{source}" for source in SKILLS_SOURCES], subagents=subagents
+            backend=backend, sources=[f"{path_prefix}/{source}" for source in SKILLS_SOURCES], subagents=subagents
         ),
         SubAgentMiddleware(backend=backend, subagents=subagents),
         *agent_conditional_middlewares,
         FilesystemMiddleware(backend=backend),
-        GitMiddleware(auto_commit_changes=auto_commit_changes),
-        GitPlatformMiddleware(git_platform=ctx.git_platform),
+    ]
+
+    # Git middlewares only apply in platform mode
+    if not is_local:
+        agent_middleware.append(GitMiddleware(auto_commit_changes=auto_commit_changes))
+        agent_middleware.append(GitPlatformMiddleware(git_platform=ctx.git_platform))
+
+    agent_middleware.extend([
         SummarizationMiddleware(
             model=model,
             backend=backend,
@@ -222,13 +249,13 @@ async def create_daiv_agent(
         ensure_non_empty_response,
         PatchToolCallsMiddleware(),
         dynamic_daiv_system_prompt,
-    ]
+    ])
 
     return create_agent(
         model,
         tools=await MCPToolkit.get_tools(),
         middleware=agent_middleware,
-        context_schema=RuntimeCtx,
+        context_schema=type(ctx),
         checkpointer=checkpointer,
         store=store,
         debug=debug,

--- a/daiv/automation/agent/middlewares/sandbox.py
+++ b/daiv/automation/agent/middlewares/sandbox.py
@@ -5,7 +5,6 @@ import io
 import json
 import logging
 import tarfile
-from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, NotRequired
 
 import httpx
@@ -15,7 +14,7 @@ from langchain.tools import ToolRuntime  # noqa: TC002
 from langchain_core.tools import tool
 from langgraph.typing import StateT  # noqa: TC002
 
-from codebase.context import RuntimeCtx  # noqa: TC001
+from codebase.context import AgentCtx, get_working_dir  # noqa: TC001
 from codebase.utils import GitManager
 from core.conf import settings
 from core.sandbox.client import DAIVSandboxClient
@@ -25,6 +24,7 @@ from core.sandbox.schemas import RunCommandsRequest, RunCommandsResponse, StartS
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
+    from pathlib import Path
 
     from langgraph.runtime import Runtime
 
@@ -143,7 +143,7 @@ Git safety (highest priority):
 
 
 @tool(BASH_TOOL_NAME, description=BASH_TOOL_DESCRIPTION)
-async def bash_tool(command: Annotated[str, "The command to execute."], runtime: ToolRuntime[RuntimeCtx]) -> str:
+async def bash_tool(command: Annotated[str, "The command to execute."], runtime: ToolRuntime[AgentCtx]) -> str:
     """
     Tool to run a list of Bash commands in a persistent shell session.
     """
@@ -151,7 +151,7 @@ async def bash_tool(command: Annotated[str, "The command to execute."], runtime:
     if denial_error:
         return denial_error
 
-    repo_working_dir = Path(runtime.context.gitrepo.working_dir)
+    repo_working_dir = get_working_dir(runtime.context)
 
     response = await _run_bash_commands([command], repo_working_dir, runtime.state["session_id"])
     if response is None:
@@ -161,16 +161,19 @@ async def bash_tool(command: Annotated[str, "The command to execute."], runtime:
         )
 
     if response.patch:
-        try:
-            GitManager(runtime.context.gitrepo).apply_patch(response.patch)
-        except Exception:
-            logger.exception("[%s] Error applying patch to the repository.", bash_tool.name)
-            return "error: Failed to persist the changes. The bash tool is not working properly."
+        if runtime.context.gitrepo is not None:
+            try:
+                GitManager(runtime.context.gitrepo).apply_patch(response.patch)
+            except Exception:
+                logger.exception("[%s] Error applying patch to the repository.", bash_tool.name)
+                return "error: Failed to persist the changes. The bash tool is not working properly."
+        else:
+            logger.warning("[%s] No git repo available, skipping patch application.", bash_tool.name)
 
     return json.dumps([result.model_dump(mode="json") for result in response.results])
 
 
-def _check_command_policy(command: str, runtime: ToolRuntime[RuntimeCtx]) -> str | None:
+def _check_command_policy(command: str, runtime: ToolRuntime[AgentCtx]) -> str | None:
     """
     Parse *command* with Parable and evaluate it against the effective policy.
 
@@ -335,13 +338,13 @@ class SandboxMiddleware(AgentMiddleware):
         self.close_session = close_session
         self.tools = [bash_tool]
 
-    async def abefore_agent(self, state: StateT, runtime: Runtime[RuntimeCtx]) -> dict[str, str] | None:
+    async def abefore_agent(self, state: StateT, runtime: Runtime[AgentCtx]) -> dict[str, str] | None:
         """
         Prepare state for lazy sandbox session start.
 
         Args:
             state (StateT): The state of the agent.
-            runtime (Runtime[RuntimeCtx]): The runtime context.
+            runtime (Runtime[AgentCtx]): The runtime context.
 
         Returns:
             dict[str, str] | None: The state updates with the sandbox session ID.
@@ -364,13 +367,13 @@ class SandboxMiddleware(AgentMiddleware):
         )
         return {"session_id": session_id}
 
-    async def aafter_agent(self, state: StateT, runtime: Runtime[RuntimeCtx]) -> dict[str, str] | None:
+    async def aafter_agent(self, state: StateT, runtime: Runtime[AgentCtx]) -> dict[str, str] | None:
         """
         Close the sandbox session after the agent finishes the execution loop.
 
         Args:
             state (StateT): The state of the agent.
-            runtime (Runtime[RuntimeCtx]): The runtime context.
+            runtime (Runtime[AgentCtx]): The runtime context.
 
         Returns:
             dict[str, str] | None: The state updates with the closed sandbox session ID.

--- a/daiv/automation/agent/middlewares/skills.py
+++ b/daiv/automation/agent/middlewares/skills.py
@@ -18,7 +18,7 @@ from langgraph.types import Command
 from automation.agent.conf import settings as agent_settings
 from automation.agent.constants import AGENTS_SKILLS_PATH, BUILTIN_SKILLS_PATH
 from automation.agent.utils import extract_body_from_frontmatter, extract_text_content
-from codebase.context import RuntimeCtx  # noqa: TC001
+from codebase.context import AgentCtx, LocalRuntimeCtx, RuntimeCtx  # noqa: TC001
 from slash_commands.parser import SlashCommandCommand, parse_slash_command
 from slash_commands.registry import slash_command_registry
 
@@ -121,7 +121,7 @@ class SkillsMiddleware(DeepAgentsSkillsMiddleware):
 
     @hook_config(can_jump_to=["end"])
     async def abefore_agent(
-        self, state: DAIVSkillsState, runtime: Runtime[RuntimeCtx], config: RunnableConfig
+        self, state: DAIVSkillsState, runtime: Runtime[AgentCtx], config: RunnableConfig
     ) -> SkillsStateUpdate | dict | None:
         """
         Apply builtin slash commands early in the conversation and copy builtin skills to the project skills directory
@@ -133,13 +133,13 @@ class SkillsMiddleware(DeepAgentsSkillsMiddleware):
         if clear_skill_mode:
             logger.info("[%s] Clearing active skill mode '%s' on user follow-up", self.name, state["active_skill_mode"])
 
+        is_local = isinstance(runtime.context, LocalRuntimeCtx)
+
         # We need to always copy builtin and custom global skills before calling the super method to make them available
         # in the filesystem not just to be captured and registered in "skills_metadata" on first run, but also to be
         # available in the filesystem so that the agent can use them using the `skill` tool, otherwise a not_found error
         # will be raised.
-        builtin_skills, custom_global_skills = await self._copy_global_skills(
-            agent_path=Path(runtime.context.gitrepo.working_dir)
-        )
+        builtin_skills, custom_global_skills = await self._copy_global_skills(is_local=is_local)
 
         skills_update = await super().abefore_agent(state, runtime, config)
 
@@ -161,8 +161,9 @@ class SkillsMiddleware(DeepAgentsSkillsMiddleware):
         # the state.
         skills_metadata = skills_update["skills_metadata"] if skills_update else state["skills_metadata"]
 
+        # Builtin slash commands only apply in platform mode (they need scope, repository, issue, etc.)
         builtin_slash_commands = None
-        if runtime.context.config.slash_commands.enabled:
+        if isinstance(runtime.context, RuntimeCtx) and runtime.context.config.slash_commands.enabled:
             builtin_slash_commands = await self._apply_builtin_slash_commands(
                 state["messages"], runtime.context, skills_metadata
             )
@@ -177,7 +178,7 @@ class SkillsMiddleware(DeepAgentsSkillsMiddleware):
 
         return skills_update
 
-    async def _copy_global_skills(self, agent_path: Path) -> tuple[list[str], list[str]]:
+    async def _copy_global_skills(self, *, is_local: bool = False) -> tuple[list[str], list[str]]:
         """
         Copy builtin and custom global skills to the project skills directory if they don't exist.
 
@@ -189,13 +190,19 @@ class SkillsMiddleware(DeepAgentsSkillsMiddleware):
         with the same name in the project skills directory and committing them to the repository.
 
         Args:
-            agent_path: The path to the agent's repository.
+            is_local: Whether running in local/ACP mode (no repo subdirectory prefix).
 
         Returns:
             A tuple of (builtin skill names, custom global skill names).
         """
         files_to_upload: list[tuple[str, bytes]] = []
-        project_skills_path = Path(f"/{agent_path.name}/{AGENTS_SKILLS_PATH}")
+        # In platform mode, sources have a repo prefix (e.g., /repo/.cursor/skills).
+        # Extract the common prefix from the first source to build the skills destination path.
+        if not is_local and self.sources:
+            prefix = str(Path(self.sources[0]).parent.parent)
+            project_skills_path = Path(f"{prefix}/{AGENTS_SKILLS_PATH}")
+        else:
+            project_skills_path = Path(f"/{AGENTS_SKILLS_PATH}")
 
         builtin_skills = self._collect_skill_files(BUILTIN_SKILLS_PATH, project_skills_path, files_to_upload)
 
@@ -269,7 +276,7 @@ class SkillsMiddleware(DeepAgentsSkillsMiddleware):
 
     @override
     async def awrap_model_call(
-        self, request: ModelRequest[RuntimeCtx], handler: Callable[[ModelRequest[RuntimeCtx]], Awaitable[ModelResponse]]
+        self, request: ModelRequest[AgentCtx], handler: Callable[[ModelRequest[AgentCtx]], Awaitable[ModelResponse]]
     ) -> ModelResponse:
         """Filter write tools when the active skill declares read-only mode."""
         active_mode = request.state.get("active_skill_mode")
@@ -391,7 +398,7 @@ class SkillsMiddleware(DeepAgentsSkillsMiddleware):
 
         async def skill_tool(
             skill: Annotated[str, "The skill name. E.g. 'code-review' or 'web-research'"],
-            runtime: ToolRuntime[RuntimeCtx, SkillsState],
+            runtime: ToolRuntime[AgentCtx, SkillsState],
             skill_args: Annotated[str | None, "Optional arguments to pass to the skill."] = None,
         ) -> str | Command:
             """

--- a/daiv/automation/agent/middlewares/web_fetch.py
+++ b/daiv/automation/agent/middlewares/web_fetch.py
@@ -6,8 +6,6 @@ import logging
 from typing import TYPE_CHECKING, Annotated
 from urllib.parse import urljoin, urlparse, urlunparse
 
-from django.core.cache import cache
-
 import markdownify
 from langchain.agents.middleware import AgentMiddleware, ModelRequest, ModelResponse
 from langchain_core.messages import HumanMessage, SystemMessage
@@ -166,12 +164,22 @@ def _cache_key_for_response(*, url: str, prompt: str) -> str:
     return f"web_fetch:response:{digest}"
 
 
+try:
+    from django.core.cache import cache as _cache
+except Exception:
+    _cache = None
+
+
 def _get_cached_response(*, url: str, prompt: str) -> str | None:
-    return cache.get(_cache_key_for_response(url=url, prompt=prompt))
+    if _cache is None:
+        return None
+    return _cache.get(_cache_key_for_response(url=url, prompt=prompt))
 
 
 def _set_cached_response(*, url: str, prompt: str, response: str) -> None:
-    cache.set(_cache_key_for_response(url=url, prompt=prompt), response, timeout=settings.WEB_FETCH_CACHE_TTL_SECONDS)
+    if _cache is None:
+        return
+    _cache.set(_cache_key_for_response(url=url, prompt=prompt), response, timeout=settings.WEB_FETCH_CACHE_TTL_SECONDS)
 
 
 async def _fetch_markdown_for_url(url: str) -> str:

--- a/daiv/automation/agent/middlewares/web_search.py
+++ b/daiv/automation/agent/middlewares/web_search.py
@@ -2,9 +2,8 @@ from __future__ import annotations
 
 import logging
 import textwrap
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Annotated
-
-from django.utils import timezone
 
 from langchain.agents.middleware import AgentMiddleware, ModelRequest, ModelResponse
 from langchain_community.utilities.duckduckgo_search import DuckDuckGoSearchAPIWrapper
@@ -159,7 +158,7 @@ class WebSearchMiddleware(AgentMiddleware):
         """
         Update the system prompt with the web search system prompt.
         """
-        current_year = timezone.now().year
+        current_year = datetime.now(UTC).year
         web_search_prompt = WEB_SEARCH_SYSTEM_PROMPT.format(current_year=current_year, previous_year=current_year - 1)
         request = request.override(system_prompt=request.system_prompt + "\n\n" + web_search_prompt)
         return await handler(request)

--- a/daiv/automation/agent/prompts.py
+++ b/daiv/automation/agent/prompts.py
@@ -48,7 +48,9 @@ Prioritize technical accuracy and truthfulness over validating the user's belief
   - Trust subagent results for research and analysis: if a subagent returns file contents or search results, use that information directly without re-reading the same files. Only re-read if the subagent's output was truncated, you need a different section not covered, or you are about to edit the file and need the current content.
 - For broader codebase exploration and deep research, use the `task` tool with subagent_type=explore. This is slower than calling `glob` or `grep` directly so use this only when a simple, directed search proves to be insufficient or when your task will clearly require more than 3 queries.
 - You can call multiple tools in a single response. If you intend to call multiple tools and there are no dependencies between them, make all independent tool calls in parallel. Maximize use of parallel tool calls where possible to increase efficiency. However, if some tool calls depend on previous calls to inform dependent values, do NOT call these tools in parallel and instead call them sequentially. For instance, if one operation must complete before another starts, run these operations sequentially instead.
+{{^local_mode}}
 - Never paste filesystem tool outputs verbatim into user-visible messages; always rewrite paths to repo-relative form.
+{{/local_mode}}
 {{#bash_tool_enabled}}
 - Do NOT use the Bash to run commands when a relevant dedicated tool is provided. Using dedicated tools allows the user to better understand and review your work. This is CRITICAL to assisting the user. Use dedicated tools such as `read_file` for reading files instead of cat/head/tail, `edit_file` for editing instead of sed/awk, and `write_file` for creating files instead of cat with heredoc or echo redirection, `glob` searching files, and `grep` searching file contents. Reserve bash tools exclusively for actual system commands and terminal operations that require shell execution.
 {{/bash_tool_enabled}}
@@ -78,6 +80,7 @@ Focus text output on:
 
 If you can say it in one sentence, don't use three. Prefer short, direct sentences over long explanations. This does not apply to code or tool calls.
 
+{{^local_mode}}
 ## Code References
 
 When referencing code, include a link so the user can navigate to the source.
@@ -106,6 +109,7 @@ The error is caught and wrapped in a `ClientError` at [src/services/process.ts:7
 then logged by the `ErrorReporter` class at [src/utils/error_reporter.ts:38]({{ repository_url }}/blob/{{ current_branch }}/src/utils/error_reporter.ts#L38).
 </example>
 {{/github_platform}}
+{{/local_mode}}
 
 ## Environment
 
@@ -123,7 +127,9 @@ You have been invoked in the following environment:
 
 **Memory and Knowledge Cutoff**: Your knowledge of general programming is up to a certain cutoff. If the user's request references a technology or library beyond what you know, you might need to use external search tools or ask the user for documentation. Be transparent if you are operating on incomplete knowledge. Do not hallucinate facts about new or unknown technologies, this is very important.
 
-**No Hard-Coding Paths**: Never hardcode sandbox/mount roots like `/repo/` in code or user-visible output. Use absolute `/repo/...` paths only inside tool calls when required, but always output repo-relative paths to the user (e.g. `daiv/core/utils.py`). Ignore file paths shown in tracebacks/issues; you should always locate files in the current repo via `glob` or `grep` before reading/editing.""",  # noqa: E501
+{{^local_mode}}
+**No Hard-Coding Paths**: Never hardcode sandbox/mount roots like `/repo/` in code or user-visible output. Use absolute `/repo/...` paths only inside tool calls when required, but always output repo-relative paths to the user (e.g. `daiv/core/utils.py`). Ignore file paths shown in tracebacks/issues; you should always locate files in the current repo via `glob` or `grep` before reading/editing.
+{{/local_mode}}""",  # noqa: E501
     "mustache",
 )
 

--- a/daiv/automation/agent/subagents.py
+++ b/daiv/automation/agent/subagents.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
     from deepagents.backends import BackendProtocol
     from langchain.chat_models import BaseChatModel
 
-    from codebase.context import RuntimeCtx
+    from codebase.context import AgentCtx
 
 logger = logging.getLogger("daiv.agent")
 
@@ -40,7 +40,7 @@ GENERAL_PURPOSE_SYSTEM_PROMPT = """You are an agent for DAIV. Given the user's m
 def _build_general_purpose_middleware(
     model: BaseChatModel,
     backend: BackendProtocol,
-    runtime: RuntimeCtx,
+    runtime: AgentCtx,
     sandbox_enabled: bool,
     web_search_enabled: bool,
     web_fetch_enabled: bool,
@@ -49,13 +49,20 @@ def _build_general_purpose_middleware(
     Build the middleware stack for a general-purpose subagent.
     """
     from automation.agent.graph import dynamic_write_todos_system_prompt
+    from codebase.context import RuntimeCtx
 
     _summarization_defaults = compute_summarization_defaults(model)
 
     middleware = [
         TodoListMiddleware(system_prompt=dynamic_write_todos_system_prompt(bash_tool_enabled=sandbox_enabled)),
         FilesystemMiddleware(backend=backend),
-        GitPlatformMiddleware(git_platform=runtime.git_platform),
+    ]
+
+    # Git platform middleware only applies in platform mode
+    if isinstance(runtime, RuntimeCtx):
+        middleware.append(GitPlatformMiddleware(git_platform=runtime.git_platform))
+
+    middleware.extend([
         SummarizationMiddleware(
             model=model,
             backend=backend,
@@ -67,7 +74,7 @@ def _build_general_purpose_middleware(
         AnthropicPromptCachingMiddleware(),
         ToolCallLoggingMiddleware(),
         PatchToolCallsMiddleware(),
-    ]
+    ])
 
     if web_search_enabled:
         middleware.append(WebSearchMiddleware())
@@ -84,7 +91,7 @@ def _build_general_purpose_middleware(
 def create_general_purpose_subagent(
     model: BaseChatModel,
     backend: BackendProtocol,
-    runtime: RuntimeCtx,
+    runtime: AgentCtx,
     sandbox_enabled: bool = True,
     web_search_enabled: bool = True,
     web_fetch_enabled: bool = True,
@@ -231,7 +238,7 @@ def _parse_subagent_frontmatter(content: str, file_path: str) -> tuple[dict, str
 async def load_custom_subagents(
     model: BaseChatModel,
     backend: BackendProtocol,
-    runtime: RuntimeCtx,
+    runtime: AgentCtx,
     sources: list[str],
     sandbox_enabled: bool = True,
     web_search_enabled: bool = True,

--- a/daiv/automation/management/commands/run_acp_server.py
+++ b/daiv/automation/management/commands/run_acp_server.py
@@ -1,0 +1,18 @@
+import asyncio
+
+from django.core.management.base import BaseCommand
+
+
+class Command(BaseCommand):
+    help = "Start the DAIV ACP server over stdio"
+
+    def handle(self, *args, **options):
+        asyncio.run(self._run())
+
+    async def _run(self):
+        from acp import run_agent as run_acp_agent
+
+        from automation.agent.acp import create_acp_server
+
+        server = create_acp_server()
+        await run_acp_agent(server)

--- a/daiv/codebase/context.py
+++ b/daiv/codebase/context.py
@@ -1,16 +1,23 @@
+from __future__ import annotations
+
+import logging
 from contextlib import asynccontextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
-from git import Repo  # noqa: TC002
+import yaml
+from git import InvalidGitRepositoryError, Repo  # noqa: TC002
 
 from codebase.base import GitPlatform, Issue, MergeRequest, Repository, Scope  # noqa: TC001
 from codebase.clients import RepoClient
-from codebase.repo_config import RepositoryConfig
+from codebase.repo_config import CONFIGURATION_FILE_NAME, RepositoryConfig
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
+
+logger = logging.getLogger("daiv.core")
 
 
 @dataclass(frozen=True)
@@ -48,6 +55,80 @@ class RuntimeCtx:
 
     bot_username: str | None = None
     """The bot username defined on the repository client"""
+
+
+@dataclass(frozen=True)
+class LocalRuntimeCtx:
+    """
+    Context for local/ACP mode without a remote git platform.
+
+    Used when the agent operates on an arbitrary filesystem path (e.g., via ACP)
+    rather than a cloned repository managed by a git platform API.
+    """
+
+    working_dir: Path
+    """The working directory path (the ACP session's cwd)."""
+
+    config: RepositoryConfig
+    """Repository config loaded from .daiv.yml or defaults."""
+
+    gitrepo: Repo | None = None
+    """Optional git.Repo if cwd is inside a git repository."""
+
+    bot_username: str = "daiv"
+    """Bot username for the system prompt."""
+
+
+AgentCtx = RuntimeCtx | LocalRuntimeCtx
+"""Union type for either platform or local runtime contexts."""
+
+
+def get_working_dir(ctx: AgentCtx) -> Path:
+    """Return the agent's working directory for either context type."""
+    if isinstance(ctx, LocalRuntimeCtx):
+        return ctx.working_dir
+    return Path(ctx.gitrepo.working_dir)
+
+
+def create_local_runtime_ctx(cwd: Path) -> LocalRuntimeCtx:
+    """
+    Create a LocalRuntimeCtx from a filesystem path.
+
+    Loads RepositoryConfig from .daiv.yml if present, auto-detects git if available.
+
+    Args:
+        cwd: The working directory path.
+
+    Returns:
+        A LocalRuntimeCtx instance.
+    """
+    config = _load_local_config(cwd)
+    gitrepo = _detect_git_repo(cwd)
+    return LocalRuntimeCtx(working_dir=cwd, config=config, gitrepo=gitrepo)
+
+
+def _load_local_config(cwd: Path) -> RepositoryConfig:
+    """Load RepositoryConfig from .daiv.yml in the given directory, or return defaults."""
+    config_path = cwd / CONFIGURATION_FILE_NAME
+    try:
+        with Path(config_path).open() as f:
+            return RepositoryConfig.model_validate(yaml.safe_load(f) or {})
+    except FileNotFoundError:
+        pass
+    except Exception:
+        logger.warning("Failed to parse %s, using defaults", config_path, exc_info=True)
+    return RepositoryConfig()
+
+
+def _detect_git_repo(cwd: Path) -> Repo | None:
+    """Detect a git repository at or above the given directory."""
+    try:
+        return Repo(cwd, search_parent_directories=True)
+    except InvalidGitRepositoryError:
+        return None
+    except Exception:
+        logger.debug("Git detection failed for %s", cwd, exc_info=True)
+        return None
 
 
 runtime_ctx: ContextVar[RuntimeCtx | None] = ContextVar[RuntimeCtx | None]("runtime_ctx", default=None)

--- a/daiv/codebase/repo_config.py
+++ b/daiv/codebase/repo_config.py
@@ -4,8 +4,6 @@ import logging
 from io import StringIO
 from typing import TYPE_CHECKING
 
-from django.core.cache import cache
-
 import yaml
 from pydantic import AliasChoices, BaseModel, Field, ValidationError
 from yaml.parser import ParserError
@@ -262,6 +260,8 @@ class RepositoryConfig(BaseModel):
         Returns:
             RepositoryConfig: The configuration for the repository.
         """
+        from django.core.cache import cache
+
         from codebase.clients import RepoClient
 
         cache_key = f"{CONFIGURATION_CACHE_KEY_PREFIX}{repo_id}"
@@ -298,5 +298,7 @@ class RepositoryConfig(BaseModel):
         """
         Invalidate cache for a specific repository.
         """
+        from django.core.cache import cache
+
         cache.delete(f"{CONFIGURATION_CACHE_KEY_PREFIX}{repo_id}")
         logger.info("Invalidated cache for repository %s", repo_id)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -137,7 +137,7 @@ services:
         condition: service_healthy
 
   sandbox:
-    image: ghcr.io/srtab/daiv-sandbox:latest
+    image: ghcr.io/srtab/daiv-sandbox:main
     profiles:
       - sandbox
       - full

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
 dependencies = [
   "ddgs==9.11.4",
   "deepagents==0.4.12",
+  "deepagents-acp>=0.0.4",
   "django==6.0.3",
   "django-crontask==1.1.3",
   "django-extensions==4.1.0",

--- a/tests/unit_tests/automation/agent/middlewares/test_skills.py
+++ b/tests/unit_tests/automation/agent/middlewares/test_skills.py
@@ -128,7 +128,7 @@ class TestSkillsMiddleware:
         middleware = SkillsMiddleware(backend=backend, sources=[f"/{repo_name}/{AGENTS_SKILLS_PATH}"])
 
         with patch("automation.agent.middlewares.skills.BUILTIN_SKILLS_PATH", builtin):
-            await middleware._copy_global_skills(agent_path=tmp_path / repo_name)
+            await middleware._copy_global_skills(is_local=False)
 
         project_skills = tmp_path / repo_name / AGENTS_SKILLS_PATH
         assert (project_skills / "skill-one" / "SKILL.md").read_text() == _make_skill_md(
@@ -172,7 +172,7 @@ class TestSkillsMiddleware:
             patch("automation.agent.middlewares.skills.BUILTIN_SKILLS_PATH", builtin),
             patch("pathlib.Path.exists", new=fake_exists),
         ):
-            await middleware._copy_global_skills(agent_path=tmp_path / repo_name)
+            await middleware._copy_global_skills(is_local=False)
 
         # SKILL.md should not be overwritten, but other files should still be uploaded.
         assert project_skill_md.read_text() == _make_skill_md(name="skill-one", description="existing")
@@ -194,7 +194,7 @@ class TestSkillsMiddleware:
             patch("automation.agent.middlewares.skills.BUILTIN_SKILLS_PATH", builtin),
             pytest.raises(RuntimeError, match="Failed to upload skill: boom"),
         ):
-            await middleware._copy_global_skills(agent_path=tmp_path / "repoX")
+            await middleware._copy_global_skills(is_local=False)
 
     def test_format_skills_list_marks_builtin_and_global(self):
         middleware = SkillsMiddleware(backend=Mock(), sources=["/skills"])
@@ -569,7 +569,7 @@ class TestCustomGlobalSkills:
             patch("automation.agent.middlewares.skills.BUILTIN_SKILLS_PATH", builtin),
             patch("automation.agent.middlewares.skills.agent_settings.CUSTOM_SKILLS_PATH", custom_global),
         ):
-            builtin_names, custom_global_names = await middleware._copy_global_skills(agent_path=tmp_path / repo_name)
+            builtin_names, custom_global_names = await middleware._copy_global_skills(is_local=False)
 
         assert "global-skill" in custom_global_names
         assert "global-skill" not in builtin_names
@@ -631,7 +631,7 @@ class TestCustomGlobalSkills:
             patch("automation.agent.middlewares.skills.BUILTIN_SKILLS_PATH", builtin),
             patch("automation.agent.middlewares.skills.agent_settings.CUSTOM_SKILLS_PATH", None),
         ):
-            builtin_names, custom_global_names = await middleware._copy_global_skills(agent_path=tmp_path / repo_name)
+            builtin_names, custom_global_names = await middleware._copy_global_skills(is_local=False)
 
         assert builtin_names == ["skill-one"]
         assert custom_global_names == []
@@ -651,7 +651,7 @@ class TestCustomGlobalSkills:
             patch("automation.agent.middlewares.skills.BUILTIN_SKILLS_PATH", builtin),
             patch("automation.agent.middlewares.skills.agent_settings.CUSTOM_SKILLS_PATH", tmp_path / "nonexistent"),
         ):
-            builtin_names, custom_global_names = await middleware._copy_global_skills(agent_path=tmp_path / repo_name)
+            builtin_names, custom_global_names = await middleware._copy_global_skills(is_local=False)
 
         assert builtin_names == ["skill-one"]
         assert custom_global_names == []

--- a/tests/unit_tests/automation/agent/middlewares/test_web_search.py
+++ b/tests/unit_tests/automation/agent/middlewares/test_web_search.py
@@ -128,9 +128,9 @@ class TestWebSearchTool:
 
 
 class TestWebSearchMiddleware:
-    @patch("automation.agent.middlewares.web_search.timezone")
-    async def test_system_prompt_contains_current_year(self, mock_timezone):
-        mock_timezone.now.return_value = datetime(2026, 3, 14)
+    @patch("automation.agent.middlewares.web_search.datetime")
+    async def test_system_prompt_contains_current_year(self, mock_datetime):
+        mock_datetime.now.return_value = datetime(2026, 3, 14)
 
         middleware = WebSearchMiddleware()
         request = MagicMock()
@@ -146,9 +146,9 @@ class TestWebSearchMiddleware:
         assert "2025" in system_prompt  # previous year in the "NOT" example
         assert "2024" not in system_prompt
 
-    @patch("automation.agent.middlewares.web_search.timezone")
-    async def test_system_prompt_does_not_contain_hardcoded_year(self, mock_timezone):
-        mock_timezone.now.return_value = datetime(2030, 1, 1)
+    @patch("automation.agent.middlewares.web_search.datetime")
+    async def test_system_prompt_does_not_contain_hardcoded_year(self, mock_datetime):
+        mock_datetime.now.return_value = datetime(2030, 1, 1)
 
         middleware = WebSearchMiddleware()
         request = MagicMock()
@@ -166,9 +166,9 @@ class TestWebSearchMiddleware:
         assert "2025" not in system_prompt
         assert "2026" not in system_prompt
 
-    @patch("automation.agent.middlewares.web_search.timezone")
-    async def test_system_prompt_appended_to_base_prompt(self, mock_timezone):
-        mock_timezone.now.return_value = datetime(2026, 6, 15)
+    @patch("automation.agent.middlewares.web_search.datetime")
+    async def test_system_prompt_appended_to_base_prompt(self, mock_datetime):
+        mock_datetime.now.return_value = datetime(2026, 6, 15)
 
         middleware = WebSearchMiddleware()
         request = MagicMock()
@@ -183,9 +183,9 @@ class TestWebSearchMiddleware:
         assert system_prompt.startswith("Base prompt\n\n")
         assert "## Web Search tool" in system_prompt
 
-    @patch("automation.agent.middlewares.web_search.timezone")
-    async def test_handler_called_with_overridden_request(self, mock_timezone):
-        mock_timezone.now.return_value = datetime(2026, 3, 14)
+    @patch("automation.agent.middlewares.web_search.datetime")
+    async def test_handler_called_with_overridden_request(self, mock_datetime):
+        mock_datetime.now.return_value = datetime(2026, 3, 14)
 
         middleware = WebSearchMiddleware()
         request = MagicMock()

--- a/tests/unit_tests/automation/agent/test_subagents.py
+++ b/tests/unit_tests/automation/agent/test_subagents.py
@@ -11,6 +11,7 @@ from automation.agent.middlewares.sandbox import SandboxMiddleware
 from automation.agent.middlewares.web_fetch import WebFetchMiddleware
 from automation.agent.middlewares.web_search import WebSearchMiddleware
 from automation.agent.subagents import create_explore_subagent, create_general_purpose_subagent, load_custom_subagents
+from codebase.context import RuntimeCtx
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -31,8 +32,10 @@ class TestGeneralPurposeSubagent:
 
     @pytest.fixture
     def mock_runtime_ctx(self):
-        """Create a mock runtime context."""
-        return Mock()
+        """Create a mock runtime context that passes isinstance(ctx, RuntimeCtx) checks."""
+        mock = Mock()
+        mock.__class__ = RuntimeCtx
+        return mock
 
     def test_returns_subagent(self, mock_model, mock_backend, mock_runtime_ctx):
         """Test that create_general_purpose_subagent returns a SubAgent."""
@@ -95,7 +98,9 @@ class TestCustomSubagents:
 
     @pytest.fixture
     def mock_runtime_ctx(self):
-        return Mock()
+        mock = Mock()
+        mock.__class__ = RuntimeCtx
+        return mock
 
     async def test_loads_custom_subagent(self, tmp_path: Path, mock_model, mock_runtime_ctx):
         from deepagents.backends.filesystem import FilesystemBackend

--- a/tests/unit_tests/codebase/test_config.py
+++ b/tests/unit_tests/codebase/test_config.py
@@ -9,7 +9,7 @@ from codebase.repo_config import (
 
 
 class RepositoryConfigTest:
-    @patch("codebase.repo_config.cache")
+    @patch("django.core.cache.cache")
     def test_get_config_from_cache(self, mock_cache):
         repo_id = "test_repo"
         cached_config = {
@@ -28,7 +28,7 @@ class RepositoryConfigTest:
         assert config.slash_commands.enabled is True
         mock_cache.get.assert_called_once_with(f"{CONFIGURATION_CACHE_KEY_PREFIX}{repo_id}")
 
-    @patch("codebase.repo_config.cache")
+    @patch("django.core.cache.cache")
     def test_get_config_from_repo(self, mock_cache, mock_repo_client):
         repo_id = "test_repo"
         mock_cache.get.return_value = None
@@ -53,7 +53,7 @@ class RepositoryConfigTest:
             f"{CONFIGURATION_CACHE_KEY_PREFIX}{repo_id}", config.model_dump(), CONFIGURATION_CACHE_TIMEOUT
         )
 
-    @patch("codebase.repo_config.cache")
+    @patch("django.core.cache.cache")
     def test_get_config_with_default_values(self, mock_cache, mock_repo_client):
         repo_id = "test_repo"
         mock_cache.get.return_value = None
@@ -70,13 +70,13 @@ class RepositoryConfigTest:
             f"{CONFIGURATION_CACHE_KEY_PREFIX}{repo_id}", config.model_dump(), CONFIGURATION_CACHE_TIMEOUT
         )
 
-    @patch("codebase.repo_config.cache")
+    @patch("django.core.cache.cache")
     def test_invalidate_cache(self, mock_cache):
         repo_id = "test_repo"
         RepositoryConfig.invalidate_cache(repo_id)
         mock_cache.delete.assert_called_once_with(f"{CONFIGURATION_CACHE_KEY_PREFIX}{repo_id}")
 
-    @patch("codebase.repo_config.cache")
+    @patch("django.core.cache.cache")
     def test_get_config_with_invalid_yaml(self, mock_cache, mock_repo_client):
         repo_id = "test_repo"
         mock_cache.get.return_value = None
@@ -93,7 +93,7 @@ class RepositoryConfigTest:
             f"{CONFIGURATION_CACHE_KEY_PREFIX}{repo_id}", config.model_dump(), CONFIGURATION_CACHE_TIMEOUT
         )
 
-    @patch("codebase.repo_config.cache")
+    @patch("django.core.cache.cache")
     def test_get_config_with_partial_yaml(self, mock_cache, mock_repo_client):
         repo_id = "test_repo"
         mock_cache.get.return_value = None
@@ -112,7 +112,7 @@ class RepositoryConfigTest:
             f"{CONFIGURATION_CACHE_KEY_PREFIX}{repo_id}", config.model_dump(), CONFIGURATION_CACHE_TIMEOUT
         )
 
-    @patch("codebase.repo_config.cache")
+    @patch("django.core.cache.cache")
     def test_get_config_with_models_section(self, mock_cache, mock_repo_client):
         """Test that models configuration is parsed correctly from YAML."""
         repo_id = "test_repo"
@@ -133,7 +133,7 @@ class RepositoryConfigTest:
         assert config.models.agent.thinking_level == "low"
         assert config.models.diff_to_metadata.model == "openrouter:openai/gpt-4.1-mini"
 
-    @patch("codebase.repo_config.cache")
+    @patch("django.core.cache.cache")
     def test_get_config_with_partial_models_section(self, mock_cache, mock_repo_client):
         """Test that partial models configuration works correctly."""
         repo_id = "test_repo"
@@ -150,7 +150,7 @@ class RepositoryConfigTest:
         assert config.models.agent.model == "openrouter:anthropic/claude-haiku-4.5"
         assert config.models.agent.thinking_level is not None
 
-    @patch("codebase.repo_config.cache")
+    @patch("django.core.cache.cache")
     def test_sandbox_command_policy_defaults(self, mock_cache, mock_repo_client):
         """Test that sandbox.command_policy defaults to empty allow/disallow lists."""
         repo_id = "test_repo"
@@ -163,7 +163,7 @@ class RepositoryConfigTest:
         assert config.sandbox.command_policy.disallow == ()
         assert config.sandbox.command_policy.allow == ()
 
-    @patch("codebase.repo_config.cache")
+    @patch("django.core.cache.cache")
     def test_sandbox_command_policy_parses_from_yaml(self, mock_cache, mock_repo_client):
         """Test that sandbox.command_policy is parsed from YAML correctly."""
         repo_id = "test_repo"
@@ -185,7 +185,7 @@ class RepositoryConfigTest:
         assert "curl" in config.sandbox.command_policy.disallow
         assert "my-safe-cmd" in config.sandbox.command_policy.allow
 
-    @patch("codebase.repo_config.cache")
+    @patch("django.core.cache.cache")
     def test_sandbox_command_policy_partial_yaml_uses_defaults(self, mock_cache, mock_repo_client):
         """Test that a partial command_policy section merges with defaults."""
         repo_id = "test_repo"

--- a/uv.lock
+++ b/uv.lock
@@ -8,6 +8,18 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "agent-client-protocol"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/13/3b893421369767e7043cc115d6ef0df417c298b84563be3a12df0416158d/agent_client_protocol-0.9.0.tar.gz", hash = "sha256:f744c48ab9af0f0b4452e5ab5498d61bcab97c26dbe7d6feec5fd36de49be30b", size = 71853, upload-time = "2026-03-26T01:21:00.379Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/ed/c284543c08aa443a4ef2c8bd120be51da8433dd174c01749b5d87c333f22/agent_client_protocol-0.9.0-py3-none-any.whl", hash = "sha256:06911500b51d8cb69112544e2be01fc5e7db39ef88fecbc3848c5c6f194798ee", size = 56850, upload-time = "2026-03-26T01:20:59.252Z" },
+]
+
+[[package]]
 name = "aiohappyeyeballs"
 version = "2.6.1"
 source = { registry = "https://pypi.org/simple" }
@@ -415,6 +427,7 @@ source = { virtual = "." }
 dependencies = [
     { name = "ddgs" },
     { name = "deepagents" },
+    { name = "deepagents-acp" },
     { name = "django" },
     { name = "django-crontask" },
     { name = "django-extensions" },
@@ -481,6 +494,7 @@ docs = [
 requires-dist = [
     { name = "ddgs", specifier = "==9.11.4" },
     { name = "deepagents", specifier = "==0.4.12" },
+    { name = "deepagents-acp", specifier = ">=0.0.4" },
     { name = "django", specifier = "==6.0.3" },
     { name = "django-crontask", specifier = "==1.1.3" },
     { name = "django-extensions", specifier = "==4.1.0" },
@@ -618,6 +632,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5a/ef/0b2ccd5e4f40c1554145de17a7f3ee41994de1dda3ea36abe28600f1a3cf/deepagents-0.4.12.tar.gz", hash = "sha256:fc24a691e5cba00920ac4fa1d94f8147d6081fe513ed22bdba7da469288681c3", size = 91870, upload-time = "2026-03-20T14:54:29.904Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5e/77/63a5cb4e3a8871c4a52d600661a232c26b35f52931ee551c3adc38eeacf6/deepagents-0.4.12-py3-none-any.whl", hash = "sha256:76a272bac25607c5ef8c5adc876e391da945f1107b504686964dfdb6afdc1ebb", size = 104455, upload-time = "2026-03-20T14:54:28.786Z" },
+]
+
+[[package]]
+name = "deepagents-acp"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "agent-client-protocol" },
+    { name = "deepagents" },
+    { name = "python-dotenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6a/1e/a545ca48441973f91d2b14a8c55160f5070ed1ec6092e080ec8d2f303f7c/deepagents_acp-0.0.4.tar.gz", hash = "sha256:db7250af6a257be19960fd88ddbfa4667500741efac16f5da8ab3e33f8ceda63", size = 13084672, upload-time = "2026-02-13T03:45:34.092Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/c8/08ad801c9528474ccf9be6084ebf4f23c75e0661c7b10806e5d3ae4e64f8/deepagents_acp-0.0.4-py3-none-any.whl", hash = "sha256:3d2bb80a9dd6c229724699f48b8d73385bd8f9691d82b7aef095c977de1db1a6", size = 13423, upload-time = "2026-02-13T03:45:32.188Z" },
 ]
 
 [[package]]
@@ -2039,7 +2067,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [


### PR DESCRIPTION
Introduce LocalRuntimeCtx for running the agent on a local filesystem path without a remote git platform. Broaden type annotations from RuntimeCtx to AgentCtx (union) across graph, middlewares, and subagents. Conditionally skip git/platform-specific middlewares and prompt sections in local mode. Decouple web_fetch cache and repo_config from top-level Django imports to support non-Django contexts. Simplify AGENTS.md.