### PR TITLE
fix(schedules): Fix dropdown clipping and time field not prepopulating

### DIFF
--- a/daiv/schedules/templates/schedules/schedule_form.html
+++ b/daiv/schedules/templates/schedules/schedule_form.html
@@ -40,7 +40,7 @@
         <form method="post"
               x-data="{
                   frequency: '{{ form.frequency.value|default:'daily' }}',
-                  time: '{{ form.time.value|default:'' }}',
+                  time: '{{ form.time.value|time:"H:i" }}',
                   get showTime() { return this.frequency !== 'hourly' && this.frequency !== 'custom' },
                   get showCron() { return this.frequency === 'custom' },
                   get summary() {
@@ -142,7 +142,7 @@
                 <!-- Time (hidden for Hourly and Custom) -->
                 <div x-show="showTime" x-cloak>
                     <label for="id_time" class="block text-[15px] font-medium text-gray-400">Time <span class="text-red-400">*</span></label>
-                    <input type="time" name="time" id="id_time" value="{{ form.time.value|default:'' }}" x-model="time" class="mt-2 !w-auto">
+                    <input type="time" name="time" id="id_time" x-model="time" class="mt-2 !w-auto">
                     {% if form.time.errors %}
                     <p class="mt-1.5 text-sm text-red-400">{{ form.time.errors.0 }}</p>
                     {% endif %}

--- a/daiv/schedules/templates/schedules/schedule_list.html
+++ b/daiv/schedules/templates/schedules/schedule_list.html
@@ -28,7 +28,7 @@
         <!-- Schedule list -->
         <div class="animate-fade-up mt-8" style="animation-delay: 100ms">
             {% if schedules %}
-            <div class="overflow-hidden rounded-2xl border border-white/[0.06]">
+            <div class="rounded-2xl border border-white/[0.06]">
                 {% for schedule in schedules %}
                 {% include "schedules/_schedule_row.html" %}
                 {% endfor %}


### PR DESCRIPTION
Remove overflow-hidden from schedule list container that clipped the kebab menu dropdown items. Use |time:"H:i" filter for the time field so the value renders in HH:MM format instead of the localized "8 a.m." format that <input type="time"> cannot parse.