### PR TITLE
fix(mcp): Switch built-in servers to streamable HTTP transport

### DIFF
--- a/daiv/automation/agent/mcp/conf.py
+++ b/daiv/automation/agent/mcp/conf.py
@@ -12,10 +12,11 @@ class MCPSettings(BaseSettings):
     # Built-in MCP server URLs (supergateway containers). Set to None to disable.
     # Note: Docker Swarm normalizes service names with dashes to underscores.
     SENTRY_URL: str | None = Field(
-        default="http://mcp_sentry:8000/sse", description="The SSE URL of the Sentry supergateway container"
+        default="http://mcp_sentry:8000/mcp", description="The streamable HTTP URL of the Sentry supergateway container"
     )
     CONTEXT7_URL: str | None = Field(
-        default="http://mcp_context7:8000/sse", description="The SSE URL of the Context7 supergateway container"
+        default="http://mcp_context7:8000/mcp",
+        description="The streamable HTTP URL of the Context7 supergateway container",
     )
 
 

--- a/daiv/automation/agent/mcp/servers.py
+++ b/daiv/automation/agent/mcp/servers.py
@@ -1,4 +1,4 @@
-from langchain_mcp_adapters.sessions import SSEConnection
+from langchain_mcp_adapters.sessions import StreamableHttpConnection
 
 from .base import MCPServer
 from .conf import settings
@@ -14,9 +14,9 @@ class SentryMCPServer(MCPServer):
     def is_enabled(self) -> bool:
         return settings.SENTRY_URL is not None
 
-    def get_connection(self) -> SSEConnection:
+    def get_connection(self) -> StreamableHttpConnection:
         assert settings.SENTRY_URL is not None  # guaranteed by is_enabled()
-        return SSEConnection(transport="sse", url=settings.SENTRY_URL)
+        return StreamableHttpConnection(transport="streamable_http", url=settings.SENTRY_URL)
 
 
 @mcp_server
@@ -27,6 +27,6 @@ class Context7MCPServer(MCPServer):
     def is_enabled(self) -> bool:
         return settings.CONTEXT7_URL is not None
 
-    def get_connection(self) -> SSEConnection:
+    def get_connection(self) -> StreamableHttpConnection:
         assert settings.CONTEXT7_URL is not None  # guaranteed by is_enabled()
-        return SSEConnection(transport="sse", url=settings.CONTEXT7_URL)
+        return StreamableHttpConnection(transport="streamable_http", url=settings.CONTEXT7_URL)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -171,6 +171,8 @@ services:
     command:
       - --stdio
       - "npx @sentry/mcp-server@latest"
+      - --outputTransport
+      - streamableHttp
       - --healthEndpoint
       - "/healthz"
     env_file:
@@ -194,6 +196,8 @@ services:
     command:
       - --stdio
       - "npx @upstash/context7-mcp@latest"
+      - --outputTransport
+      - streamableHttp
       - --healthEndpoint
       - "/healthz"
     env_file:

--- a/docs/customization/mcp-tools.md
+++ b/docs/customization/mcp-tools.md
@@ -23,7 +23,7 @@ The [Sentry MCP Server](https://www.npmjs.com/package/@sentry/mcp-server) gives 
 **Configuration:**
 
 ```bash
-MCP_SENTRY_URL=http://mcp-sentry:8000/sse   # Default; set to None to disable
+MCP_SENTRY_URL=http://mcp-sentry:8000/mcp   # Default; set to None to disable
 ```
 
 `SENTRY_ACCESS_TOKEN` is consumed by the `mcp-sentry` container — add it to your secrets env file. `SENTRY_HOST` is set as a regular environment variable on the container.
@@ -44,7 +44,7 @@ The [Context7 MCP Server](https://www.npmjs.com/package/@upstash/context7-mcp) p
 **Configuration:**
 
 ```bash
-MCP_CONTEXT7_URL=http://mcp-context7:8000/sse  # Default; set to None to disable
+MCP_CONTEXT7_URL=http://mcp-context7:8000/mcp  # Default; set to None to disable
 ```
 
 Context7 credentials (`CONTEXT7_API_KEY`) are consumed by the `mcp-context7` container. Add them to your secrets env file.

--- a/docs/reference/env-variables.md
+++ b/docs/reference/env-variables.md
@@ -271,8 +271,8 @@ MCP (Model Context Protocol) tools extend agent capabilities by providing access
 | Variable                        | Description                                                    | Default                        | Example |
 |---------------------------------|----------------------------------------------------------------|:------------------------------:|---------|
 | `MCP_SERVERS_CONFIG_FILE`       | Path to user-defined MCP servers JSON config file              | *(none)*                       | `/path/to/mcp.json` |
-| `MCP_SENTRY_URL`                | SSE URL for the Sentry supergateway container (set to `None` to disable) | `http://mcp-sentry:8000/sse`   | `http://localhost:8001/sse` |
-| `MCP_CONTEXT7_URL`              | SSE URL for the Context7 supergateway container (set to `None` to disable) | `http://mcp-context7:8000/sse` | `http://localhost:8002/sse` |
+| `MCP_SENTRY_URL`                | Streamable HTTP URL for the Sentry supergateway container (set to `None` to disable) | `http://mcp-sentry:8000/mcp`   | `http://localhost:8001/mcp` |
+| `MCP_CONTEXT7_URL`              | Streamable HTTP URL for the Context7 supergateway container (set to `None` to disable) | `http://mcp-context7:8000/mcp` | `http://localhost:8002/mcp` |
 
 !!! info
     For detailed MCP server configuration including user-defined servers, see [MCP Tools](../customization/mcp-tools.md).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
   "langsmith-fetch==0.3.1",
   "markdown==3.10.2",
   "markdownify==1.2.2",
-  "mcp[cli]==1.27.0",
+  "mcp[cli]==1.22.0",
   "nh3==0.3.4",
   "parable",
   "prompt-toolkit==3.0.52",

--- a/tests/unit_tests/automation/agent/mcp/test_servers.py
+++ b/tests/unit_tests/automation/agent/mcp/test_servers.py
@@ -10,7 +10,7 @@ class TestSentryMCPServer:
 
     @patch("automation.agent.mcp.servers.settings")
     def test_sentry_server_is_enabled_when_url_set(self, mock_settings):
-        mock_settings.SENTRY_URL = "http://mcp-sentry:8000/sse"
+        mock_settings.SENTRY_URL = "http://mcp-sentry:8000/mcp"
         server = SentryMCPServer()
 
         assert server.is_enabled() is True
@@ -32,12 +32,12 @@ class TestSentryMCPServer:
 
     @patch("automation.agent.mcp.servers.settings")
     def test_sentry_get_connection_returns_correct_url(self, mock_settings):
-        mock_settings.SENTRY_URL = "http://mcp-sentry:8000/sse"
+        mock_settings.SENTRY_URL = "http://mcp-sentry:8000/mcp"
         server = SentryMCPServer()
         connection = server.get_connection()
 
-        assert connection["transport"] == "sse"
-        assert connection["url"] == "http://mcp-sentry:8000/sse"
+        assert connection["transport"] == "streamable_http"
+        assert connection["url"] == "http://mcp-sentry:8000/mcp"
 
 
 class TestContext7MCPServer:
@@ -47,7 +47,7 @@ class TestContext7MCPServer:
 
     @patch("automation.agent.mcp.servers.settings")
     def test_context7_server_is_enabled_when_url_set(self, mock_settings):
-        mock_settings.CONTEXT7_URL = "http://mcp-context7:8000/sse"
+        mock_settings.CONTEXT7_URL = "http://mcp-context7:8000/mcp"
         server = Context7MCPServer()
 
         assert server.is_enabled() is True
@@ -69,9 +69,9 @@ class TestContext7MCPServer:
 
     @patch("automation.agent.mcp.servers.settings")
     def test_context7_get_connection_returns_correct_url(self, mock_settings):
-        mock_settings.CONTEXT7_URL = "http://mcp-context7:8000/sse"
+        mock_settings.CONTEXT7_URL = "http://mcp-context7:8000/mcp"
         server = Context7MCPServer()
         connection = server.get_connection()
 
-        assert connection["transport"] == "sse"
-        assert connection["url"] == "http://mcp-context7:8000/sse"
+        assert connection["transport"] == "streamable_http"
+        assert connection["url"] == "http://mcp-context7:8000/mcp"

--- a/uv.lock
+++ b/uv.lock
@@ -528,7 +528,7 @@ requires-dist = [
     { name = "langsmith-fetch", specifier = "==0.3.1" },
     { name = "markdown", specifier = "==3.10.2" },
     { name = "markdownify", specifier = "==1.2.2" },
-    { name = "mcp", extras = ["cli"], specifier = "==1.27.0" },
+    { name = "mcp", extras = ["cli"], specifier = "==1.22.0" },
     { name = "nh3", specifier = "==0.3.4" },
     { name = "parable", git = "https://github.com/ldayton/Parable.git?rev=9f7e15734bd3e5bb9fe252d2491d6f61572f0e57" },
     { name = "prompt-toolkit", specifier = "==3.0.52" },
@@ -1731,7 +1731,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.27.0"
+version = "1.22.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1749,9 +1749,9 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8b/eb/c0cfc62075dc6e1ec1c64d352ae09ac051d9334311ed226f1f425312848a/mcp-1.27.0.tar.gz", hash = "sha256:d3dc35a7eec0d458c1da4976a48f982097ddaab87e278c5511d5a4a56e852b83", size = 607509, upload-time = "2026-04-02T14:48:08.88Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/a2/c5ec0ab38b35ade2ae49a90fada718fbc76811dc5aa1760414c6aaa6b08a/mcp-1.22.0.tar.gz", hash = "sha256:769b9ac90ed42134375b19e777a2858ca300f95f2e800982b3e2be62dfc0ba01", size = 471788, upload-time = "2025-11-20T20:11:28.095Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9c/46/f6b4ad632c67ef35209a66127e4bddc95759649dd595f71f13fba11bdf9a/mcp-1.27.0-py3-none-any.whl", hash = "sha256:5ce1fa81614958e267b21fb2aa34e0aea8e2c6ede60d52aba45fd47246b4d741", size = 215967, upload-time = "2026-04-02T14:48:07.24Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/bb/711099f9c6bb52770f56e56401cdfb10da5b67029f701e0df29362df4c8e/mcp-1.22.0-py3-none-any.whl", hash = "sha256:bed758e24df1ed6846989c909ba4e3df339a27b4f30f1b8b627862a4bade4e98", size = 175489, upload-time = "2025-11-20T20:11:26.542Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
Per-call SSE sessions race on teardown under Python 3.14 + anyio 4.13: when ClientSession.__aexit__ closes the read stream, the sse_reader task can still try to forward a final event and raises anyio.BrokenResourceError, wrapped in an ExceptionGroup that crashes the job run.

Streamable HTTP uses request/response framing without a long-lived reader task, eliminating the race. Endpoint paths move from /sse to /mcp (supergateway default); MCP_SENTRY_URL and MCP_CONTEXT7_URL env var names are preserved.