### PR TITLE
fix(tracing): Standardize LangSmith metadata and tags across all agen…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Standardized LangSmith metadata and tags across all agent invocation paths. The Jobs API and Chat API were missing critical metadata fields (`scope`, `repository`, `git_platform`) and had no tags, making their traces invisible in several LangSmith dashboard charts.
 - Fixed `__version__` in `daiv/daiv/__init__.py` to match `pyproject.toml` version (`2.0.0`).
 - Fixed `web_fetch` tool to limit same-host redirects (max 5) and re-validate SSRF protection on each redirect, preventing infinite redirect loops and DNS rebinding attacks.
 - Fixed `PullRequestMetadata.branch` validation to reject invalid branch names (e.g., names with spaces or uppercase characters) that previously passed the incomplete regex.

--- a/daiv/automation/agent/publishers.py
+++ b/daiv/automation/agent/publishers.py
@@ -8,6 +8,7 @@ from urllib.parse import quote, urlencode
 
 from django.template.loader import render_to_string
 
+from automation.agent.utils import build_langsmith_config
 from codebase.base import GitPlatform, MergeRequest, Scope
 from codebase.clients import RepoClient
 from codebase.utils import GitManager, redact_diff_content
@@ -151,13 +152,10 @@ class GitChangePublisher(ChangePublisher):
             )
 
         changes_metadata_graph = create_diff_to_metadata_graph(ctx=self.ctx, include_pr_metadata=bool(pr_metadata_diff))
-        result = await changes_metadata_graph.ainvoke(
-            input_data,
-            config={
-                "tags": [self.ctx.git_platform.value],
-                "metadata": {"scope": self.ctx.scope, "repo_id": self.ctx.repository.slug},
-            },
+        config = build_langsmith_config(
+            self.ctx, trigger="diff_to_metadata", model=self.ctx.config.models.diff_to_metadata.model
         )
+        result = await changes_metadata_graph.ainvoke(input_data, config=config)
         if result and ("pr_metadata" in result or "commit_message" in result):
             return result
 

--- a/daiv/automation/agent/utils.py
+++ b/daiv/automation/agent/utils.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
 
 from langchain_core.messages.content import create_image_block
+from langchain_core.runnables import RunnableConfig
 
 from codebase.base import GitPlatform
 from codebase.clients import RepoClient
@@ -18,6 +19,7 @@ from .schemas import Image
 if TYPE_CHECKING:
     from langchain_core.messages import ImageContentBlock
 
+    from codebase.context import RuntimeCtx
     from codebase.repo_config import AgentModelConfig
 
 
@@ -230,6 +232,64 @@ def get_daiv_agent_kwargs(*, model_config: AgentModelConfig, use_max: bool = Fal
         thinking_level = site_settings.agent_max_thinking_level
 
     return {"model_names": [model] + fallback_models, "thinking_level": thinking_level}
+
+
+def build_langsmith_config(
+    ctx: RuntimeCtx,
+    *,
+    trigger: str,
+    model: str,
+    thinking_level: str | None = None,
+    agent_name: str | None = None,
+    extra_metadata: dict[str, Any] | None = None,
+    extra_tags: list[str] | None = None,
+    configurable: dict[str, Any] | None = None,
+) -> RunnableConfig:
+    """
+    Build a standardized RunnableConfig with LangSmith metadata and tags.
+
+    Ensures all agent invocations carry the dashboard-critical metadata fields
+    (scope, repository, git_platform, trigger, model) regardless of the callsite.
+
+    Args:
+        ctx: The runtime context.
+        trigger: What triggered this invocation (e.g. "job", "chat", "label", "mention", "diff_to_metadata").
+        model: The primary model name used for this invocation.
+        thinking_level: The thinking level, if applicable.
+        agent_name: The agent name to include in tags (e.g. "DAIV Agent").
+        extra_metadata: Additional metadata fields specific to the callsite.
+        extra_tags: Additional tags specific to the callsite.
+        configurable: Configurable dict (e.g. thread_id for checkpointed agents).
+
+    Returns:
+        A RunnableConfig with standardized metadata and tags.
+    """
+    metadata: dict[str, Any] = {
+        "repository": ctx.repository.slug,
+        "git_platform": ctx.git_platform.value,
+        "trigger": trigger,
+        "model": model,
+    }
+    if ctx.scope is not None:
+        metadata["scope"] = ctx.scope
+    if thinking_level is not None:
+        metadata["thinking_level"] = thinking_level
+    if extra_metadata:
+        metadata.update(extra_metadata)
+
+    tags: list[str] = [ctx.git_platform.value, ctx.repository.slug]
+    if ctx.scope:
+        tags.append(ctx.scope)
+    if agent_name:
+        tags.append(agent_name)
+    if extra_tags:
+        tags.extend(extra_tags)
+
+    config_kwargs: dict[str, Any] = {"metadata": metadata, "tags": tags}
+    if configurable is not None:
+        config_kwargs["configurable"] = configurable
+
+    return RunnableConfig(**config_kwargs)
 
 
 def extract_body_from_frontmatter(frontmatter_text: str) -> str:

--- a/daiv/chat/api/utils.py
+++ b/daiv/chat/api/utils.py
@@ -7,14 +7,15 @@ from datetime import datetime
 from typing import TYPE_CHECKING
 
 from automation.agent.graph import create_daiv_agent
+from automation.agent.utils import build_langsmith_config
 from chat.api.schemas import ChatCompletionChunk
 from codebase.base import Scope
 from codebase.context import set_runtime_ctx
+from core.site_settings import site_settings
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator
 
-    from langchain_core.runnables import RunnableConfig
     from langchain_core.runnables.schema import StreamEvent
 
 
@@ -39,9 +40,7 @@ def extract_text_from_event_data(event_data: StreamEvent) -> str:
     return ""
 
 
-async def generate_stream(
-    input_data: dict, model_id: str, *, repo_id: str, ref: str, config: RunnableConfig
-) -> AsyncGenerator[str]:
+async def generate_stream(input_data: dict, model_id: str, *, repo_id: str, ref: str) -> AsyncGenerator[str]:
     """
     Generate a stream of chat completion events.
 
@@ -50,7 +49,6 @@ async def generate_stream(
         model_id: The model ID.
         repo_id: The repository ID.
         ref: The reference.
-        config: The config.
 
     Returns:
         The stream of chat completion events.
@@ -60,6 +58,13 @@ async def generate_stream(
 
     async with set_runtime_ctx(repo_id=repo_id, scope=Scope.GLOBAL, ref=ref) as runtime_ctx:
         try:
+            config = build_langsmith_config(
+                runtime_ctx,
+                trigger="chat",
+                model=site_settings.agent_model_name,
+                thinking_level=site_settings.agent_thinking_level,
+                extra_metadata={"model_id": model_id, "chat_stream": True},
+            )
             daiv_agent = await create_daiv_agent(ctx=runtime_ctx)
 
             async for message_chunk, _metadata in daiv_agent.astream(input_data, config=config, context=runtime_ctx):

--- a/daiv/chat/api/views.py
+++ b/daiv/chat/api/views.py
@@ -4,11 +4,10 @@ from datetime import datetime
 
 from django.http import Http404, HttpRequest, StreamingHttpResponse
 
-from langchain_core.runnables import RunnableConfig
 from ninja import Router
 
 from automation.agent.graph import create_daiv_agent
-from automation.agent.utils import extract_text_content
+from automation.agent.utils import build_langsmith_config, extract_text_content
 from codebase.base import Scope
 from codebase.context import set_runtime_ctx
 from core.constants import BOT_NAME
@@ -48,24 +47,20 @@ async def create_chat_completion(request: HttpRequest, payload: ChatCompletionRe
     repo_id, ref = request.headers.get(HEADER_REPO_ID), request.headers.get(HEADER_REF)
 
     input_data = {"messages": [msg.dict() for msg in payload.messages]}
-    config = RunnableConfig(
-        metadata={
-            "model_id": MODEL_ID,
-            "chat_stream": payload.stream,
-            "repo_id": repo_id,
-            "ref": ref,
-            "model": site_settings.agent_model_name,
-            "thinking_level": site_settings.agent_thinking_level,
-        }
-    )
 
     if payload.stream:
         return StreamingHttpResponse(
-            generate_stream(input_data, MODEL_ID, repo_id=repo_id, ref=ref, config=config),
-            content_type="text/event-stream",
+            generate_stream(input_data, MODEL_ID, repo_id=repo_id, ref=ref), content_type="text/event-stream"
         )
     try:
         async with set_runtime_ctx(repo_id=repo_id, scope=Scope.GLOBAL, ref=ref) as runtime_ctx:
+            config = build_langsmith_config(
+                runtime_ctx,
+                trigger="chat",
+                model=site_settings.agent_model_name,
+                thinking_level=site_settings.agent_thinking_level,
+                extra_metadata={"model_id": MODEL_ID, "chat_stream": payload.stream},
+            )
             daiv_agent = await create_daiv_agent(ctx=runtime_ctx)
             result = await daiv_agent.ainvoke(input_data, config=config, context=runtime_ctx)
 

--- a/daiv/codebase/managers/issue_addressor.py
+++ b/daiv/codebase/managers/issue_addressor.py
@@ -5,11 +5,10 @@ from django.conf import settings as django_settings
 from django.template.loader import render_to_string
 
 from langchain_core.messages import HumanMessage
-from langchain_core.runnables import RunnableConfig
 from langgraph.checkpoint.redis.aio import AsyncRedisSaver
 
 from automation.agent.graph import create_daiv_agent
-from automation.agent.utils import extract_text_content, get_daiv_agent_kwargs
+from automation.agent.utils import build_langsmith_config, extract_text_content, get_daiv_agent_kwargs
 from codebase.base import GitPlatform
 from core.constants import BOT_NAME
 from core.utils import generate_uuid
@@ -99,20 +98,18 @@ class IssueAddressorManager(BaseManager):
             daiv_agent = await create_daiv_agent(
                 ctx=self.ctx, checkpointer=checkpointer, store=self.store, **agent_kwargs
             )
-            agent_config = RunnableConfig(
+            agent_config = build_langsmith_config(
+                self.ctx,
+                trigger="mention" if self.mention_comment_id else "label",
+                model=agent_kwargs["model_names"][0],
+                thinking_level=agent_kwargs["thinking_level"],
+                agent_name=daiv_agent.get_name(),
                 configurable={"thread_id": self.thread_id},
-                tags=[daiv_agent.get_name(), self.client.git_platform.value, self.ctx.repository.slug, self.ctx.scope],
-                metadata={
+                extra_metadata={
                     "author": self.issue.author.username,
                     "triggered_by": triggered_by,
-                    "trigger": "mention" if self.mention_comment_id else "label",
-                    "repository": self.ctx.repository.slug,
-                    "git_platform": self.client.git_platform.value,
                     "issue_id": self.issue.iid,
                     "labels": [label.lower() for label in self.issue.labels],
-                    "scope": self.ctx.scope,
-                    "model": agent_kwargs["model_names"][0],
-                    "thinking_level": agent_kwargs["thinking_level"],
                 },
             )
             try:

--- a/daiv/codebase/managers/review_addressor.py
+++ b/daiv/codebase/managers/review_addressor.py
@@ -7,13 +7,12 @@ from django.conf import settings as django_settings
 from django.template.loader import render_to_string
 
 from langchain_core.messages import HumanMessage
-from langchain_core.runnables import RunnableConfig
 from langgraph.checkpoint.redis.aio import AsyncRedisSaver
 from unidiff import LINE_TYPE_CONTEXT, Hunk, PatchedFile
 from unidiff.patch import Line
 
 from automation.agent.graph import create_daiv_agent
-from automation.agent.utils import extract_text_content, get_daiv_agent_kwargs
+from automation.agent.utils import build_langsmith_config, extract_text_content, get_daiv_agent_kwargs
 from codebase.base import GitPlatform, MergeRequest, Note, NoteDiffPosition, NoteDiffPositionType, NotePositionType
 from core.constants import BOT_NAME
 from core.utils import generate_uuid
@@ -236,19 +235,17 @@ class CommentsAddressorManager(BaseManager):
             daiv_agent = await create_daiv_agent(
                 ctx=self.ctx, checkpointer=checkpointer, store=self.store, **agent_kwargs
             )
-            agent_config = RunnableConfig(
+            agent_config = build_langsmith_config(
+                self.ctx,
+                trigger="mention",
+                model=agent_kwargs["model_names"][0],
+                thinking_level=agent_kwargs["thinking_level"],
+                agent_name=daiv_agent.get_name(),
                 configurable={"thread_id": self.thread_id},
-                tags=[daiv_agent.get_name(), self.client.git_platform.value, self.ctx.repository.slug, self.ctx.scope],
-                metadata={
+                extra_metadata={
                     "author": self.merge_request.author.username,
                     "triggered_by": mention_comment.notes[0].author.username,
-                    "trigger": "mention",
-                    "repository": self.ctx.repository.slug,
-                    "git_platform": self.client.git_platform.value,
                     "merge_request_id": self.merge_request.merge_request_id,
-                    "scope": self.ctx.scope,
-                    "model": agent_kwargs["model_names"][0],
-                    "thinking_level": agent_kwargs["thinking_level"],
                 },
             )
 

--- a/daiv/jobs/tasks.py
+++ b/daiv/jobs/tasks.py
@@ -2,10 +2,9 @@ import logging
 
 from django_tasks import task
 from langchain_core.messages import HumanMessage
-from langchain_core.runnables import RunnableConfig
 
 from automation.agent.graph import create_daiv_agent
-from automation.agent.utils import extract_text_content, get_daiv_agent_kwargs
+from automation.agent.utils import build_langsmith_config, extract_text_content, get_daiv_agent_kwargs
 from codebase.base import Scope
 from codebase.context import set_runtime_ctx
 
@@ -30,14 +29,12 @@ async def run_job_task(repo_id: str, prompt: str, ref: str | None = None, use_ma
     try:
         async with set_runtime_ctx(repo_id=repo_id, scope=Scope.GLOBAL, ref=ref) as runtime_ctx:
             agent_kwargs = get_daiv_agent_kwargs(model_config=runtime_ctx.config.models.agent, use_max=use_max)
-            config = RunnableConfig(
-                metadata={
-                    "repo_id": repo_id,
-                    "ref": ref,
-                    "trigger": "job",
-                    "model": agent_kwargs["model_names"][0],
-                    "thinking_level": agent_kwargs["thinking_level"],
-                }
+            config = build_langsmith_config(
+                runtime_ctx,
+                trigger="job",
+                model=agent_kwargs["model_names"][0],
+                thinking_level=agent_kwargs["thinking_level"],
+                extra_metadata={"ref": ref},
             )
             daiv_agent = await create_daiv_agent(ctx=runtime_ctx, **agent_kwargs)
             result = await daiv_agent.ainvoke(input_data, config=config, context=runtime_ctx)


### PR DESCRIPTION
…t invocations

Add build_langsmith_config() utility that ensures every agent callsite includes the dashboard-critical metadata fields (scope, repository, git_platform, trigger, model) and consistent tags. The Jobs API and Chat API were missing these fields, making their traces invisible in several LangSmith dashboard charts.