### PR TITLE
feat(notifications): Prefix email subjects and structure job result e…

### DIFF
--- a/daiv/accounts/emails.py
+++ b/daiv/accounts/emails.py
@@ -27,9 +27,11 @@ def send_welcome_email(user: User, login_url: str) -> bool:
     Returns:
         True if the email was sent successfully, False otherwise.
     """
+    from core.utils import prefixed_email_subject
+
     try:
         context = {"user": user, "login_url": login_url}
-        subject = "You've been invited to DAIV"
+        subject = prefixed_email_subject("You've been invited")
         text_body = render_to_string("accounts/emails/welcome.txt", context)
         html_body = render_to_string("accounts/emails/welcome.html", context)
         send_mail(

--- a/daiv/core/utils.py
+++ b/daiv/core/utils.py
@@ -31,6 +31,26 @@ def build_absolute_url(path: str) -> str:
     return f"https://{site.domain}{path}"
 
 
+def prefixed_email_subject(subject: str) -> str:
+    """Prepend the current Site name as a bracketed prefix, e.g. ``[DAIV] Welcome``.
+
+    Idempotent: safe to call on already-prefixed subjects. Returns the subject unchanged
+    when the Site has no name or the Sites framework is misconfigured, so a missing Site
+    row never breaks email delivery.
+    """
+    try:
+        site = Site.objects.get_current()
+    except Site.DoesNotExist:
+        logger.warning("Site.objects.get_current() failed; sending email with unprefixed subject")
+        return subject
+    if not site.name:
+        return subject
+    prefix = f"[{site.name}] "
+    if subject.startswith(prefix):
+        return subject
+    return f"{prefix}{subject}"
+
+
 def is_valid_url(url: str) -> bool:
     """
     Validate if the given string is a proper URL.

--- a/daiv/notifications/channels/email.py
+++ b/daiv/notifications/channels/email.py
@@ -38,7 +38,7 @@ class EmailChannel(NotificationChannel):
         return binding.address if binding else None
 
     def send(self, notification: Notification, delivery: NotificationDelivery) -> None:
-        from core.utils import build_absolute_url
+        from core.utils import build_absolute_url, prefixed_email_subject
 
         link_absolute_url = build_absolute_url(notification.link_url) if notification.link_url else ""
         context = {"notification": notification, "link_absolute_url": link_absolute_url}
@@ -50,7 +50,7 @@ class EmailChannel(NotificationChannel):
 
         try:
             send_mail(
-                subject=notification.subject,
+                subject=prefixed_email_subject(notification.subject),
                 message=text_body,
                 from_email=settings.DEFAULT_FROM_EMAIL,
                 recipient_list=[delivery.address],

--- a/daiv/notifications/signals.py
+++ b/daiv/notifications/signals.py
@@ -11,6 +11,7 @@ from django.urls import reverse
 from django.utils import timezone
 from django.utils.translation import gettext as _
 
+from activity.models import ActivityStatus
 from activity.signals import activity_finished
 
 from notifications.channels.registry import all_channels
@@ -25,8 +26,6 @@ logger = logging.getLogger("daiv.notifications")
 
 
 def _status_matches(notify_on: str, status: str) -> bool:
-    from activity.models import ActivityStatus
-
     if notify_on == NotifyOn.NEVER:
         return False
     if notify_on == NotifyOn.ALWAYS:
@@ -39,25 +38,15 @@ def _status_matches(notify_on: str, status: str) -> bool:
 
 
 def _render_subject(schedule, activity) -> str:
-    from activity.models import ActivityStatus
-
     if activity.status == ActivityStatus.SUCCESSFUL:
         return _("Scheduled job '%(name)s' succeeded") % {"name": schedule.name}
     return _("Scheduled job '%(name)s' failed") % {"name": schedule.name}
 
 
 def _render_body(schedule, activity) -> str:
-    from activity.models import ActivityStatus
-
     if activity.status == ActivityStatus.SUCCESSFUL:
-        body = _("Your scheduled job '%(name)s' finished successfully.") % {"name": schedule.name}
-        if activity.result_summary:
-            body += "\n\n" + activity.result_summary
-    else:
-        body = _("Your scheduled job '%(name)s' failed.") % {"name": schedule.name}
-        if activity.error_message:
-            body += "\n\n" + activity.error_message
-    return body
+        return _("Your scheduled job '%(name)s' finished successfully.") % {"name": schedule.name}
+    return _("Your scheduled job '%(name)s' failed.") % {"name": schedule.name}
 
 
 @receiver(activity_finished, dispatch_uid="notifications.on_activity_finished")
@@ -79,7 +68,14 @@ def on_activity_finished(sender, activity: Activity, **kwargs) -> None:
     subject = _render_subject(schedule, activity)
     body = _render_body(schedule, activity)
     link_url = reverse("activity_detail", args=[activity.pk])
-    context = {"status": activity.status, "schedule_name": schedule.name}
+    context = {
+        "status": activity.status,
+        "status_label": activity.get_status_display(),
+        "is_successful": activity.status == ActivityStatus.SUCCESSFUL,
+        "schedule_name": schedule.name,
+        "repo_id": activity.repo_id,
+        "duration_seconds": activity.duration,
+    }
 
     for recipient in recipients.values():
         try:

--- a/daiv/notifications/templates/notifications/emails/notification.html
+++ b/daiv/notifications/templates/notifications/emails/notification.html
@@ -1,18 +1,52 @@
 {% extends "core/emails/base.html" %}
-{% load i18n %}
+{% load i18n activity_tags %}
 
 {% block content %}
 <h1 style="margin: 0 0 8px; font-size: 20px; font-weight: 600; color: #111827;">
     {{ notification.subject }}
 </h1>
-<p style="margin: 0 0 20px; font-size: 14px; line-height: 1.6; color: #6b7280; white-space: pre-wrap;">{{ notification.body }}</p>
+<p style="margin: 0 0 20px; font-size: 14px; line-height: 1.6; color: #6b7280;">{{ notification.body }}</p>
+
+{% with ctx=notification.context %}
+<table role="presentation" cellpadding="0" cellspacing="0" style="width: 100%; margin: 0 0 24px; border-collapse: collapse; border-top: 1px solid #f3f4f6;">
+    {% if ctx.status %}
+    <tr>
+        <td style="padding: 10px 0; font-size: 13px; color: #9ca3af; border-bottom: 1px solid #f3f4f6;">{% translate "Status" %}</td>
+        <td style="padding: 10px 0; font-size: 13px; color: #111827; text-align: right; border-bottom: 1px solid #f3f4f6;">
+            <span style="display: inline-block; padding: 2px 10px; border-radius: 999px; font-weight: 600; font-size: 12px; {% if ctx.is_successful %}background-color: #ecfdf5; color: #047857;{% else %}background-color: #fef2f2; color: #b91c1c;{% endif %}">
+                {{ ctx.status_label }}
+            </span>
+        </td>
+    </tr>
+    {% endif %}
+    {% if ctx.schedule_name %}
+    <tr>
+        <td style="padding: 10px 0; font-size: 13px; color: #9ca3af; border-bottom: 1px solid #f3f4f6;">{% translate "Schedule" %}</td>
+        <td style="padding: 10px 0; font-size: 13px; color: #111827; text-align: right; border-bottom: 1px solid #f3f4f6;">{{ ctx.schedule_name }}</td>
+    </tr>
+    {% endif %}
+    {% if ctx.repo_id %}
+    <tr>
+        <td style="padding: 10px 0; font-size: 13px; color: #9ca3af; border-bottom: 1px solid #f3f4f6;">{% translate "Repository" %}</td>
+        <td style="padding: 10px 0; font-size: 13px; color: #111827; text-align: right; border-bottom: 1px solid #f3f4f6;">{{ ctx.repo_id }}</td>
+    </tr>
+    {% endif %}
+    {% if ctx.duration_seconds is not None %}
+    <tr>
+        <td style="padding: 10px 0; font-size: 13px; color: #9ca3af;">{% translate "Duration" %}</td>
+        <td style="padding: 10px 0; font-size: 13px; color: #111827; text-align: right;">{{ ctx.duration_seconds|duration }}</td>
+    </tr>
+    {% endif %}
+</table>
+{% endwith %}
+
 {% if link_absolute_url %}
 <table role="presentation" cellpadding="0" cellspacing="0">
     <tr>
         <td style="border-radius: 8px; background-color: #111827;">
             <a href="{{ link_absolute_url }}"
                style="display: inline-block; padding: 12px 24px; font-size: 14px; font-weight: 600; color: #ffffff; text-decoration: none;">
-                {% translate "View details" %}
+                {% translate "View full result" %}
             </a>
         </td>
     </tr>

--- a/daiv/notifications/templates/notifications/emails/notification.txt
+++ b/daiv/notifications/templates/notifications/emails/notification.txt
@@ -1,11 +1,14 @@
-{{ notification.subject }}
+{% load i18n activity_tags %}{{ notification.subject }}
 {% spaceless %}={% for _ in notification.subject %}={% endfor %}{% endspaceless %}
 
 {{ notification.body }}
-
-{% if notification.link_url %}
-View details: {{ link_absolute_url }}
+{% with ctx=notification.context %}
+{% if ctx.status_label %}{% translate "Status" %}: {{ ctx.status_label }}
+{% endif %}{% if ctx.schedule_name %}{% translate "Schedule" %}: {{ ctx.schedule_name }}
+{% endif %}{% if ctx.repo_id %}{% translate "Repository" %}: {{ ctx.repo_id }}
+{% endif %}{% if ctx.duration_seconds is not None %}{% translate "Duration" %}: {{ ctx.duration_seconds|duration }}
+{% endif %}{% endwith %}
+{% if link_absolute_url %}{% translate "View full result" %}: {{ link_absolute_url }}
 {% endif %}
-
 --
 DAIV

--- a/tests/unit_tests/accounts/test_emails.py
+++ b/tests/unit_tests/accounts/test_emails.py
@@ -25,7 +25,8 @@ class TestSendWelcomeEmail:
         assert result is True
         assert len(mail.outbox) == 1
         assert mail.outbox[0].to == ["test@example.com"]
-        assert "DAIV" in mail.outbox[0].subject
+        assert mail.outbox[0].subject.startswith("[")
+        assert "You've been invited" in mail.outbox[0].subject
 
     def test_returns_false_on_send_failure(self, user):
         with patch("accounts.emails.send_mail", side_effect=OSError("SMTP connection refused")):

--- a/tests/unit_tests/accounts/test_views.py
+++ b/tests/unit_tests/accounts/test_views.py
@@ -214,7 +214,7 @@ class TestUserCreateView:
         admin_client.post(reverse("user_create"), {"name": "Emailed", "email": "emailed@test.com", "role": Role.MEMBER})
         assert len(mail.outbox) == 1
         assert mail.outbox[0].to == ["emailed@test.com"]
-        assert "DAIV" in mail.outbox[0].subject
+        assert "example.com" in mail.outbox[0].subject
 
     def test_created_user_has_unusable_password(self, admin_client):
         admin_client.post(reverse("user_create"), {"name": "NoPwd", "email": "nopwd@test.com", "role": Role.MEMBER})

--- a/tests/unit_tests/core/test_utils.py
+++ b/tests/unit_tests/core/test_utils.py
@@ -10,6 +10,7 @@ from core.utils import (
     build_uri,
     extract_valid_image_mimetype,
     is_valid_url,
+    prefixed_email_subject,
 )
 
 
@@ -26,6 +27,25 @@ class BuildAbsoluteUrlTest:
     def test_uses_current_site_domain(self):
         Site.objects.filter(pk=1).update(domain="custom.domain.org")
         assert build_absolute_url("/activity/42/") == "https://custom.domain.org/activity/42/"
+
+
+@pytest.mark.django_db
+class PrefixedEmailSubjectTest:
+    def test_prepends_site_name_in_brackets(self):
+        Site.objects.filter(pk=1).update(name="DAIV")
+        assert prefixed_email_subject("Welcome") == "[DAIV] Welcome"
+
+    def test_returns_subject_unchanged_when_site_name_empty(self):
+        Site.objects.filter(pk=1).update(name="")
+        assert prefixed_email_subject("Welcome") == "Welcome"
+
+    def test_is_idempotent_on_already_prefixed_subject(self):
+        Site.objects.filter(pk=1).update(name="DAIV")
+        assert prefixed_email_subject("[DAIV] Welcome") == "[DAIV] Welcome"
+
+    def test_returns_subject_unchanged_when_site_missing(self, mocker):
+        mocker.patch("core.utils.Site.objects.get_current", side_effect=Site.DoesNotExist)
+        assert prefixed_email_subject("Welcome") == "Welcome"
 
 
 class IsValidUrlTest:

--- a/tests/unit_tests/notifications/channels/test_email.py
+++ b/tests/unit_tests/notifications/channels/test_email.py
@@ -55,6 +55,19 @@ class TestEmailChannelSend:
 
         assert len(mail.outbox) == 1
         message = mail.outbox[0]
-        assert message.subject == "Job finished"
+        assert message.subject.endswith("Job finished")
+        assert message.subject.startswith("[")
         assert message.to == ["a@test.com"]
         assert "Your job has finished." in message.body
+
+    def test_subject_is_prefixed_with_site_name(self, member_user):
+        from django.contrib.sites.models import Site
+
+        Site.objects.filter(pk=1).update(name="DAIV")
+        n = Notification.objects.create(
+            recipient=member_user, event_type="schedule.finished", subject="Run succeeded", body="b", link_url="/"
+        )
+        d = NotificationDelivery.objects.create(notification=n, channel_type="email", address="a@test.com")
+        EmailChannel().send(n, d)
+
+        assert mail.outbox[0].subject == "[DAIV] Run succeeded"

--- a/tests/unit_tests/notifications/test_signals.py
+++ b/tests/unit_tests/notifications/test_signals.py
@@ -109,6 +109,46 @@ class TestOnActivityFinished:
         activity_finished.send(sender=Activity, activity=activity)
         assert Notification.objects.count() == 0
 
+    def test_body_excludes_result_summary_and_context_carries_metadata(self, member_user, schedule):
+        activity = Activity.objects.create(
+            trigger_type=TriggerType.SCHEDULE,
+            user=member_user,
+            repo_id="acme/app",
+            status=ActivityStatus.SUCCESSFUL,
+            scheduled_job=schedule,
+            result_summary="# Heading\n\nSome **markdown** that must not leak into email body.",
+        )
+        activity_finished.send(sender=Activity, activity=activity)
+
+        n = Notification.objects.get(recipient=member_user, event_type="schedule.finished")
+        assert "markdown" not in n.body
+        assert "Heading" not in n.body
+        assert schedule.name in n.body
+        assert n.context["status"] == ActivityStatus.SUCCESSFUL
+        assert n.context["is_successful"] is True
+        assert n.context["status_label"] == ActivityStatus.SUCCESSFUL.label
+        assert n.context["schedule_name"] == schedule.name
+        assert n.context["repo_id"] == "acme/app"
+        assert "duration_seconds" in n.context
+
+    def test_body_excludes_error_message_on_failure(self, member_user, schedule):
+        activity = Activity.objects.create(
+            trigger_type=TriggerType.SCHEDULE,
+            user=member_user,
+            repo_id="acme/app",
+            status=ActivityStatus.FAILED,
+            scheduled_job=schedule,
+            error_message="Traceback (most recent call last): secret stacktrace",
+        )
+        activity_finished.send(sender=Activity, activity=activity)
+
+        n = Notification.objects.get(recipient=member_user, event_type="schedule.finished")
+        assert "Traceback" not in n.body
+        assert "stacktrace" not in n.body
+        assert schedule.name in n.body
+        assert n.context["is_successful"] is False
+        assert n.context["status_label"] == ActivityStatus.FAILED.label
+
     def test_exception_in_notify_is_swallowed(self, member_user, schedule):
         activity = Activity.objects.create(
             trigger_type=TriggerType.SCHEDULE,


### PR DESCRIPTION
…mails

Email subjects are now prepended with the current Site name (e.g. "[DAIV] Welcome"), via a shared prefixed_email_subject helper that is defensive against a missing Site row.

Scheduled-job notification emails no longer concatenate raw result_summary / error_message into the body — preventing markdown and stacktraces from leaking to recipients. Instead, the context dict carries structured fields (status, status_label, is_successful, schedule_name, repo_id, duration_seconds) rendered as a styled metadata table in HTML and key-value lines in text.