### PR TITLE
refactor(agent): Clarify auto-commit and gitlab tool guidance

### DIFF
--- a/daiv/automation/agent/middlewares/git.py
+++ b/daiv/automation/agent/middlewares/git.py
@@ -32,6 +32,12 @@ GIT_SYSTEM_PROMPT = SystemMessagePromptTemplate.from_template(
 - Current branch: {{current_branch}}
 - Default branch: {{default_branch}}
 - Git status: nothing to commit, working tree clean (This is the git status at the start of the conversation. Note that this status is a snapshot in time, and will not update during the conversation.)
+
+**Committing and pushing is automatic.** The harness commits and pushes any file changes you make when your turn ends. You do not need to — and must not try to — run `git add`, `git commit`, `git push`, `git reset`, `git rebase`, `git config`, or any other index- or history-mutating git command. These are hard-blocked by sandbox policy; attempting them or their synonyms (`git stage`, `git update-index`, `git read-tree -m`, `git commit-tree`, …) will fail and waste turns.
+
+- If a task tells you to "commit and push," interpret it as "make the edits" — the harness ships them.
+- If a task asks you to "rebase" or "resolve merge conflicts with the target branch," tell the user this harness does not support rebase-style workflows and stop. Do not try to emulate rebase with `git show`/`git checkout -- <paths>`; it cannot complete without a staging primitive.
+- Read-only git commands (`git log`, `git diff`, `git status`, `git show`, `git branch`, `git ls-files`, …) are allowed and useful for understanding branch state.
 {{#issue_iid}}
 
 You're currently working on issue #{{issue_iid}}.

--- a/daiv/automation/agent/middlewares/git_platform.py
+++ b/daiv/automation/agent/middlewares/git_platform.py
@@ -68,18 +68,21 @@ This tool is best for retrieving the current state of:
 - Output may be truncated bottom-up to {DEFAULT_MAX_OUTPUT_LINES} lines
 
 **How to use it well:**
-- Use `output_mode="simplified"` to discover the right resource (recent items, IDs, pipeline list)
-- Use `output_mode="detailed"` once you know the exact target and need full fields or logs
-- Prefer one targeted query over broad listings
-- If debugging CI, move in this order: pipeline -> jobs -> failing job trace
+- Use `output_mode="simplified"` ONLY for broad `list` discovery where you just need IDs (e.g. `project-merge-request list --state opened`).
+- Use `output_mode="detailed"` for every `get --iid`/`--id` call and for any `list` subcommand where you need status/name/stage fields. `simplified` strips almost every field on `get` and is pure overhead when the target is already known.
+- Do NOT call a resource in `simplified` mode and then re-call the same resource in `detailed` mode — the second call makes the first redundant. Pick the right mode up front.
+- Prefer one targeted query over broad listings.
+- If debugging CI, move in this order: pipeline -> failing jobs -> failing job trace.
 
 **Useful subcommand patterns:**
 - Issue by IID: `project-issue get --iid <issue_iid>`
 - Issue note (comment): `project-issue-note create --issue-iid <issue_iid> --body "<text>"`
 - Merge request by IID: `project-merge-request get --iid <merge_request_iid>`
 - MR note (comment): `project-merge-request-note create --mr-iid <merge_request_iid> --body "<text>"`
-- MR pipelines: `project-merge-request-pipeline list --mr-iid <merge_request_iid>`
-- Pipeline jobs: `project-pipeline-job list --pipeline-id <pipeline_id>`
+- MR pipelines (only when you need the *history* of pipelines for an MR): `project-merge-request-pipeline list --mr-iid <merge_request_iid>`
+  - For the *latest* pipeline status of an MR, do NOT call this — the detailed response of `project-merge-request get --iid <merge_request_iid>` already includes `head_pipeline.status` and `head_pipeline.id`.
+- Pipeline jobs (failures only — preferred for CI triage): `project-pipeline-job list --pipeline-id <pipeline_id> --scope failed`
+- Pipeline jobs (all): `project-pipeline-job list --pipeline-id <pipeline_id>` (use only when you need to see passing/skipped jobs too, e.g. to diagnose a *skipped* job)
 - Job trace: `project-job trace --id <job_id>`
 - Filtered issue list: `project-issue list --state opened --labels bug --page <page_number>`
 - MR diff versions: `project-merge-request-diff list --mr-iid <merge_request_iid>`
@@ -203,8 +206,6 @@ Use this tool for GitLab issues, merge requests, pipelines, jobs, and traces.
 - For issue work, fetch the issue first and use its title/description as the task definition.
 - For merge request work, fetch the MR first; if CI is relevant, inspect its latest pipeline before changing code.
 - For pipeline failures, do not edit code or CI config until you have read the failing job trace(s).
-- Use `output_mode="simplified"` to discover the right resource.
-- Use `output_mode="detailed"` to inspect a specific resource or read traces.
 
 **Inline MR comment policy:**
 - When the user asks for an inline MR comment, do not create a plain merge request note.
@@ -236,11 +237,11 @@ assistant:
 <example>
 user: Fix the failing pipeline for merge request #123.
 assistant:
-  [Call `{GITLAB_TOOL_NAME}("project-merge-request-pipeline list --mr-iid 123", output_mode="simplified")`]
-  [Pick the latest relevant pipeline_id]
-  [Call `{GITLAB_TOOL_NAME}("project-pipeline-job list --pipeline-id <pipeline_id>", output_mode="detailed")`]
-  [Identify failing jobs]
+  [Call `{GITLAB_TOOL_NAME}("project-merge-request get --iid 123", output_mode="detailed")`]
+  [Read `head_pipeline.status` and `head_pipeline.id` directly from the MR detail — no separate pipeline fetch needed for the latest pipeline]
+  [Call `{GITLAB_TOOL_NAME}("project-pipeline-job list --pipeline-id <pipeline_id> --scope failed", output_mode="detailed")`]
   [For each failing job: Call `{GITLAB_TOOL_NAME}("project-job trace --id <job_id>", output_mode="detailed")`]
+  [If no jobs come back with --scope failed (pipeline failed because a job was *skipped* or config-rejected), re-list without --scope to inspect job statuses/stages]
 assistant:
   [Use the traces to form a root-cause hypothesis]
   [Then change code or CI config]

--- a/daiv/automation/agent/middlewares/sandbox.py
+++ b/daiv/automation/agent/middlewares/sandbox.py
@@ -244,10 +244,16 @@ def _check_command_policy(command: str, runtime: ToolRuntime[RuntimeCtx]) -> str
 
     reason_label = result.denial_reason.value if result.denial_reason else "policy"
     matched = result.matched_rule or "unknown"
+    hint = (
+        " This capability is intentionally unavailable — do not rephrase or try synonyms. "
+        "The Git middleware commits and pushes file changes automatically at turn-end "
+        "(see the Git context section in the system prompt)."
+        if matched.startswith("git ")
+        else " This capability is intentionally unavailable — do not rephrase."
+    )
     return (
         f"error: Command blocked by policy ({reason_label}): "
-        f"the command or one of its sub-commands matches the rule '{matched}'. "
-        "Remove or replace the disallowed command segment and retry."
+        f"the command or one of its sub-commands matches the rule '{matched}'.{hint}"
     )
 
 


### PR DESCRIPTION
Trace analysis revealed that the agent didn't know the harness auto-commits at turn-end, so pipeline-fix tasks burned many tool calls attempting git add/commit/push/rebase (all blocked by sandbox policy). Agents also tended to re-fetch gitlab resources in simplified then detailed mode, and to enumerate all pipeline jobs before filtering to failures.

- GIT_SYSTEM_PROMPT: state that commits/pushes are automatic, list hard-blocked verbs and synonyms, note rebase is unsupported, whitelist read-only git commands.
- GitLab tool description: scope output_mode=simplified to list discovery; mandate detailed for get-by-id; forbid same-resource mode upgrades.
- Pipeline-fix example: use project-merge-request get's head_pipeline.status shortcut and project-pipeline-job list --scope failed.
- Sandbox denial message: append a "capability is intentionally unavailable, do not rephrase" hint, with a git-specific branch pointing the agent at the auto-commit contract.