### PR TITLE
fix(dashboard): Rework velocity attribution and add code changes metric

### DIFF
--- a/daiv/accounts/templates/accounts/dashboard.html
+++ b/daiv/accounts/templates/accounts/dashboard.html
@@ -40,7 +40,7 @@
 
             <div class="rounded-2xl border border-white/[0.06] bg-white/[0.015] p-6">
                 {# Hero numbers #}
-                <div class="grid grid-cols-2 gap-6 sm:grid-cols-4">
+                <div class="grid grid-cols-2 gap-6 sm:grid-cols-5">
                     <div>
                         <p class="animate-number text-[42px] font-extrabold tabular-nums leading-none tracking-tight text-white" style="animation-delay: 150ms">{{ activity.total }}</p>
                         <p class="mt-2 text-[13px] text-gray-400">jobs processed</p>
@@ -57,7 +57,11 @@
                         <p class="mt-2 text-[13px] text-gray-400">running now</p>
                     </div>
                     <div>
-                        <p class="animate-number text-[42px] font-extrabold tabular-nums leading-none tracking-tight text-white" style="animation-delay: 300ms">{{ activity.avg_duration }}</p>
+                        <p class="animate-number text-[42px] font-extrabold tabular-nums leading-none tracking-tight text-white" style="animation-delay: 300ms">{{ activity.code_changes }}</p>
+                        <p class="mt-2 text-[13px] text-gray-400">with code changes <span class="text-gray-500">({{ activity.code_changes_pct }})</span></p>
+                    </div>
+                    <div>
+                        <p class="animate-number text-[42px] font-extrabold tabular-nums leading-none tracking-tight text-white" style="animation-delay: 350ms">{{ activity.avg_duration }}</p>
                         <p class="mt-2 text-[13px] text-gray-400">avg duration</p>
                     </div>
                 </div>
@@ -142,15 +146,15 @@
                     <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
                         <div class="rounded-xl border border-white/[0.05] bg-white/[0.02] px-5 py-4">
                             <div class="flex items-baseline justify-between">
-                                <span class="text-[13px] text-gray-400">Lines authored by DAIV</span>
-                                <span class="text-[20px] font-bold tabular-nums text-violet-300">{{ velocity.daiv_lines_pct }}</span>
+                                <span class="text-[13px] text-gray-400">MRs involving DAIV</span>
+                                <span class="text-[20px] font-bold tabular-nums text-violet-300">{{ velocity.daiv_merges_pct }}</span>
                             </div>
                             <div class="mt-3 flex h-2 w-full overflow-hidden rounded-full bg-white/[0.04]">
-                                <div class="animate-bar h-full rounded-full bg-gradient-to-r from-violet-600/60 to-violet-400/40" style="width: {{ velocity.daiv_lines_pct_raw }}%; animation-delay: 700ms"></div>
+                                <div class="animate-bar h-full rounded-full bg-gradient-to-r from-violet-600/60 to-violet-400/40" style="width: {{ velocity.daiv_merges_pct_raw }}%; animation-delay: 700ms"></div>
                             </div>
                             <div class="mt-2 flex justify-between text-[11px] text-gray-500">
-                                <span>DAIV: {{ velocity.daiv_lines }} lines</span>
-                                <span>Human: {{ velocity.human_lines }} lines</span>
+                                <span>DAIV: {{ velocity.daiv_merges }} MRs</span>
+                                <span>Human: {{ velocity.human_merges }} MRs</span>
                             </div>
                         </div>
                         <div class="rounded-xl border border-white/[0.05] bg-white/[0.02] px-5 py-4">

--- a/daiv/accounts/views.py
+++ b/daiv/accounts/views.py
@@ -114,6 +114,7 @@ class DashboardView(LoginRequiredMixin, TemplateView):
             mrs=Count("id", filter=mr_trigger & ~failed),
             mcp_jobs=Count("id", filter=mcp_trigger & ~failed),
             scheduled=Count("id", filter=schedule_trigger & ~failed),
+            code_changes=Count("id", filter=successful & Q(code_changes=True)),
             avg_duration=Avg(duration_expr, filter=successful),
         )
 
@@ -152,12 +153,16 @@ class DashboardView(LoginRequiredMixin, TemplateView):
                 "url": url,
             })
 
+        code_changes_count = stats["code_changes"]
+
         return {
             "total": total,
             "running": running_count,
             "success_rate": _format_pct(successful_count, successful_count + failed_count),
             "success_rate_raw": _raw_pct(successful_count, successful_count + failed_count),
             "failed": failed_count,
+            "code_changes": code_changes_count,
+            "code_changes_pct": _format_pct(code_changes_count, successful_count),
             "avg_duration": _format_duration(stats["avg_duration"]),
             "activity_url": activity_url,
             "segments": segments,
@@ -172,10 +177,7 @@ class DashboardView(LoginRequiredMixin, TemplateView):
             total=Count("id"),
             total_added=Sum("lines_added", default=0),
             total_removed=Sum("lines_removed", default=0),
-            daiv_added=Sum("daiv_lines_added", default=0),
-            daiv_removed=Sum("daiv_lines_removed", default=0),
-            human_added=Sum("human_lines_added", default=0),
-            human_removed=Sum("human_lines_removed", default=0),
+            daiv_merges=Count("id", filter=Q(daiv_commits__gt=0)),
             total_commits_sum=Sum("total_commits", default=0),
             daiv_commits_sum=Sum("daiv_commits", default=0),
         )
@@ -183,23 +185,23 @@ class DashboardView(LoginRequiredMixin, TemplateView):
         if not stats["total"]:
             return None
 
-        daiv_lines = stats["daiv_added"] + stats["daiv_removed"]
-        human_lines = stats["human_added"] + stats["human_removed"]
-        attribution_total = daiv_lines + human_lines
+        total_merges = stats["total"]
+        daiv_merges = stats["daiv_merges"]
+        human_merges = total_merges - daiv_merges
         total_commits = stats["total_commits_sum"]
         daiv_commits = stats["daiv_commits_sum"]
         human_commits = max(0, total_commits - daiv_commits)
         max_lines = max(stats["total_added"], stats["total_removed"], 1)
 
         return {
-            "total_merges": stats["total"],
+            "total_merges": total_merges,
             "lines_added": stats["total_added"],
             "lines_removed": stats["total_removed"],
             "net_lines": stats["total_added"] - stats["total_removed"],
-            "daiv_lines_pct": _format_pct(daiv_lines, attribution_total),
-            "daiv_lines_pct_raw": min(_raw_pct(daiv_lines, attribution_total) or 0, 100),
-            "daiv_lines": daiv_lines,
-            "human_lines": human_lines,
+            "daiv_merges_pct": _format_pct(daiv_merges, total_merges),
+            "daiv_merges_pct_raw": min(_raw_pct(daiv_merges, total_merges) or 0, 100),
+            "daiv_merges": daiv_merges,
+            "human_merges": human_merges,
             "daiv_commits_pct": _format_pct(daiv_commits, total_commits),
             "daiv_commits_pct_raw": min(_raw_pct(daiv_commits, total_commits) or 0, 100),
             "daiv_commits": daiv_commits,


### PR DESCRIPTION
Replace misleading "lines authored by DAIV" (which mixed MR-level and commit-level stats) with "MRs involving DAIV" — a count of merge requests where DAIV had at least one commit. Add "with code changes" counter to agent activity showing how many successful jobs produced code.