### PR TITLE
fix(activity): Unlocalize issue and MR IIDs in templates

### DIFF
--- a/daiv/activity/templates/activity/activity_detail.html
+++ b/daiv/activity/templates/activity/activity_detail.html
@@ -101,7 +101,7 @@
                 {% if activity.issue_iid %}
                 <div class="flex items-center gap-2">
                     <span class="text-gray-400">Issue:</span>
-                    <span class="text-gray-300">#{{ activity.issue_iid }}</span>
+                    <span class="text-gray-300">#{{ activity.issue_iid|unlocalize }}</span>
                 </div>
                 {% endif %}
 
@@ -111,10 +111,10 @@
                     {% if activity.merge_request_web_url %}
                     <a href="{{ activity.merge_request_web_url }}" target="_blank" rel="noopener"
                        class="text-gray-300 underline decoration-gray-600 hover:text-white hover:decoration-gray-400">
-                        !{{ activity.merge_request_iid }}
+                        !{{ activity.merge_request_iid|unlocalize }}
                     </a>
                     {% else %}
-                    <span class="text-gray-300">!{{ activity.merge_request_iid }}</span>
+                    <span class="text-gray-300">!{{ activity.merge_request_iid|unlocalize }}</span>
                     {% endif %}
                 </div>
                 {% endif %}

--- a/daiv/activity/templates/activity/activity_list.html
+++ b/daiv/activity/templates/activity/activity_list.html
@@ -121,9 +121,9 @@
                                   :class="dotClass('{{ a.pk }}', '{{ a.status }}')"></span>
                             <p class="text-[15px] font-medium text-white truncate">
                                 {% if a.trigger_type == "issue_webhook" %}
-                                    Issue #{{ a.issue_iid }}
+                                    Issue #{{ a.issue_iid|unlocalize }}
                                 {% elif a.trigger_type == "mr_webhook" %}
-                                    MR/PR !{{ a.merge_request_iid }}
+                                    MR/PR !{{ a.merge_request_iid|unlocalize }}
                                 {% endif %}
                                 {% if a.prompt %}
                                     {% if a.trigger_type == "issue_webhook" or a.trigger_type == "mr_webhook" %}&mdash;{% endif %}


### PR DESCRIPTION
Django's USE_THOUSAND_SEPARATOR was formatting numeric IIDs with commas (e.g. !2,716 instead of !2716). Apply |unlocalize to IID outputs so identifiers render as plain integers.