### PR TITLE
feat(activity): Add markdown download for activity results

### DIFF
--- a/daiv/activity/models.py
+++ b/daiv/activity/models.py
@@ -100,6 +100,15 @@ class Activity(models.Model):
             return (self.finished_at - self.started_at).total_seconds()
         return None
 
+    @property
+    def response_text(self) -> str:
+        """Return the response text from the task result, or the truncated denormalized summary if unavailable."""
+        if self.task_result and self.task_result.return_value:
+            parsed = parse_agent_result(self.task_result.return_value)
+            if parsed["response"]:
+                return parsed["response"]
+        return self.result_summary
+
     def sync_from_task_result(self) -> list[str]:
         """Pull latest status/timing/result from the linked DBTaskResult.
 

--- a/daiv/activity/templates/activity/activity_detail.html
+++ b/daiv/activity/templates/activity/activity_detail.html
@@ -128,14 +128,19 @@
         <div class="animate-fade-up mt-6" style="animation-delay: 200ms">
             {% if activity.status == "SUCCESSFUL" %}
             <div class="rounded-2xl border border-white/[0.06] bg-white/[0.02] p-6">
-                <h2 class="text-[15px] font-semibold text-gray-300">Result</h2>
-                {% if activity.task_result and activity.task_result.return_value.response %}
-                <div class="prose-dark mt-3 rounded-xl bg-black/30 p-4">
-                    {{ activity.task_result.return_value.response|render_markdown }}
+                <div class="flex items-center justify-between">
+                    <h2 class="text-[15px] font-semibold text-gray-300">Result</h2>
+                    {% if activity.response_text %}
+                    <a href="{% url 'activity_download_md' activity.pk %}"
+                       class="btn-secondary gap-2 rounded-lg px-3 py-1.5 text-sm">
+                        {% icon "arrow-down-tray" "h-4 w-4" %}
+                        Markdown
+                    </a>
+                    {% endif %}
                 </div>
-                {% elif activity.result_summary %}
+                {% if activity.response_text %}
                 <div class="prose-dark mt-3 rounded-xl bg-black/30 p-4">
-                    {{ activity.result_summary|render_markdown }}
+                    {{ activity.response_text|render_markdown }}
                 </div>
                 {% else %}
                 <p class="mt-3 text-sm text-gray-400">No result data available.</p>

--- a/daiv/activity/urls.py
+++ b/daiv/activity/urls.py
@@ -1,9 +1,10 @@
 from django.urls import path
 
-from activity.views import ActivityDetailView, ActivityListView, ActivityStreamView
+from activity.views import ActivityDetailView, ActivityDownloadMarkdownView, ActivityListView, ActivityStreamView
 
 urlpatterns = [
     path("", ActivityListView.as_view(), name="activity_list"),
     path("stream/", ActivityStreamView.as_view(), name="activity_stream"),
     path("<uuid:pk>/", ActivityDetailView.as_view(), name="activity_detail"),
+    path("<uuid:pk>/download/md/", ActivityDownloadMarkdownView.as_view(), name="activity_download_md"),
 ]

--- a/daiv/activity/views.py
+++ b/daiv/activity/views.py
@@ -9,7 +9,8 @@ from datetime import date
 from typing import TYPE_CHECKING
 
 from django.contrib.auth.mixins import LoginRequiredMixin
-from django.http import HttpResponse, HttpResponseBase, StreamingHttpResponse
+from django.http import Http404, HttpResponse, HttpResponseBase, StreamingHttpResponse
+from django.utils.text import slugify
 from django.views import View
 from django.views.generic import DetailView, ListView
 
@@ -96,6 +97,49 @@ class ActivityDetailView(LoginRequiredMixin, DetailView):
         activity: Activity = context["activity"]
         context["is_in_flight"] = activity.status not in ActivityStatus.terminal()
         return context
+
+
+class ActivityDownloadMarkdownView(LoginRequiredMixin, DetailView):
+    """Serve the activity result as a downloadable Markdown file."""
+
+    model = Activity
+
+    def get_queryset(self) -> QuerySet[Activity]:
+        return super().get_queryset().filter(status=ActivityStatus.SUCCESSFUL).select_related("task_result")
+
+    def get(self, request, *args, **kwargs):
+        activity = self.get_object()
+        content = self._build_markdown(activity)
+        if not content:
+            raise Http404
+        filename = self._build_filename(activity)
+        response = HttpResponse(content, content_type="text/markdown; charset=utf-8")
+        response["Content-Disposition"] = f'attachment; filename="{filename}"'
+        return response
+
+    def _build_markdown(self, activity: Activity) -> str:
+        response_text = activity.response_text
+        if not response_text:
+            return ""
+
+        meta_lines = ["---", f"repository: {activity.repo_id}", f"trigger: {activity.get_trigger_type_display()}"]
+        if activity.ref:
+            meta_lines.append(f"ref: {activity.ref}")
+        meta_lines.append(f"created: {activity.created_at.strftime('%Y-%m-%d %H:%M:%S %Z')}")
+        if activity.finished_at:
+            meta_lines.append(f"finished: {activity.finished_at.strftime('%Y-%m-%d %H:%M:%S %Z')}")
+        if activity.issue_iid:
+            meta_lines.append(f"issue: '#{activity.issue_iid}'")
+        if activity.merge_request_iid:
+            meta_lines.append(f"merge_request: '!{activity.merge_request_iid}'")
+        meta_lines.append("---")
+
+        return "\n".join(meta_lines) + "\n\n" + response_text
+
+    def _build_filename(self, activity: Activity) -> str:
+        repo_slug = slugify(activity.repo_id.replace("/", "-")) or "unknown"
+        date_str = activity.created_at.strftime("%Y-%m-%d")
+        return f"daiv-{repo_slug}-{date_str}.md"
 
 
 POLL_INTERVAL = 2.0

--- a/daiv/core/static/core/img/icons/arrow-down-tray.svg
+++ b/daiv/core/static/core/img/icons/arrow-down-tray.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5M16.5 12 12 16.5m0 0L7.5 12m4.5 4.5V3" />
+</svg>

--- a/tests/unit_tests/activity/test_views.py
+++ b/tests/unit_tests/activity/test_views.py
@@ -1,0 +1,143 @@
+import uuid
+
+from django.test import Client
+from django.urls import reverse
+
+import pytest
+from activity.models import Activity, ActivityStatus, TriggerType
+from django_tasks_db.models import DBTaskResult
+
+from accounts.models import User
+
+
+@pytest.fixture
+def user(db):
+    return User.objects.create_user(username="alice", email="alice@test.com", password="testpass123")  # noqa: S106
+
+
+@pytest.fixture
+def logged_in_client(user):
+    client = Client()
+    client.force_login(user)
+    return client
+
+
+def _create_task_result(*, status="SUCCESSFUL", return_value=None):
+    return DBTaskResult.objects.create(
+        id=uuid.uuid4(),
+        status=status,
+        task_path="jobs.tasks.run_job_task",
+        args_kwargs={"args": [], "kwargs": {}},
+        queue_name="default",
+        backend_name="default",
+        run_after="9999-01-01T00:00:00Z",
+        return_value=return_value or {},
+        exception_class_path="",
+        traceback="",
+    )
+
+
+def _create_activity(*, status=ActivityStatus.SUCCESSFUL, task_result=None, **kwargs):
+    defaults = {
+        "trigger_type": TriggerType.SCHEDULE,
+        "repo_id": "group/project",
+        "ref": "main",
+        "prompt": "Run a security audit",
+        "status": status,
+        "task_result": task_result,
+    }
+    defaults.update(kwargs)
+    return Activity.objects.create(**defaults)
+
+
+@pytest.mark.django_db
+class TestActivityDownloadMarkdownView:
+    def test_download_with_task_result(self, logged_in_client):
+        tr = _create_task_result(return_value={"response": "# Security Report\n\nAll good.", "code_changes": False})
+        activity = _create_activity(task_result=tr)
+
+        response = logged_in_client.get(reverse("activity_download_md", kwargs={"pk": activity.pk}))
+
+        assert response.status_code == 200
+        assert response["Content-Type"] == "text/markdown; charset=utf-8"
+        assert "attachment" in response["Content-Disposition"]
+        assert ".md" in response["Content-Disposition"]
+
+        body = response.content.decode()
+        assert "---" in body
+        assert "repository: group/project" in body
+        assert "# Security Report" in body
+        assert "All good." in body
+
+    def test_download_with_result_summary_fallback(self, logged_in_client):
+        activity = _create_activity(result_summary="Summary of the result")
+
+        response = logged_in_client.get(reverse("activity_download_md", kwargs={"pk": activity.pk}))
+
+        assert response.status_code == 200
+        body = response.content.decode()
+        assert "Summary of the result" in body
+
+    def test_download_includes_metadata(self, logged_in_client):
+        activity = _create_activity(
+            result_summary="Result content", ref="feature-branch", issue_iid=42, merge_request_iid=10
+        )
+
+        response = logged_in_client.get(reverse("activity_download_md", kwargs={"pk": activity.pk}))
+
+        body = response.content.decode()
+        assert "ref: feature-branch" in body
+        assert "issue: '#42'" in body
+        assert "merge_request: '!10'" in body
+        assert "trigger: Scheduled Job" in body
+
+    def test_download_filename_format(self, logged_in_client):
+        activity = _create_activity(result_summary="Content")
+
+        response = logged_in_client.get(reverse("activity_download_md", kwargs={"pk": activity.pk}))
+
+        disposition = response["Content-Disposition"]
+        assert disposition.startswith('attachment; filename="daiv-group-project-')
+        assert disposition.endswith('.md"')
+
+    def test_task_result_response_takes_priority_over_result_summary(self, logged_in_client):
+        tr = _create_task_result(return_value={"response": "Full response text", "code_changes": False})
+        activity = _create_activity(task_result=tr, result_summary="Truncated summary")
+
+        response = logged_in_client.get(reverse("activity_download_md", kwargs={"pk": activity.pk}))
+
+        body = response.content.decode()
+        assert "Full response text" in body
+        assert "Truncated summary" not in body
+
+    def test_legacy_return_value_without_response_falls_back_to_summary(self, logged_in_client):
+        tr = _create_task_result(return_value={"code_changes": True})
+        activity = _create_activity(task_result=tr, result_summary="Fallback summary")
+
+        response = logged_in_client.get(reverse("activity_download_md", kwargs={"pk": activity.pk}))
+
+        body = response.content.decode()
+        assert "Fallback summary" in body
+
+    def test_non_successful_activity_returns_404(self, logged_in_client):
+        activity = _create_activity(status=ActivityStatus.FAILED, result_summary="error")
+
+        response = logged_in_client.get(reverse("activity_download_md", kwargs={"pk": activity.pk}))
+
+        assert response.status_code == 404
+
+    def test_successful_activity_without_result_returns_404(self, logged_in_client):
+        activity = _create_activity(result_summary="")
+
+        response = logged_in_client.get(reverse("activity_download_md", kwargs={"pk": activity.pk}))
+
+        assert response.status_code == 404
+
+    def test_unauthenticated_redirects_to_login(self):
+        activity = _create_activity(result_summary="Content")
+        client = Client()
+
+        response = client.get(reverse("activity_download_md", kwargs={"pk": activity.pk}))
+
+        assert response.status_code == 302
+        assert "/accounts/login/" in response.url


### PR DESCRIPTION
Allow users to download successful activity results as a .md file with YAML front matter metadata (repository, trigger, dates, refs).

Adds a response_text property to the Activity model centralizing the fallback logic previously duplicated in the template.