### PR TITLE
fix(mcp): Update Sentry tool filter to match current tool names

### DIFF
--- a/daiv/automation/agent/mcp/servers.py
+++ b/daiv/automation/agent/mcp/servers.py
@@ -9,10 +9,7 @@ from .schemas import ToolFilter
 @mcp_server
 class SentryMCPServer(MCPServer):
     name = "sentry"
-    tool_filter = ToolFilter(
-        mode="allow",
-        items=["find_organizations", "find_projects", "search_issues", "search_events", "get_issue_details"],
-    )
+    tool_filter = ToolFilter(mode="allow", items=["find_organizations", "find_projects", "list_issues", "list_events"])
 
     def is_enabled(self) -> bool:
         return settings.SENTRY_URL is not None

--- a/tests/unit_tests/automation/agent/mcp/test_servers.py
+++ b/tests/unit_tests/automation/agent/mcp/test_servers.py
@@ -28,7 +28,7 @@ class TestSentryMCPServer:
         assert server.tool_filter is not None
         assert server.tool_filter.mode == "allow"
         assert "find_organizations" in server.tool_filter.items
-        assert "search_issues" in server.tool_filter.items
+        assert "list_issues" in server.tool_filter.items
 
     @patch("automation.agent.mcp.servers.settings")
     def test_sentry_get_connection_returns_correct_url(self, mock_settings):


### PR DESCRIPTION
Rename search_issues → list_issues, search_events → list_events and remove get_issue_details which is no longer available.