### PR TITLE
refactor(usage-tracking): Propagate usage handler via ContextVar hook

### DIFF
--- a/daiv/automation/agent/usage_tracking.py
+++ b/daiv/automation/agent/usage_tracking.py
@@ -2,14 +2,43 @@ from __future__ import annotations
 
 import dataclasses
 import logging
+from contextlib import contextmanager
+from contextvars import ContextVar
 from dataclasses import dataclass, field
 from decimal import Decimal
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from genai_prices import Usage, calc_price
-from langchain_core.callbacks.usage import UsageMetadataCallbackHandler  # noqa: F401 (re-export)
+from langchain_core.callbacks.usage import UsageMetadataCallbackHandler
+from langchain_core.tracers.context import register_configure_hook
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 logger = logging.getLogger("daiv.usage")
+
+# Registered once at import time. Upstream ``get_usage_metadata_callback`` creates a new
+# ContextVar and hook registration on every call, leaking into the module-level hook list.
+_usage_metadata_var: ContextVar[UsageMetadataCallbackHandler | None] = ContextVar(
+    "daiv_usage_metadata_callback", default=None
+)
+register_configure_hook(_usage_metadata_var, inheritable=True)
+
+
+@contextmanager
+def track_usage_metadata() -> Iterator[UsageMetadataCallbackHandler]:
+    """Activate a ``UsageMetadataCallbackHandler`` for the enclosed block.
+
+    The handler is auto-propagated to every nested ``Runnable`` invocation (including
+    subagents) via the registered ``ContextVar`` hook, so callers don't need to thread
+    callbacks through ``RunnableConfig``.
+    """
+    handler = UsageMetadataCallbackHandler()
+    token = _usage_metadata_var.set(handler)
+    try:
+        yield handler
+    finally:
+        _usage_metadata_var.reset(token)
 
 
 @dataclass
@@ -52,6 +81,7 @@ def _calc_model_cost(model_name: str, usage_metadata: dict[str, Any]) -> Decimal
 def build_usage_summary(handler_data: dict[str, dict[str, Any]]) -> UsageSummary:
     """Build a UsageSummary from ``UsageMetadataCallbackHandler.usage_metadata``."""
     if not handler_data:
+        logger.warning("Usage metadata is empty; callback hook may not have fired on any LLM call")
         return UsageSummary()
 
     total_input = 0

--- a/daiv/automation/agent/utils.py
+++ b/daiv/automation/agent/utils.py
@@ -17,7 +17,6 @@ from core.utils import extract_valid_image_mimetype, is_valid_url
 from .schemas import Image
 
 if TYPE_CHECKING:
-    from langchain_core.callbacks.usage import UsageMetadataCallbackHandler
     from langchain_core.messages import ImageContentBlock
 
     from codebase.context import RuntimeCtx
@@ -291,20 +290,6 @@ def build_langsmith_config(
         config_kwargs["configurable"] = configurable
 
     return RunnableConfig(**config_kwargs)
-
-
-def attach_usage_tracker(config: RunnableConfig) -> UsageMetadataCallbackHandler:
-    """Attach a ``UsageMetadataCallbackHandler`` to *config* and return it.
-
-    After the agent run, call ``build_usage_summary(handler.usage_metadata)``
-    to get the aggregated usage summary.
-    """
-    from .usage_tracking import UsageMetadataCallbackHandler
-
-    handler = UsageMetadataCallbackHandler()
-    callbacks = config.get("callbacks") or []
-    config["callbacks"] = [handler, *callbacks]
-    return handler
 
 
 def extract_body_from_frontmatter(frontmatter_text: str) -> str:

--- a/daiv/codebase/managers/issue_addressor.py
+++ b/daiv/codebase/managers/issue_addressor.py
@@ -8,13 +8,8 @@ from langchain_core.messages import HumanMessage
 from langgraph.checkpoint.redis.aio import AsyncRedisSaver
 
 from automation.agent.graph import create_daiv_agent
-from automation.agent.usage_tracking import build_usage_summary
-from automation.agent.utils import (
-    attach_usage_tracker,
-    build_langsmith_config,
-    extract_text_content,
-    get_daiv_agent_kwargs,
-)
+from automation.agent.usage_tracking import build_usage_summary, track_usage_metadata
+from automation.agent.utils import build_langsmith_config, extract_text_content, get_daiv_agent_kwargs
 from codebase.base import GitPlatform
 from core.constants import BOT_NAME
 from core.utils import generate_uuid
@@ -119,9 +114,9 @@ class IssueAddressorManager(BaseManager):
                     "labels": [label.lower() for label in self.issue.labels],
                 },
             )
-            usage_handler = attach_usage_tracker(agent_config)
             try:
-                result = await daiv_agent.ainvoke({"messages": messages}, config=agent_config, context=self.ctx)
+                with track_usage_metadata() as usage_handler:
+                    result = await daiv_agent.ainvoke({"messages": messages}, config=agent_config, context=self.ctx)
             except Exception:
                 draft_published = await self._recover_draft(
                     daiv_agent, agent_config, entity_label="issue", entity_id=self.issue.iid

--- a/daiv/codebase/managers/review_addressor.py
+++ b/daiv/codebase/managers/review_addressor.py
@@ -12,13 +12,8 @@ from unidiff import LINE_TYPE_CONTEXT, Hunk, PatchedFile
 from unidiff.patch import Line
 
 from automation.agent.graph import create_daiv_agent
-from automation.agent.usage_tracking import build_usage_summary
-from automation.agent.utils import (
-    attach_usage_tracker,
-    build_langsmith_config,
-    extract_text_content,
-    get_daiv_agent_kwargs,
-)
+from automation.agent.usage_tracking import build_usage_summary, track_usage_metadata
+from automation.agent.utils import build_langsmith_config, extract_text_content, get_daiv_agent_kwargs
 from codebase.base import GitPlatform, MergeRequest, Note, NoteDiffPosition, NoteDiffPositionType, NotePositionType
 from core.constants import BOT_NAME
 from core.utils import generate_uuid
@@ -255,21 +250,21 @@ class CommentsAddressorManager(BaseManager):
                     "merge_request_id": self.merge_request.merge_request_id,
                 },
             )
-            usage_handler = attach_usage_tracker(agent_config)
             try:
-                result = await daiv_agent.ainvoke(
-                    {
-                        "messages": [
-                            HumanMessage(
-                                name=mention_comment.notes[0].author.username,
-                                id=mention_comment.notes[0].id,
-                                content=mention_comment.notes[0].body,
-                            )
-                        ]
-                    },
-                    config=agent_config,
-                    context=self.ctx,
-                )
+                with track_usage_metadata() as usage_handler:
+                    result = await daiv_agent.ainvoke(
+                        {
+                            "messages": [
+                                HumanMessage(
+                                    name=mention_comment.notes[0].author.username,
+                                    id=mention_comment.notes[0].id,
+                                    content=mention_comment.notes[0].body,
+                                )
+                            ]
+                        },
+                        config=agent_config,
+                        context=self.ctx,
+                    )
             except Exception:
                 draft_published = await self._recover_draft(
                     daiv_agent,

--- a/daiv/jobs/tasks.py
+++ b/daiv/jobs/tasks.py
@@ -7,13 +7,8 @@ from langgraph.checkpoint.memory import InMemorySaver
 
 from automation.agent.graph import create_daiv_agent
 from automation.agent.results import AgentResult, build_agent_result
-from automation.agent.usage_tracking import build_usage_summary
-from automation.agent.utils import (
-    attach_usage_tracker,
-    build_langsmith_config,
-    extract_text_content,
-    get_daiv_agent_kwargs,
-)
+from automation.agent.usage_tracking import build_usage_summary, track_usage_metadata
+from automation.agent.utils import build_langsmith_config, extract_text_content, get_daiv_agent_kwargs
 from codebase.base import Scope
 from codebase.context import set_runtime_ctx
 
@@ -50,9 +45,9 @@ async def run_job_task(repo_id: str, prompt: str, ref: str | None = None, use_ma
                 extra_metadata={"ref": ref},
                 configurable={"thread_id": str(uuid.uuid4())},
             )
-            usage_handler = attach_usage_tracker(config)
             daiv_agent = await create_daiv_agent(ctx=runtime_ctx, checkpointer=checkpointer, **agent_kwargs)
-            result = await daiv_agent.ainvoke(input_data, config=config, context=runtime_ctx)
+            with track_usage_metadata() as usage_handler:
+                result = await daiv_agent.ainvoke(input_data, config=config, context=runtime_ctx)
     except Exception:
         logger.exception("Job failed for repo_id=%s, ref=%s, use_max=%s", repo_id, ref, use_max)
         raise

--- a/docs/reference/monitoring.md
+++ b/docs/reference/monitoring.md
@@ -195,8 +195,8 @@ DAIV tracks token usage and estimated cost for every agent execution internally 
 
 ### How it works
 
-1. A `UsageMetadataCallbackHandler` (from LangChain) is attached to the `RunnableConfig` before each agent invocation.
-2. The handler captures `usage_metadata` from every LLM call during graph execution — including fallback model invocations and tool-internal model calls.
+1. Each agent invocation runs inside the `track_usage_metadata()` context manager (in `daiv/automation/agent/usage_tracking.py`), which binds a `UsageMetadataCallbackHandler` to a module-level `ContextVar` registered with LangChain's `register_configure_hook`. The handler is automatically inherited by every nested `Runnable` — including subagent invocations — without needing to thread callbacks through `RunnableConfig`.
+2. The handler captures `usage_metadata` from every LLM call during graph execution — including fallback model invocations, tool-internal model calls, and subagents spawned via the `task` tool.
 3. After the run, token counts are aggregated per model and cost is calculated using [genai-prices](https://github.com/pydantic/genai-prices) (maintained by Pydantic).
 4. The usage summary is stored in the `AgentResult` and denormalized onto the `Activity` record for long-term retention.
 
@@ -223,7 +223,6 @@ Token detail buckets (when available from the provider):
 
 ### Known limitations
 
-- **Subagent calls** are not tracked — the `SubAgentMiddleware` creates a separate execution context that does not inherit the parent's callbacks.
 - **Summarization middleware calls** may not be tracked if the middleware overrides the config.
 - If a model is **not in the genai-prices database**, token usage is still recorded but cost is stored as `null`. A warning is logged.
 - Cost estimates are **approximations** based on published list prices. Actual billing may differ based on your provider agreement.

--- a/tests/unit_tests/automation/agent/test_usage_tracking.py
+++ b/tests/unit_tests/automation/agent/test_usage_tracking.py
@@ -122,3 +122,14 @@ class TestBuildUsageSummary:
         summary = build_usage_summary(handler_data)
         model_usage = summary.by_model["claude-sonnet-4-6"]
         assert model_usage["output_token_details"]["reasoning"] == 200
+
+
+class TestEmptyMetadataWarning:
+    def test_empty_handler_data_logs_warning(self, caplog):
+        import logging
+
+        with caplog.at_level(logging.WARNING, logger="daiv.usage"):
+            summary = build_usage_summary({})
+
+        assert summary.input_tokens == 0
+        assert any("callback hook may not have fired" in rec.message for rec in caplog.records)


### PR DESCRIPTION
Replace the per-invocation attach_usage_tracker helper with a track_usage_metadata context manager that binds a
UsageMetadataCallbackHandler to a module-level ContextVar registered via register_configure_hook. The handler is auto-inherited by every nested Runnable, including subagents spawned by SubAgentMiddleware, so callers no longer need to thread callbacks through RunnableConfig. Update issue/review addressors and job runner accordingly, warn when no usage is captured, refresh monitoring docs, and drop the obsolete log_partial_usage_on_failure test class.