### PR TITLE
feat(schedules): Redirect run-now to the created activity

### DIFF
--- a/daiv/schedules/views.py
+++ b/daiv/schedules/views.py
@@ -109,8 +109,9 @@ class ScheduleRunNowView(_ScheduleOwnerMixin, LoginRequiredMixin, View):
             messages.error(request, f"Failed to trigger schedule '{schedule.name}'. Please try again.")
             return redirect("schedule_list")
 
+        activity = None
         try:
-            create_activity(
+            activity = create_activity(
                 trigger_type=TriggerType.SCHEDULE,
                 task_result_id=result.id,
                 repo_id=schedule.repo_id,
@@ -123,6 +124,8 @@ class ScheduleRunNowView(_ScheduleOwnerMixin, LoginRequiredMixin, View):
             logger.exception("Failed to create activity for run-now schedule pk=%d (%s)", schedule.pk, schedule.name)
 
         messages.success(request, f"Schedule '{schedule.name}' triggered successfully.")
+        if activity is not None:
+            return redirect("activity_detail", pk=activity.pk)
         return redirect("schedule_list")
 
 

--- a/tests/unit_tests/schedules/test_views.py
+++ b/tests/unit_tests/schedules/test_views.py
@@ -113,12 +113,14 @@ class TestScheduleToggleView:
 
 @pytest.mark.django_db
 class TestScheduleRunNowView:
-    def test_enqueues_job_and_creates_activity(self, member_client, member_user, schedule, mocker):
+    def test_enqueues_job_and_redirects_to_activity_detail(self, member_client, member_user, schedule, mocker):
         mock_result = mocker.MagicMock()
         mock_result.id = uuid.uuid4()
         mock_task = mocker.patch("schedules.views.run_job_task")
         mock_task.enqueue = mocker.MagicMock(return_value=mock_result)
-        mock_create = mocker.patch("schedules.views.create_activity")
+        mock_activity = mocker.MagicMock()
+        mock_activity.pk = uuid.uuid4()
+        mock_create = mocker.patch("schedules.views.create_activity", return_value=mock_activity)
 
         response = member_client.post(reverse("schedule_run_now", args=[schedule.pk]))
 
@@ -135,6 +137,7 @@ class TestScheduleRunNowView:
             user=member_user,
         )
         assert response.status_code == 302
+        assert response.url == reverse("activity_detail", args=[mock_activity.pk])
 
         schedule.refresh_from_db()
         assert schedule.run_count == 0
@@ -148,10 +151,13 @@ class TestScheduleRunNowView:
         mock_result.id = uuid.uuid4()
         mock_task = mocker.patch("schedules.views.run_job_task")
         mock_task.enqueue = mocker.MagicMock(return_value=mock_result)
-        mock_create = mocker.patch("schedules.views.create_activity")
+        mock_activity = mocker.MagicMock()
+        mock_activity.pk = uuid.uuid4()
+        mock_create = mocker.patch("schedules.views.create_activity", return_value=mock_activity)
 
         response = member_client.post(reverse("schedule_run_now", args=[schedule.pk]))
         assert response.status_code == 302
+        assert response.url == reverse("activity_detail", args=[mock_activity.pk])
         mock_create.assert_called_once()
 
     def test_enqueue_failure_returns_error_message(self, member_client, schedule, mocker):
@@ -165,14 +171,16 @@ class TestScheduleRunNowView:
         content = response.content.decode()
         assert "Failed to trigger" in content
 
-    def test_activity_failure_still_succeeds(self, member_client, schedule, mocker):
+    def test_activity_failure_falls_back_to_schedule_list(self, member_client, schedule, mocker):
         mock_result = mocker.MagicMock()
         mock_result.id = uuid.uuid4()
         mock_task = mocker.patch("schedules.views.run_job_task")
         mock_task.enqueue = mocker.MagicMock(return_value=mock_result)
         mocker.patch("schedules.views.create_activity", side_effect=RuntimeError("db error"))
 
-        response = member_client.post(reverse("schedule_run_now", args=[schedule.pk]), follow=True)
-        assert response.status_code == 200
-        content = response.content.decode()
-        assert "triggered successfully" in content
+        response = member_client.post(reverse("schedule_run_now", args=[schedule.pk]))
+        assert response.status_code == 302
+        assert response.url == reverse("schedule_list")
+
+        followed = member_client.get(response.url)
+        assert "triggered successfully" in followed.content.decode()


### PR DESCRIPTION
When a user triggers a schedule via the Run now action, redirect them to the detail page of the activity that was just created, instead of returning them to the schedule list. The success toast is preserved. If activity creation fails (already logged), fall back to the schedule list to retain prior behavior.