### PR TITLE
feat(email): Add SMTP email relay configuration

### DIFF
--- a/daiv/daiv/settings/components/common.py
+++ b/daiv/daiv/settings/components/common.py
@@ -123,5 +123,10 @@ WHITENOISE_ROOT = Path(__file__).resolve().parents[2] / "public"
 
 # EMAIL
 
-EMAIL_BACKEND = config("EMAIL_BACKEND", default="django.core.mail.backends.console.EmailBackend")
+EMAIL_BACKEND = config("EMAIL_BACKEND", default="django.core.mail.backends.smtp.EmailBackend")
+EMAIL_HOST = config("EMAIL_HOST", default="localhost")
+EMAIL_PORT = config("EMAIL_PORT", default=25, cast=int)
+EMAIL_HOST_USER = config("EMAIL_HOST_USER", default="")
+EMAIL_HOST_PASSWORD = get_docker_secret("EMAIL_HOST_PASSWORD", default="")
+EMAIL_USE_TLS = config("EMAIL_USE_TLS", default=False, cast=bool)
 DEFAULT_FROM_EMAIL = config("DEFAULT_FROM_EMAIL", default="noreply@daiv.dev")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,6 +56,14 @@ services:
     ports:
       - "6379:6379"
 
+  mailpit:
+    image: axllent/mailpit:latest
+    container_name: daiv-mailpit
+    restart: unless-stopped
+    ports:
+      - "8025:8025"
+      - "1025:1025"
+
   app:
     <<: *x_app_default
     container_name: daiv-app

--- a/docker/local/app/config.env
+++ b/docker/local/app/config.env
@@ -15,6 +15,10 @@ DB_PASSWORD=dbpass
 DB_PORT=5432
 DB_SSLMODE=prefer
 
+# Email
+EMAIL_HOST=mailpit
+EMAIL_PORT=1025
+
 # Codebase client — set to "gitlab" for local GitLab or "github" for GitHub
 CODEBASE_CLIENT=gitlab
 CODEBASE_GITLAB_URL=http://gitlab:8929

--- a/docs/getting-started/deployment.md
+++ b/docs/getting-started/deployment.md
@@ -42,6 +42,7 @@ This guide walks you through deploying DAIV using Docker Swarm or Docker Compose
 * **`codebase_gitlab_auth_token`** - GitLab personal access token with `api` scope (see [Platform Setup](platform-setup.md#gitlab-configuration))
 * **`codebase_gitlab_webhook_secret`** - Random secret for GitLab webhook validation
 * **`daiv_sandbox_api_key`** - Random API key for Sandbox service authentication
+* **`email_host_password`** - SMTP authentication password (if your relay requires authentication)
 * **`openrouter_api_key`** - [OpenRouter API key](https://openrouter.ai/settings/keys) for LLM access
 * **`allauth_github_client_id`** - GitHub OAuth App client ID (see [Authentication](../reference/env-variables.md#authentication))
 * **`allauth_github_secret`** - GitHub OAuth App secret
@@ -83,6 +84,10 @@ x-app-environment-defaults: &app_environment_defaults
   # CODEBASE
   CODEBASE_CLIENT: gitlab
   CODEBASE_GITLAB_URL: https://gitlab.com (3)
+  # EMAIL
+  EMAIL_HOST: smtp.example.com
+  EMAIL_PORT: 587
+  EMAIL_USE_TLS: true
   # SANDBOX
   DAIV_SANDBOX_URL: http://sandbox:8000 (4)
 
@@ -151,6 +156,7 @@ services:
       - codebase_gitlab_webhook_secret
       - daiv_sandbox_api_key
       - openrouter_api_key
+      - email_host_password
       - allauth_github_client_id
       - allauth_github_secret
       - allauth_gitlab_client_id
@@ -175,6 +181,7 @@ services:
       - codebase_gitlab_webhook_secret
       - daiv_sandbox_api_key
       - openrouter_api_key
+      - email_host_password
     networks:
       - internal
     # volumes:  (16)
@@ -288,6 +295,8 @@ secrets:
     external: true
   openrouter_api_key:
     external: true
+  email_host_password:
+    external: true
   sentry_access_token:
     external: true
   allauth_github_client_id:
@@ -384,6 +393,10 @@ x-app-defaults: &x_app_default
     CODEBASE_GITLAB_WEBHOOK_SECRET: gitlab-webhook-secret (6)
     # LLM Providers settings
     OPENROUTER_API_KEY: openrouter-api-key (8)
+    # Email settings
+    EMAIL_HOST: smtp.example.com
+    EMAIL_PORT: 587
+    EMAIL_USE_TLS: true
     # Sandbox settings
     DAIV_SANDBOX_API_KEY: daiv-sandbox-api-key (9)
     # Authentication (at least one social provider recommended)

--- a/docs/reference/env-variables.md
+++ b/docs/reference/env-variables.md
@@ -122,7 +122,12 @@ DAIV uses [django-allauth](https://docs.allauth.org/) for web authentication. Us
 | `ALLAUTH_GITLAB_SECRET` :material-lock: | GitLab OAuth Application secret | *(none)* | |
 | `ALLAUTH_GITLAB_URL` | GitLab instance URL (for OAuth redirects to the user's browser) | `https://gitlab.com` | `https://gitlab.example.com` |
 | `ALLAUTH_GITLAB_SERVER_URL` | GitLab server URL (for server-to-server API calls, if different from `ALLAUTH_GITLAB_URL`) | *(none)* | `http://gitlab:8929` |
-| `EMAIL_BACKEND` | Django email backend for login-by-code emails | `django.core.mail.backends.console.EmailBackend` | `django.core.mail.backends.smtp.EmailBackend` |
+| `EMAIL_BACKEND` | Django email backend for login-by-code emails | `django.core.mail.backends.smtp.EmailBackend` | `django.core.mail.backends.console.EmailBackend` |
+| `EMAIL_HOST` | SMTP server hostname | `localhost` | `smtp.example.com` |
+| `EMAIL_PORT` | SMTP server port | `25` | `587` |
+| `EMAIL_HOST_USER` | SMTP authentication username | *(empty)* | `user@example.com` |
+| `EMAIL_HOST_PASSWORD` :material-lock: | SMTP authentication password | *(empty)* | |
+| `EMAIL_USE_TLS` | Use TLS for SMTP connection | `False` | `True` |
 | `DEFAULT_FROM_EMAIL` | Sender address for login-by-code emails | `noreply@daiv.dev` | `noreply@example.com` |
 
 !!! info "Setting up social providers"


### PR DESCRIPTION
Add configurable SMTP settings (host, port, TLS, credentials) with Mailpit for local development. Default email backend changed from console to SMTP. Update deployment docs and env variable reference.