### PR TITLE
fix(mcp): Use underscores in MCP service hostnames for Docker Swarm DNS

### DIFF
--- a/daiv/automation/agent/mcp/conf.py
+++ b/daiv/automation/agent/mcp/conf.py
@@ -10,11 +10,12 @@ class MCPSettings(BaseSettings):
     )
 
     # Built-in MCP server URLs (supergateway containers). Set to None to disable.
+    # Note: Docker Swarm normalizes service names with dashes to underscores.
     SENTRY_URL: str | None = Field(
-        default="http://mcp-sentry:8000/sse", description="The SSE URL of the Sentry supergateway container"
+        default="http://mcp_sentry:8000/sse", description="The SSE URL of the Sentry supergateway container"
     )
     CONTEXT7_URL: str | None = Field(
-        default="http://mcp-context7:8000/sse", description="The SSE URL of the Context7 supergateway container"
+        default="http://mcp_context7:8000/sse", description="The SSE URL of the Context7 supergateway container"
     )
 
 

--- a/daiv/automation/agent/mcp/toolkits.py
+++ b/daiv/automation/agent/mcp/toolkits.py
@@ -15,6 +15,11 @@ if TYPE_CHECKING:
 logger = logging.getLogger("daiv.tools")
 
 
+def _get_connection_url(conn) -> str:
+    """Extract the URL from a langchain MCP connection object."""
+    return getattr(conn, "url", "unknown")
+
+
 class MCPToolkit(BaseToolkit):
     """
     Toolkit for using MCP servers.
@@ -25,12 +30,19 @@ class MCPToolkit(BaseToolkit):
         from automation.agent.mcp.registry import mcp_registry
 
         connections, tool_filters = mcp_registry.get_connections_and_filters()
+
+        if not connections:
+            return []
+
+        server_urls = {name: _get_connection_url(conn) for name, conn in connections.items()}
+        logger.debug("Connecting to MCP servers: %s", server_urls)
+
         client = MultiServerMCPClient(connections, tool_name_prefix=True)
 
         try:
             tools = await client.get_tools()
         except Exception:
-            logger.warning("Error getting tools from MCP servers.", exc_info=True)
+            logger.warning("Error getting tools from MCP servers: %s", server_urls, exc_info=True)
             tools = []
 
         if tool_filters:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -128,7 +128,7 @@ services:
       - "./data/gitlab/logs:/var/log/gitlab"
       - "./data/gitlab/data:/var/opt/gitlab"
 
-  gitlab-runner:
+  gitlab_runner:
     image: gitlab/gitlab-runner:latest
     container_name: daiv-gitlab-runner
     profiles:
@@ -161,7 +161,7 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
 
-  mcp-sentry:
+  mcp_sentry:
     image: supercorp/supergateway:latest
     profiles:
       - mcp
@@ -184,7 +184,7 @@ services:
       retries: 3
       start_period: 30s
 
-  mcp-context7:
+  mcp_context7:
     image: supercorp/supergateway:latest
     profiles:
       - mcp


### PR DESCRIPTION
Docker Swarm normalizes service names with dashes to underscores, causing DNS resolution failures when the worker tried to connect to mcp-sentry/mcp-context7. Also log server URLs on connection errors to speed up future diagnosis.