### PR TITLE
fix(activity): Refresh detail page on status transitions

### DIFF
--- a/daiv/activity/static/activity/js/activity-stream.js
+++ b/daiv/activity/static/activity/js/activity-stream.js
@@ -1,14 +1,14 @@
 /**
  * Alpine.js components for real-time activity status updates via SSE.
  *
- * activityStream (list page) — tracks multiple activities:
+ * activityStream (list page) — tracks multiple activities in place:
  *   dotClass(id, fallback)    → "status-dot-{variant}" CSS class
  *   statusClass(id, fallback) → "status-badge-{variant}" CSS class
  *   statusLabel(id, fallback) → human-readable label
  *
- * activityDetail (detail page) — tracks one activity, reloads on completion:
- *   statusClass() → "status-badge-{variant}" CSS class
- *   statusLabel() → human-readable label
+ * activityDetail (detail page) — subscribes to one activity and reloads the
+ * page on any state change so server-rendered fields (started_at, finished_at,
+ * elapsed counter, duration, timeline dots) reflect the new state.
  */
 document.addEventListener("alpine:init", () => {
     function statusVariantFor(status) {
@@ -53,34 +53,22 @@ document.addEventListener("alpine:init", () => {
         },
     }));
 
+    // The SSE endpoint always emits the current state on first poll (it doesn't
+    // know what the page rendered with), so reload only when the status has
+    // actually drifted from what the template saw — otherwise a RUNNING page
+    // would reload every poll interval.
     Alpine.data("activityDetail", (streamUrl, activityId, initialStatus) => ({
-        currentStatus: initialStatus || null,
         init() {
             const url = streamUrl + "?ids=" + activityId;
             const source = new EventSource(url);
             source.onmessage = (event) => {
                 const data = JSON.parse(event.data);
-                if (data.done) {
-                    source.close();
-                    window.location.reload();
-                    return;
-                }
-                this.currentStatus = data.status;
-                if (data.status === "SUCCESSFUL" || data.status === "FAILED") {
+                if (data.done || (data.status && data.status !== initialStatus)) {
                     source.close();
                     window.location.reload();
                 }
             };
             source.onerror = () => source.close();
-        },
-        statusClass() {
-            return "status-badge-" + statusVariantFor(this.currentStatus);
-        },
-        dotClass() {
-            return "status-dot-" + statusVariantFor(this.currentStatus);
-        },
-        statusLabel() {
-            return statusLabelFor(this.currentStatus);
         },
     }));
 });

--- a/daiv/activity/templates/activity/_status_pill.html
+++ b/daiv/activity/templates/activity/_status_pill.html
@@ -1,10 +1,10 @@
 {% comment %}
 Status pill. Required: variant, label.
-Live modes: pk+status (list rows) or live=True (detail). Otherwise static.
+Pass pk+status (list rows) to wire up in-place Alpine updates. Otherwise static.
 {% endcomment %}
 <span class="status-badge status-badge-{{ variant }} inline-flex items-center gap-1.5"
-      {% if pk %}:class="statusClass('{{ pk }}', '{{ status }}')"{% elif live %}:class="statusClass()"{% endif %}>
+      {% if pk %}:class="statusClass('{{ pk }}', '{{ status }}')"{% endif %}>
     <span class="status-dot status-dot-{{ variant }}"
-          {% if pk %}:class="dotClass('{{ pk }}', '{{ status }}')"{% elif live %}:class="dotClass()"{% endif %}></span>
-    <span {% if pk %}x-text="statusLabel('{{ pk }}', '{{ label|escapejs }}')"{% elif live %}x-text="statusLabel()"{% endif %}>{{ label }}</span>
+          {% if pk %}:class="dotClass('{{ pk }}', '{{ status }}')"{% endif %}></span>
+    <span {% if pk %}x-text="statusLabel('{{ pk }}', '{{ label|escapejs }}')"{% endif %}>{{ label }}</span>
 </span>

--- a/daiv/activity/templates/activity/_status_strip.html
+++ b/daiv/activity/templates/activity/_status_strip.html
@@ -2,7 +2,7 @@
 <div class="animate-fade-up mt-6 flex flex-wrap items-center gap-3 rounded-2xl border border-white/[0.06] bg-white/[0.02] px-4 py-3"
      style="animation-delay: 80ms">
 
-    {% include "activity/_status_pill.html" with variant=activity.status|status_variant label=activity.get_status_display live=is_in_flight %}
+    {% include "activity/_status_pill.html" with variant=activity.status|status_variant label=activity.get_status_display %}
 
     {% include "activity/_trigger_badge.html" with trigger_type=activity.trigger_type trigger_type_display=activity.get_trigger_type_display %}
 


### PR DESCRIPTION
The activity detail page only reloaded when the run reached a terminal state, so the PENDING -> RUNNING transition left server-rendered fields (Started timestamp, elapsed counter, duration) stuck on their initial snapshot. The status pill updated via Alpine, hiding the staleness.

Reload on any status drift from what the template saw. Guarded against the server's first-poll redundant emission to avoid a reload loop while RUNNING. Drop the now-redundant live-binding branch from _status_pill.