### PR TITLE
refactor(filters): Replace hand-rolled search with django-filter

### DIFF
--- a/daiv/accounts/filters.py
+++ b/daiv/accounts/filters.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from django.db.models import Q
+
+import django_filters
+
+from accounts.models import Role, User
+
+
+class UserFilter(django_filters.FilterSet):
+    q = django_filters.CharFilter(method="filter_search")
+    role = django_filters.ChoiceFilter(choices=Role.choices)
+
+    class Meta:
+        model = User
+        # All filters are declared above; disable auto-generation from model fields.
+        fields: list[str] = []
+
+    def filter_search(self, queryset, name, value):
+        value = (value or "").strip()
+        if not value:
+            return queryset
+        return queryset.filter(Q(name__icontains=value) | Q(email__icontains=value))

--- a/daiv/accounts/views.py
+++ b/daiv/accounts/views.py
@@ -13,11 +13,13 @@ from django.views import View
 from django.views.generic import CreateView, DeleteView, ListView, TemplateView, UpdateView
 
 from activity.models import Activity, ActivityStatus, TriggerType
+from django_filters.views import FilterView
 
 from accounts.emails import send_welcome_email
+from accounts.filters import UserFilter
 from accounts.forms import APIKeyCreateForm, UserCreateForm, UserUpdateForm
 from accounts.mixins import AdminRequiredMixin
-from accounts.models import APIKey, Role, User
+from accounts.models import APIKey, User
 from codebase.models import MergeMetric
 from schedules.models import ScheduledJob
 
@@ -278,27 +280,22 @@ class APIKeyRevokeView(LoginRequiredMixin, View):
 # ---------------------------------------------------------------------------
 
 
-class UserListView(AdminRequiredMixin, ListView):
+class UserListView(AdminRequiredMixin, FilterView):
     model = User
+    filterset_class = UserFilter
     template_name = "accounts/users.html"
     context_object_name = "users"
     ordering = ["-date_joined"]
     paginate_by = 25
-
-    def get_queryset(self):
-        qs = super().get_queryset()
-        q = self.request.GET.get("q", "").strip()
-        if q:
-            qs = qs.filter(Q(name__icontains=q) | Q(email__icontains=q))
-        role = self.request.GET.get("role", "").strip()
-        if role in {Role.ADMIN, Role.MEMBER}:
-            qs = qs.filter(role=role)
-        return qs
+    # Invalid URL params (e.g. ?role=bogus) drop silently instead of blanking the list.
+    strict = False
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context["search_query"] = self.request.GET.get("q", "")
-        context["current_role"] = self.request.GET.get("role", "")
+        form = context["filter"].form
+        cleaned = form.cleaned_data if form.is_valid() else {}
+        context["search_query"] = cleaned.get("q") or ""
+        context["current_role"] = cleaned.get("role") or ""
         return context
 
 

--- a/daiv/activity/filters.py
+++ b/daiv/activity/filters.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import django_filters
+
+from activity.models import Activity, ActivityStatus, TriggerType
+
+
+class ActivityFilter(django_filters.FilterSet):
+    status = django_filters.ChoiceFilter(choices=ActivityStatus.choices)
+    trigger = django_filters.ChoiceFilter(field_name="trigger_type", choices=TriggerType.choices)
+    repo = django_filters.CharFilter(field_name="repo_id")
+    schedule = django_filters.NumberFilter(field_name="scheduled_job_id")
+    date_from = django_filters.DateFilter(field_name="created_at", lookup_expr="date__gte")
+    date_to = django_filters.DateFilter(field_name="created_at", lookup_expr="date__lte")
+
+    class Meta:
+        model = Activity
+        # All filters are declared above; disable auto-generation from model fields.
+        fields: list[str] = []

--- a/daiv/activity/templates/activity/activity_list.html
+++ b/daiv/activity/templates/activity/activity_list.html
@@ -89,11 +89,11 @@
                     {% if current_trigger %}<input type="hidden" name="trigger" value="{{ current_trigger }}">{% endif %}
                     {% if current_repo %}<input type="hidden" name="repo" value="{{ current_repo }}">{% endif %}
                     {% if current_schedule %}<input type="hidden" name="schedule" value="{{ current_schedule }}">{% endif %}
-                    <input type="date" name="from" value="{{ current_from }}"
+                    <input type="date" name="date_from" value="{{ current_from }}"
                            class="rounded-lg border border-white/[0.06] bg-[#0d1117] px-3 py-1.5 text-sm text-gray-300"
                            placeholder="From" onchange="this.form.submit()">
                     <span class="text-sm text-gray-400">to</span>
-                    <input type="date" name="to" value="{{ current_to }}"
+                    <input type="date" name="date_to" value="{{ current_to }}"
                            class="rounded-lg border border-white/[0.06] bg-[#0d1117] px-3 py-1.5 text-sm text-gray-300"
                            placeholder="To" onchange="this.form.submit()">
                 </form>

--- a/daiv/activity/views.py
+++ b/daiv/activity/views.py
@@ -1,19 +1,20 @@
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import json
 import time
 import uuid
-from datetime import date
 from typing import TYPE_CHECKING
 
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.http import Http404, HttpResponse, HttpResponseBase, StreamingHttpResponse
 from django.utils.text import slugify
 from django.views import View
-from django.views.generic import DetailView, ListView
+from django.views.generic import DetailView
 
+from django_filters.views import FilterView
+
+from activity.filters import ActivityFilter
 from activity.models import Activity, ActivityStatus, TriggerType
 from schedules.models import ScheduledJob
 
@@ -24,54 +25,31 @@ if TYPE_CHECKING:
     from accounts.models import User
 
 
-class ActivityListView(LoginRequiredMixin, ListView):
+class ActivityListView(LoginRequiredMixin, FilterView):
     model = Activity
+    filterset_class = ActivityFilter
     template_name = "activity/activity_list.html"
     context_object_name = "activities"
     paginate_by = 25
+    # Preserve pre-django-filter UX: an invalid URL param (e.g. ?status=bogus) should
+    # silently drop that filter, not blank the whole list.
+    strict = False
 
     def get_queryset(self) -> QuerySet[Activity]:
-        qs = Activity.objects.by_owner(self.request.user).select_related("task_result", "scheduled_job", "user")
-
-        if (status := self.request.GET.get("status", "")) and status in ActivityStatus.values:
-            qs = qs.filter(status=status)
-
-        if (trigger := self.request.GET.get("trigger", "")) and trigger in dict(TriggerType.choices):
-            qs = qs.filter(trigger_type=trigger)
-
-        if repo := self.request.GET.get("repo", ""):
-            qs = qs.filter(repo_id=repo)
-
-        if schedule_id := self.request.GET.get("schedule", ""):
-            with contextlib.suppress(ValueError, TypeError):
-                qs = qs.filter(scheduled_job_id=int(schedule_id))
-
-        if date_from := self.request.GET.get("from", ""):
-            try:
-                date.fromisoformat(date_from)
-            except ValueError:
-                pass
-            else:
-                qs = qs.filter(created_at__date__gte=date_from)
-
-        if date_to := self.request.GET.get("to", ""):
-            try:
-                date.fromisoformat(date_to)
-            except ValueError:
-                pass
-            else:
-                qs = qs.filter(created_at__date__lte=date_to)
-
-        return qs
+        return Activity.objects.by_owner(self.request.user).select_related("task_result", "scheduled_job", "user")
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context["current_status"] = self.request.GET.get("status", "")
-        context["current_trigger"] = self.request.GET.get("trigger", "")
-        context["current_repo"] = self.request.GET.get("repo", "")
-        context["current_schedule"] = self.request.GET.get("schedule", "")
-        context["current_from"] = self.request.GET.get("from", "")
-        context["current_to"] = self.request.GET.get("to", "")
+        form = context["filter"].form
+        cleaned = form.cleaned_data if form.is_valid() else {}
+        context["current_status"] = cleaned.get("status") or ""
+        context["current_trigger"] = cleaned.get("trigger") or ""
+        context["current_repo"] = cleaned.get("repo") or ""
+        context["current_schedule"] = cleaned.get("schedule") or ""
+        # Date fields are read raw: cleaned_data yields `date` objects, but the
+        # HTML `<input type="date">` needs the original ISO string to round-trip.
+        context["current_from"] = self.request.GET.get("date_from", "")
+        context["current_to"] = self.request.GET.get("date_to", "")
         context["trigger_types"] = TriggerType.choices
         context["statuses"] = ActivityStatus.choices
         # Resolve schedule name for display

--- a/daiv/daiv/settings/components/common.py
+++ b/daiv/daiv/settings/components/common.py
@@ -16,6 +16,7 @@ LOCAL_APPS = ["accounts", "activity", "automation", "codebase", "core", "mcp_ser
 THIRD_PARTY_APPS = [
     "crontask",
     "django_extensions",
+    "django_filters",
     "django_tasks",
     "django_tasks_db",
     "oauth2_provider",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
   "django-allauth[socialaccount]==65.15.1",
   "django-crontask==1.1.3",
   "django-extensions==4.1.0",
+  "django-filter==25.2",
   "django-ninja==1.6.2",
   "django-oauth-toolkit==3.2.0",
   "django-split-settings==1.3.2",

--- a/tests/unit_tests/accounts/test_filters.py
+++ b/tests/unit_tests/accounts/test_filters.py
@@ -1,0 +1,82 @@
+import pytest
+
+from accounts.filters import UserFilter
+from accounts.models import Role, User
+
+
+@pytest.fixture
+def users(db):
+    alice = User.objects.create_user(
+        username="alice",
+        email="alice@test.com",
+        password="testpass123",  # noqa: S106
+        name="Alice Admin",
+        role=Role.ADMIN,
+    )
+    bob = User.objects.create_user(
+        username="bob",
+        email="bob@test.com",
+        password="testpass123",  # noqa: S106
+        name="Bob Member",
+        role=Role.MEMBER,
+    )
+    return alice, bob
+
+
+@pytest.mark.django_db
+class TestUserFilter:
+    def test_no_params_returns_all(self, users):
+        alice, bob = users
+        qs = UserFilter({}, queryset=User.objects.all()).qs
+        assert alice in qs
+        assert bob in qs
+
+    def test_q_matches_name(self, users):
+        alice, bob = users
+        qs = UserFilter({"q": "Alice"}, queryset=User.objects.all()).qs
+        assert alice in qs
+        assert bob not in qs
+
+    def test_q_matches_email(self, users):
+        alice, bob = users
+        qs = UserFilter({"q": "bob@"}, queryset=User.objects.all()).qs
+        assert bob in qs
+        assert alice not in qs
+
+    def test_q_is_case_insensitive(self, users):
+        alice, _bob = users
+        qs = UserFilter({"q": "alice"}, queryset=User.objects.all()).qs
+        assert alice in qs
+
+    def test_q_whitespace_is_stripped(self, users):
+        alice, bob = users
+        qs = UserFilter({"q": "   "}, queryset=User.objects.all()).qs
+        assert alice in qs
+        assert bob in qs
+
+    def test_role_filter_admin(self, users):
+        alice, bob = users
+        qs = UserFilter({"role": Role.ADMIN}, queryset=User.objects.all()).qs
+        assert alice in qs
+        assert bob not in qs
+
+    def test_role_filter_member(self, users):
+        alice, bob = users
+        qs = UserFilter({"role": Role.MEMBER}, queryset=User.objects.all()).qs
+        assert bob in qs
+        assert alice not in qs
+
+    def test_invalid_role_is_ignored(self, users):
+        alice, bob = users
+        f = UserFilter({"role": "bogus"}, queryset=User.objects.all())
+        # Invalid choice → form invalid → FilterView fallback: no filter applied.
+        assert not f.form.is_valid()
+        # Still returns full queryset since the invalid value cannot be translated to a filter.
+        assert alice in f.qs
+        assert bob in f.qs
+
+    def test_q_and_role_combined(self, users):
+        alice, bob = users
+        qs = UserFilter({"q": "bob", "role": Role.MEMBER}, queryset=User.objects.all()).qs
+        assert bob in qs
+        assert alice not in qs

--- a/tests/unit_tests/activity/test_filters.py
+++ b/tests/unit_tests/activity/test_filters.py
@@ -1,0 +1,131 @@
+from datetime import UTC, datetime, time
+
+import pytest
+from activity.filters import ActivityFilter
+from activity.models import Activity, ActivityStatus, TriggerType
+
+from accounts.models import User
+from schedules.models import Frequency, ScheduledJob
+
+
+@pytest.fixture
+def user(db):
+    return User.objects.create_user(
+        username="alice",
+        email="alice@test.com",
+        password="testpass123",  # noqa: S106
+    )
+
+
+def _create(**kwargs):
+    defaults = {
+        "trigger_type": TriggerType.SCHEDULE,
+        "repo_id": "group/project",
+        "ref": "main",
+        "status": ActivityStatus.SUCCESSFUL,
+    }
+    defaults.update(kwargs)
+    return Activity.objects.create(**defaults)
+
+
+@pytest.mark.django_db
+class TestActivityFilter:
+    def test_no_params_returns_all(self, user):
+        a = _create()
+        b = _create(status=ActivityStatus.FAILED)
+        qs = ActivityFilter({}, queryset=Activity.objects.all()).qs
+        assert a in qs
+        assert b in qs
+
+    def test_status_filter(self, user):
+        successful = _create(status=ActivityStatus.SUCCESSFUL)
+        failed = _create(status=ActivityStatus.FAILED)
+        qs = ActivityFilter({"status": ActivityStatus.SUCCESSFUL}, queryset=Activity.objects.all()).qs
+        assert successful in qs
+        assert failed not in qs
+
+    def test_invalid_status_is_ignored(self, user):
+        a = _create()
+        f = ActivityFilter({"status": "bogus"}, queryset=Activity.objects.all())
+        assert not f.form.is_valid()
+        # Invalid choice is dropped from cleaned_data → no filter applied for that field.
+        assert a in f.qs
+
+    def test_trigger_filter(self, user):
+        sched = _create(trigger_type=TriggerType.SCHEDULE)
+        webhook = _create(trigger_type=TriggerType.ISSUE_WEBHOOK)
+        qs = ActivityFilter({"trigger": TriggerType.SCHEDULE}, queryset=Activity.objects.all()).qs
+        assert sched in qs
+        assert webhook not in qs
+
+    def test_repo_filter(self, user):
+        a = _create(repo_id="group/project")
+        b = _create(repo_id="group/other")
+        qs = ActivityFilter({"repo": "group/project"}, queryset=Activity.objects.all()).qs
+        assert a in qs
+        assert b not in qs
+
+    def test_schedule_filter_accepts_int_string(self, user):
+        a = _create()
+        f = ActivityFilter({"schedule": "not-a-number"}, queryset=Activity.objects.all())
+        assert not f.form.is_valid()
+        # Invalid int is dropped from cleaned_data.
+        assert a in f.qs
+
+    def test_schedule_filter_matches_fk(self, user):
+        job = ScheduledJob.objects.create(
+            user=user, name="nightly", prompt="x", repo_id="group/project", frequency=Frequency.DAILY, time=time(3, 0)
+        )
+        match = _create(scheduled_job=job)
+        other = _create()
+        qs = ActivityFilter({"schedule": str(job.pk)}, queryset=Activity.objects.all()).qs
+        assert match in qs
+        assert other not in qs
+
+    def test_date_from_filter(self, user):
+        old = _create()
+        Activity.objects.filter(pk=old.pk).update(created_at=datetime(2020, 1, 1, tzinfo=UTC))
+        recent = _create()
+        Activity.objects.filter(pk=recent.pk).update(created_at=datetime(2026, 1, 1, tzinfo=UTC))
+        qs = ActivityFilter({"date_from": "2025-06-01"}, queryset=Activity.objects.all()).qs
+        assert recent in qs
+        assert old not in qs
+
+    def test_date_to_filter(self, user):
+        old = _create()
+        Activity.objects.filter(pk=old.pk).update(created_at=datetime(2020, 1, 1, tzinfo=UTC))
+        recent = _create()
+        Activity.objects.filter(pk=recent.pk).update(created_at=datetime(2026, 1, 1, tzinfo=UTC))
+        qs = ActivityFilter({"date_to": "2025-06-01"}, queryset=Activity.objects.all()).qs
+        assert old in qs
+        assert recent not in qs
+
+    def test_date_range_combined(self, user):
+        before = _create()
+        Activity.objects.filter(pk=before.pk).update(created_at=datetime(2020, 1, 1, tzinfo=UTC))
+        inside = _create()
+        Activity.objects.filter(pk=inside.pk).update(created_at=datetime(2025, 6, 15, tzinfo=UTC))
+        after = _create()
+        Activity.objects.filter(pk=after.pk).update(created_at=datetime(2026, 1, 1, tzinfo=UTC))
+        qs = ActivityFilter({"date_from": "2025-01-01", "date_to": "2025-12-31"}, queryset=Activity.objects.all()).qs
+        assert inside in qs
+        assert before not in qs
+        assert after not in qs
+
+    def test_invalid_date_is_ignored(self, user):
+        a = _create()
+        f = ActivityFilter({"date_from": "not-a-date"}, queryset=Activity.objects.all())
+        assert not f.form.is_valid()
+        # Invalid date is dropped from cleaned_data → no filter applied.
+        assert a in f.qs
+
+    def test_combined_filters(self, user):
+        match = _create(status=ActivityStatus.SUCCESSFUL, repo_id="group/project")
+        wrong_status = _create(status=ActivityStatus.FAILED, repo_id="group/project")
+        wrong_repo = _create(status=ActivityStatus.SUCCESSFUL, repo_id="group/other")
+        qs = ActivityFilter(
+            {"status": ActivityStatus.SUCCESSFUL, "repo": "group/project"}, queryset=Activity.objects.all()
+        ).qs
+        assert match in qs
+        assert wrong_status not in qs
+        assert wrong_repo not in qs

--- a/tests/unit_tests/activity/test_views.py
+++ b/tests/unit_tests/activity/test_views.py
@@ -141,3 +141,53 @@ class TestActivityDownloadMarkdownView:
 
         assert response.status_code == 302
         assert "/accounts/login/" in response.url
+
+
+@pytest.mark.django_db
+class TestActivityListView:
+    def test_unauthenticated_redirects_to_login(self):
+        response = Client().get(reverse("activity_list"))
+        assert response.status_code == 302
+        assert "/accounts/login/" in response.url
+
+    def test_owner_scoping_applied_before_filters(self, logged_in_client, user):
+        mine = _create_activity(user=user, repo_id="mine/repo")
+        other = User.objects.create_user(
+            username="bob",
+            email="bob@test.com",
+            password="testpass123",  # noqa: S106
+        )
+        theirs = _create_activity(user=other, repo_id="mine/repo")
+
+        response = logged_in_client.get(reverse("activity_list"), {"repo": "mine/repo"})
+
+        assert response.status_code == 200
+        activities = list(response.context["activities"])
+        assert mine in activities
+        # by_owner must run before the filterset — without it, the repo filter would leak `theirs`.
+        assert theirs not in activities
+
+    def test_filter_by_status(self, logged_in_client, user):
+        success = _create_activity(user=user, status=ActivityStatus.SUCCESSFUL)
+        failed = _create_activity(user=user, status=ActivityStatus.FAILED)
+        response = logged_in_client.get(reverse("activity_list"), {"status": ActivityStatus.SUCCESSFUL})
+        activities = list(response.context["activities"])
+        assert success in activities
+        assert failed not in activities
+
+    def test_date_param_names_are_date_from_and_date_to(self, logged_in_client, user):
+        """Lock in the URL contract after the `from`/`to` → `date_from`/`date_to` rename."""
+        _create_activity(user=user)
+        response = logged_in_client.get(reverse("activity_list"), {"date_from": "2020-01-01", "date_to": "2100-01-01"})
+        assert response.status_code == 200
+        # Values round-trip to the template context so the date inputs stay populated.
+        assert response.context["current_from"] == "2020-01-01"
+        assert response.context["current_to"] == "2100-01-01"
+
+    def test_invalid_filter_drops_silently(self, logged_in_client, user):
+        activity = _create_activity(user=user)
+        response = logged_in_client.get(reverse("activity_list"), {"status": "bogus"})
+        assert response.status_code == 200
+        # Invalid choice is dropped; full (owner-scoped) list is shown and context key is empty.
+        assert activity in response.context["activities"]
+        assert response.context["current_status"] == ""

--- a/uv.lock
+++ b/uv.lock
@@ -432,6 +432,7 @@ dependencies = [
     { name = "django-allauth", extra = ["socialaccount"] },
     { name = "django-crontask" },
     { name = "django-extensions" },
+    { name = "django-filter" },
     { name = "django-ninja" },
     { name = "django-oauth-toolkit" },
     { name = "django-split-settings" },
@@ -506,6 +507,7 @@ requires-dist = [
     { name = "django-allauth", extras = ["socialaccount"], specifier = "==65.15.1" },
     { name = "django-crontask", specifier = "==1.1.3" },
     { name = "django-extensions", specifier = "==4.1.0" },
+    { name = "django-filter", specifier = "==25.2" },
     { name = "django-ninja", specifier = "==1.6.2" },
     { name = "django-oauth-toolkit", specifier = "==3.2.0" },
     { name = "django-split-settings", specifier = "==1.3.2" },
@@ -724,6 +726,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/6d/b3/ed0f54ed706ec0b54fd251cc0364a249c6cd6c6ec97f04dc34be5e929eac/django_extensions-4.1.tar.gz", hash = "sha256:7b70a4d28e9b840f44694e3f7feb54f55d495f8b3fa6c5c0e5e12bcb2aa3cdeb", size = 283078, upload-time = "2025-04-11T01:15:39.617Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/64/96/d967ca440d6a8e3861120f51985d8e5aec79b9a8bdda16041206adfe7adc/django_extensions-4.1-py3-none-any.whl", hash = "sha256:0699a7af28f2523bf8db309a80278519362cd4b6e1fd0a8cd4bf063e1e023336", size = 232980, upload-time = "2025-04-11T01:15:37.701Z" },
+]
+
+[[package]]
+name = "django-filter"
+version = "25.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "django" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2c/e4/465d2699cd388c0005fb8d6ae6709f239917c6d8790ac35719676fffdcf3/django_filter-25.2.tar.gz", hash = "sha256:760e984a931f4468d096f5541787efb8998c61217b73006163bf2f9523fe8f23", size = 143818, upload-time = "2025-10-05T09:51:31.521Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/40/6a02495c5658beb1f31eb09952d8aa12ef3c2a66342331ce3a35f7132439/django_filter-25.2-py3-none-any.whl", hash = "sha256:9c0f8609057309bba611062fe1b720b4a873652541192d232dd28970383633e3", size = 94145, upload-time = "2025-10-05T09:51:29.728Z" },
 ]
 
 [[package]]
@@ -995,7 +1009,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/78/02/bde66806e8f169cf90b14d02c500c44cdbe02c8e224c9c67bafd1b8cadd1/greenlet-3.4.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:10a07aca6babdd18c16a3f4f8880acfffc2b88dfe431ad6aa5f5740759d7d75e", size = 286291, upload-time = "2026-04-08T17:09:34.307Z" },
     { url = "https://files.pythonhosted.org/packages/05/1f/39da1c336a87d47c58352fb8a78541ce63d63ae57c5b9dae1fe02801bbc2/greenlet-3.4.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:076e21040b3a917d3ce4ad68fb5c3c6b32f1405616c4a57aa83120979649bd3d", size = 656749, upload-time = "2026-04-08T16:24:41.721Z" },
     { url = "https://files.pythonhosted.org/packages/d3/6c/90ee29a4ee27af7aa2e2ec408799eeb69ee3fcc5abcecac6ddd07a5cd0f2/greenlet-3.4.0-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e82689eea4a237e530bb5cb41b180ef81fa2160e1f89422a67be7d90da67f615", size = 669084, upload-time = "2026-04-08T16:31:01.372Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/4a/74078d3936712cff6d3c91a930016f476ce4198d84e224fe6d81d3e02880/greenlet-3.4.0-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:06c2d3b89e0c62ba50bd7adf491b14f39da9e7e701647cb7b9ff4c99bee04b19", size = 673405, upload-time = "2026-04-08T16:40:42.527Z" },
     { url = "https://files.pythonhosted.org/packages/07/49/d4cad6e5381a50947bb973d2f6cf6592621451b09368b8c20d9b8af49c5b/greenlet-3.4.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4df3b0b2289ec686d3c821a5fee44259c05cfe824dd5e6e12c8e5f5df23085cf", size = 665621, upload-time = "2026-04-08T15:56:35.995Z" },
+    { url = "https://files.pythonhosted.org/packages/79/3e/df8a83ab894751bc31e1106fdfaa80ca9753222f106b04de93faaa55feb7/greenlet-3.4.0-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:070b8bac2ff3b4d9e0ff36a0d19e42103331d9737e8504747cd1e659f76297bd", size = 471670, upload-time = "2026-04-08T16:43:08.512Z" },
     { url = "https://files.pythonhosted.org/packages/37/31/d1edd54f424761b5d47718822f506b435b6aab2f3f93b465441143ea5119/greenlet-3.4.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8bff29d586ea415688f4cec96a591fcc3bf762d046a796cdadc1fdb6e7f2d5bf", size = 1622259, upload-time = "2026-04-08T16:26:23.201Z" },
     { url = "https://files.pythonhosted.org/packages/b0/c6/6d3f9cdcb21c4e12a79cb332579f1c6aa1af78eb68059c5a957c7812d95e/greenlet-3.4.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:8a569c2fb840c53c13a2b8967c63621fafbd1a0e015b9c82f408c33d626a2fda", size = 1686916, upload-time = "2026-04-08T15:57:34.282Z" },
     { url = "https://files.pythonhosted.org/packages/63/45/c1ca4a1ad975de4727e52d3ffe641ae23e1d7a8ffaa8ff7a0477e1827b92/greenlet-3.4.0-cp314-cp314-win_amd64.whl", hash = "sha256:207ba5b97ea8b0b60eb43ffcacf26969dd83726095161d676aac03ff913ee50d", size = 239821, upload-time = "2026-04-08T17:03:48.423Z" },
@@ -1003,7 +1019,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/8f/18d72b629783f5e8d045a76f5325c1e938e659a9e4da79c7dcd10169a48d/greenlet-3.4.0-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:d70012e51df2dbbccfaf63a40aaf9b40c8bed37c3e3a38751c926301ce538ece", size = 294681, upload-time = "2026-04-08T15:52:35.778Z" },
     { url = "https://files.pythonhosted.org/packages/9e/ad/5fa86ec46769c4153820d58a04062285b3b9e10ba3d461ee257b68dcbf53/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a58bec0751f43068cd40cff31bb3ca02ad6000b3a51ca81367af4eb5abc480c8", size = 658899, upload-time = "2026-04-08T16:24:43.32Z" },
     { url = "https://files.pythonhosted.org/packages/43/f0/4e8174ca0e87ae748c409f055a1ba161038c43cc0a5a6f1433a26ac2e5bf/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:05fa0803561028f4b2e3b490ee41216a842eaee11aed004cc343a996d9523aa2", size = 665284, upload-time = "2026-04-08T16:31:02.833Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/92/466b0d9afd44b8af623139a3599d651c7564fa4152f25f117e1ee5949ffb/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c4cd56a9eb7a6444edbc19062f7b6fbc8f287c663b946e3171d899693b1c19fa", size = 665872, upload-time = "2026-04-08T16:40:43.912Z" },
     { url = "https://files.pythonhosted.org/packages/19/da/991cf7cd33662e2df92a1274b7eb4d61769294d38a1bba8a45f31364845e/greenlet-3.4.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e60d38719cb80b3ab5e85f9f1aed4960acfde09868af6762ccb27b260d68f4ed", size = 661861, upload-time = "2026-04-08T15:56:37.269Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/14/3395a7ef3e260de0325152ddfe19dffb3e49fe10873b94654352b53ad48e/greenlet-3.4.0-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:1f85f204c4d54134ae850d401fa435c89cd667d5ce9dc567571776b45941af72", size = 489237, upload-time = "2026-04-08T16:43:09.993Z" },
     { url = "https://files.pythonhosted.org/packages/36/c5/6c2c708e14db3d9caea4b459d8464f58c32047451142fe2cfd90e7458f41/greenlet-3.4.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7f50c804733b43eded05ae694691c9aa68bca7d0a867d67d4a3f514742a2d53f", size = 1622182, upload-time = "2026-04-08T16:26:24.777Z" },
     { url = "https://files.pythonhosted.org/packages/7a/4c/50c5fed19378e11a29fabab1f6be39ea95358f4a0a07e115a51ca93385d8/greenlet-3.4.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2d4f0635dc4aa638cda4b2f5a07ae9a2cff9280327b581a3fcb6f317b4fbc38a", size = 1685050, upload-time = "2026-04-08T15:57:36.453Z" },
     { url = "https://files.pythonhosted.org/packages/db/72/85ae954d734703ab48e622c59d4ce35d77ce840c265814af9c078cacc7aa/greenlet-3.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:1a4a48f24681300c640f143ba7c404270e1ebbbcf34331d7104a4ff40f8ea705", size = 245554, upload-time = "2026-04-08T17:03:50.044Z" },


### PR DESCRIPTION
Introduce django-filter to centralize validation and sanitization of list-view query params, removing duplicated GET-parsing boilerplate from UserListView and ActivityListView.

Both views now inherit FilterView and delegate field validation to a FilterSet (UserFilter, ActivityFilter). ActivityListView keeps its by_owner scoping in get_queryset so ownership is applied before filtering. Template context keys are sourced from validated cleaned_data, so invalid URL params reset the UI state instead of echoing back the raw input.

strict=False is set on both views so invalid params drop silently (preserving the old UX) rather than blanking the list. Meta.fields is set to [] on each FilterSet to disable auto-generation from model fields and prevent drift if a declared filter is later renamed.

The activity list date query params were renamed from/to -> date_from/ date_to because `from` is a Python reserved word and cannot be a FilterSet class attribute.