### PR TITLE
refactor(sandbox): Reuse one httpx pool per agent run

### DIFF
--- a/daiv/automation/agent/middlewares/file_system.py
+++ b/daiv/automation/agent/middlewares/file_system.py
@@ -97,22 +97,37 @@ def _format_sync_error(reason: str, *, rollback_ok: bool) -> str:
 class _SandboxSyncer:
     """Mirrors successful local writes to the sandbox session associated with the agent run.
 
-    Bundles the backend, the working_dir → /repo mapping, the sandbox client factory, and a
-    single lock that serialises the upstream-write→sandbox-sync critical section across all
-    concurrent write_file/edit_file calls in one agent run, so rollback can never overwrite a
-    sibling tool call's edit. The edit-path snapshot is taken outside the lock — if it fails we
-    short-circuit to upstream's canonical "not found" error rather than acquiring the lock for
-    a doomed call.
+    Bundles the backend, the working_dir → /repo mapping, a long-lived sandbox client (opened
+    lazily on first mirror so its TCP+TLS pool is reused across every write/edit in the run),
+    and a single lock that serialises the upstream-write→sandbox-sync critical section across
+    all concurrent write_file/edit_file calls in one agent run, so rollback can never overwrite
+    a sibling tool call's edit. The edit-path snapshot is taken outside the lock — if it fails
+    we short-circuit to upstream's canonical "not found" error rather than acquiring the lock
+    for a doomed call.
     """
 
     backend: Any
     working_dir: Path
-    client_factory: Callable[[], DAIVSandboxClient]
+    client: DAIVSandboxClient
     lock: asyncio.Lock = field(default_factory=asyncio.Lock)
     _resolved_working_dir: Path = field(init=False, repr=False)
+    _opened: bool = field(default=False, init=False, repr=False)
 
     def __post_init__(self) -> None:
         self._resolved_working_dir = self.working_dir.resolve()
+
+    async def _ensure_client(self) -> DAIVSandboxClient:
+        # Callers always invoke this from inside ``self.lock`` (via ``mirror``),
+        # so the open-once flag does not need its own guard.
+        if not self._opened:
+            await self.client.open()
+            self._opened = True
+        return self.client
+
+    async def aclose(self) -> None:
+        if self._opened:
+            self._opened = False
+            await self.client.close()
 
     def sandbox_path(self, local_path: str | Path) -> str:
         """Map ``<working_dir>/<rel>`` → ``/repo/<rel>``. Raises ``ValueError`` if outside ``working_dir``."""
@@ -139,7 +154,8 @@ class _SandboxSyncer:
             mutations=[PutMutation(path=sandbox_path, content=base64.b64encode(content_bytes), mode=mode)]
         )
         try:
-            response = await self.client_factory().apply_file_mutations(session_id, request)
+            client = await self._ensure_client()
+            response = await client.apply_file_mutations(session_id, request)
         except Exception as exc:
             logger.exception("sandbox apply_file_mutations failed for %s", sandbox_path)
             return _format_sync_error(f"sandbox sync raised: {exc}", rollback_ok=rollback())
@@ -342,9 +358,8 @@ class FilesystemMiddleware(BaseFilesystemMiddleware):
         # Resolve the factory at construction time so test monkeypatching of
         # `DAIVSandboxClient` on this module sticks (default args are captured
         # at function-definition time, which would defeat the monkeypatch).
-        return _SandboxSyncer(
-            backend=backend, working_dir=Path(working_dir), client_factory=sandbox_client_factory or DAIVSandboxClient
-        )
+        factory = sandbox_client_factory or DAIVSandboxClient
+        return _SandboxSyncer(backend=backend, working_dir=Path(working_dir), client=factory())
 
     def _create_write_file_tool(self) -> BaseTool:
         original = super()._create_write_file_tool()
@@ -353,3 +368,8 @@ class FilesystemMiddleware(BaseFilesystemMiddleware):
     def _create_edit_file_tool(self) -> BaseTool:
         original = super()._create_edit_file_tool()
         return self._syncer.wrap_edit_tool(original) if self._syncer is not None else original
+
+    async def aafter_agent(self, state, runtime) -> dict | None:
+        if self._syncer is not None:
+            await self._syncer.aclose()
+        return await super().aafter_agent(state, runtime)

--- a/daiv/automation/agent/middlewares/sandbox.py
+++ b/daiv/automation/agent/middlewares/sandbox.py
@@ -12,7 +12,7 @@ import httpx
 from langchain.agents.middleware import AgentMiddleware, AgentState, ModelRequest, ModelResponse
 from langchain.agents.middleware.types import OmitFromOutput
 from langchain.tools import ToolRuntime  # noqa: TC002
-from langchain_core.tools import tool
+from langchain_core.tools import BaseTool, tool
 from langgraph.typing import StateT  # noqa: TC002
 
 from codebase.context import RuntimeCtx  # noqa: TC001
@@ -145,35 +145,6 @@ Git safety (highest priority):
 - VERY IMPORTANT: If a user request is prohibited by these rules, respond without running bash."""  # noqa: E501
 
 
-@tool(BASH_TOOL_NAME, description=BASH_TOOL_DESCRIPTION)
-async def bash_tool(command: Annotated[str, "The command to execute."], runtime: ToolRuntime[RuntimeCtx]) -> str:
-    """
-    Tool to run a list of Bash commands in a persistent shell session.
-    """
-    denial_error = _check_command_policy(command, runtime)
-    if denial_error:
-        return denial_error
-
-    response = await _run_bash_commands([command], runtime.state["session_id"])
-    if response is None:
-        return (
-            "error: Failed to run command. Verify that the command is valid. "
-            "If the commands are valid, maybe the bash tool is not working properly."
-        )
-
-    if response.patch:
-        try:
-            GitManager(runtime.context.gitrepo).apply_patch(response.patch)
-        except Exception:
-            logger.exception("[%s] Error applying patch to the repository.", bash_tool.name)
-            return "error: Failed to persist the changes. The bash tool is not working properly."
-
-    return json.dumps({
-        "commands": [result.model_dump(mode="json") for result in response.results],
-        "files_changed": files_changed_from_patch(response.patch),
-    })
-
-
 def _check_command_policy(command: str, runtime: ToolRuntime[RuntimeCtx]) -> str | None:
     """
     Parse *command* with Parable and evaluate it against the effective policy.
@@ -270,10 +241,12 @@ def _make_repo_archive(working_dir: str) -> bytes:
     return buf.getvalue()
 
 
-async def _run_bash_commands(commands: list[str], session_id: str) -> RunCommandsResponse | None:
-    """Run bash commands in the existing sandbox session."""
+async def _run_bash_commands(
+    client: DAIVSandboxClient, commands: list[str], session_id: str
+) -> RunCommandsResponse | None:
+    """Run bash commands in the existing sandbox session using the supplied long-lived client."""
     try:
-        return await DAIVSandboxClient().run_commands(session_id, RunCommandsRequest(commands=commands, fail_fast=True))
+        return await client.run_commands(session_id, RunCommandsRequest(commands=commands, fail_fast=True))
     except httpx.RequestError:
         logger.exception("Unexpected error calling sandbox API.")
         return None
@@ -325,14 +298,54 @@ class SandboxMiddleware(AgentMiddleware):
             raise RuntimeError("Sandbox API key is not configured. Set DAIV_SANDBOX_API_KEY or use the config UI.")
 
         self.close_session = close_session
-        self.tools = [bash_tool]
+        self._client: DAIVSandboxClient | None = None
+        self.tools = [self._build_bash_tool()]
+
+    def _build_bash_tool(self) -> BaseTool:
+        """Build a bash tool bound to this middleware's per-run sandbox client."""
+
+        @tool(BASH_TOOL_NAME, description=BASH_TOOL_DESCRIPTION)
+        async def bash_tool(
+            command: Annotated[str, "The command to execute."], runtime: ToolRuntime[RuntimeCtx]
+        ) -> str:
+            """Run a Bash command in the persistent shell session of this run."""
+            denial_error = _check_command_policy(command, runtime)
+            if denial_error:
+                return denial_error
+
+            if self._client is None:
+                raise RuntimeError("SandboxMiddleware bash tool invoked before abefore_agent opened the sandbox client")
+
+            response = await _run_bash_commands(self._client, [command], runtime.state["session_id"])
+            if response is None:
+                return (
+                    "error: Sandbox call failed (transport or HTTP error — see server logs). "
+                    "The bash tool may be unavailable for this run."
+                )
+
+            if response.patch:
+                try:
+                    GitManager(runtime.context.gitrepo).apply_patch(response.patch)
+                except Exception:
+                    logger.exception("[%s] Error applying patch to the repository.", BASH_TOOL_NAME)
+                    return "error: Failed to persist the changes. The bash tool is not working properly."
+
+            return json.dumps({
+                "commands": [result.model_dump(mode="json") for result in response.results],
+                "files_changed": files_changed_from_patch(response.patch),
+            })
+
+        return bash_tool
 
     async def abefore_agent(self, state: StateT, runtime: Runtime[RuntimeCtx]) -> dict[str, str] | None:
         """
-        Prepare state for lazy sandbox session start.
+        Open the per-run sandbox client and lazily start a session.
 
         Starts the session, seeds the workspace from the on-disk repo, and
-        cleans up the session on seed failure to avoid container leaks.
+        cleans up the session on seed failure to avoid container leaks. The
+        client stays open for the rest of the agent run so every bash call
+        and (for the file-system middleware) every file mirror reuses the
+        same connection pool.
 
         Args:
             state (StateT): The state of the agent.
@@ -341,35 +354,49 @@ class SandboxMiddleware(AgentMiddleware):
         Returns:
             dict[str, str] | None: The state updates with the sandbox session ID.
         """
-        if not self.close_session and "session_id" in state:
-            # Subagent path: the parent already started a session and owns its
-            # lifecycle. Skip starting a duplicate.
-            return None
-
         client = DAIVSandboxClient()
-        session_id = await client.start_session(
-            StartSessionRequest(
-                base_image=runtime.context.config.sandbox.base_image,
-                extract_patch=True,
-                network_enabled=runtime.context.config.sandbox.network_enabled,
-                memory_bytes=runtime.context.config.sandbox.memory_bytes,
-                cpus=runtime.context.config.sandbox.cpus,
-            )
-        )
+        await client.open()
+        self._client = client
+
         try:
-            archive = await asyncio.to_thread(_make_repo_archive, runtime.context.gitrepo.working_dir)
-            await client.seed_session(session_id, repo_archive=archive)
-        except Exception:
+            if not self.close_session and "session_id" in state:
+                # Subagent path: parent owns session lifecycle; we just keep our client open
+                # so bash calls reuse the pool.
+                return None
+
+            session_id = await client.start_session(
+                StartSessionRequest(
+                    base_image=runtime.context.config.sandbox.base_image,
+                    extract_patch=True,
+                    network_enabled=runtime.context.config.sandbox.network_enabled,
+                    memory_bytes=runtime.context.config.sandbox.memory_bytes,
+                    cpus=runtime.context.config.sandbox.cpus,
+                )
+            )
             try:
-                await client.close_session(session_id)
+                archive = await asyncio.to_thread(_make_repo_archive, runtime.context.gitrepo.working_dir)
+                await client.seed_session(session_id, repo_archive=archive)
             except Exception:
-                logger.exception("Failed to close session %s after seed failure", session_id)
+                try:
+                    await client.close_session(session_id)
+                except Exception:
+                    logger.exception("Failed to close session %s after seed failure", session_id)
+                raise
+        except BaseException:
+            # Release the client we just opened; otherwise its httpx pool leaks for the run.
+            await client.close()
+            self._client = None
             raise
         return {"session_id": session_id}
 
     async def aafter_agent(self, state: StateT, runtime: Runtime[RuntimeCtx]) -> dict[str, str] | None:
         """
-        Close the sandbox session after the agent finishes the execution loop.
+        Close the sandbox session and the long-lived client after the agent finishes.
+
+        ``aafter_agent`` only runs on a successful agent loop; on agent failure the
+        client is not awaited closed and may leak its httpx pool until process
+        teardown. Acceptable today because each run is short-lived; revisit if
+        agent runs grow long enough that leaked pools matter.
 
         Args:
             state (StateT): The state of the agent.
@@ -378,22 +405,33 @@ class SandboxMiddleware(AgentMiddleware):
         Returns:
             dict[str, str] | None: The state updates with the closed sandbox session ID.
         """
-        if self.close_session and "session_id" in state and state["session_id"] is not None:
-            session_id = state["session_id"]
-            try:
-                await DAIVSandboxClient().close_session(session_id)
-            except httpx.HTTPStatusError as exc:
-                status = exc.response.status_code
-                if status in (404, 409):
-                    logger.debug("Sandbox session %s already closed (status=%s)", session_id, status)
-                else:
-                    logger.exception(
-                        "Sandbox session %s close returned status=%s; container may have leaked", session_id, status
-                    )
-            except httpx.RequestError:
-                logger.exception("Sandbox session %s close request failed; container may have leaked", session_id)
-            return {"session_id": None}
-        return None
+        client = self._client
+        try:
+            if client is not None and self.close_session and "session_id" in state and state["session_id"] is not None:
+                session_id = state["session_id"]
+                try:
+                    await client.close_session(session_id)
+                except httpx.HTTPStatusError as exc:
+                    status = exc.response.status_code
+                    if status in (404, 409):
+                        logger.debug("Sandbox session %s already closed (status=%s)", session_id, status)
+                    else:
+                        logger.exception(
+                            "Sandbox session %s close returned status=%s; container may have leaked", session_id, status
+                        )
+                except httpx.RequestError:
+                    logger.exception("Sandbox session %s close request failed; container may have leaked", session_id)
+                return {"session_id": None}
+            return None
+        finally:
+            if client is not None:
+                # Wrap teardown so a transport-level failure can't mask whatever close_session
+                # (or another caller) was already raising.
+                try:
+                    await client.close()
+                except Exception:
+                    logger.exception("Failed to close sandbox httpx client; pool may have leaked")
+                self._client = None
 
     async def awrap_model_call(
         self, request: ModelRequest, handler: Callable[[ModelRequest], Awaitable[ModelResponse]]

--- a/daiv/core/sandbox/client.py
+++ b/daiv/core/sandbox/client.py
@@ -1,5 +1,7 @@
-import base64
+from __future__ import annotations
+
 import logging
+from typing import Self
 
 import httpx
 
@@ -11,7 +13,6 @@ from .schemas import (
     ApplyMutationsResponse,
     RunCommandsRequest,
     RunCommandsResponse,
-    SeedSessionRequest,
     StartSessionRequest,
 )
 
@@ -21,10 +22,37 @@ logger = logging.getLogger("daiv.sandbox")
 class DAIVSandboxClient:
     """
     Client to interact with the daiv-sandbox service.
+
+    Open the client once and reuse it for the lifetime of an agent run so a
+    single ``httpx.AsyncClient`` (with its TCP+TLS connection pool) is shared
+    across every call. Headers and timeout are resolved from ``site_settings``
+    on open, so runtime changes propagate on the next open.
     """
 
     def __init__(self):
         self.url = settings.SANDBOX_URL.unicode_string()
+        self._client: httpx.AsyncClient | None = None
+
+    async def open(self) -> Self:
+        """Open the underlying ``httpx.AsyncClient``. Re-entry is rejected to avoid leaking the previous client."""
+        if self._client is not None:
+            raise RuntimeError("DAIVSandboxClient is already open; nested entry would leak the previous httpx client")
+        self._client = httpx.AsyncClient(
+            base_url=self.url, headers=self._get_headers(), timeout=site_settings.sandbox_timeout
+        )
+        return self
+
+    async def close(self) -> None:
+        """Close the underlying ``httpx.AsyncClient``. Safe to call when not open."""
+        client, self._client = self._client, None
+        if client is not None:
+            await client.aclose()
+
+    async def __aenter__(self) -> Self:
+        return await self.open()
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        await self.close()
 
     async def start_session(self, request: StartSessionRequest) -> str:
         """
@@ -36,31 +64,31 @@ class DAIVSandboxClient:
         Returns:
             The session ID.
         """
-        async with httpx.AsyncClient(
-            timeout=site_settings.sandbox_timeout, base_url=self.url, headers=self._get_headers()
-        ) as client:
-            response = await client.post("session/", json=request.model_dump(mode="json"))
-            response.raise_for_status()
-            return response.json()["session_id"]
+        response = await self._client.post("session/", json=request.model_dump(mode="json"))
+        response.raise_for_status()
+        return response.json()["session_id"]
 
-    async def seed_session(self, session_id: str, repo_archive: bytes) -> None:
+    async def seed_session(
+        self, session_id: str, repo_archive: bytes | None = None, skills_archive: bytes | None = None
+    ) -> None:
         """
-        Seed a session with the initial state of /repo.
+        Seed a session with the initial state of /repo and/or /skills.
 
-        One-shot per session. A 409 from the sandbox (already seeded) is
-        treated as a no-op so retries and checkpoint replays are safe.
+        One-shot per session: a 409 from the sandbox (already seeded) is treated
+        as a no-op so retries and checkpoint replays are safe.
         """
-        async with httpx.AsyncClient(
-            timeout=site_settings.sandbox_timeout, base_url=self.url, headers=self._get_headers()
-        ) as client:
-            response = await client.post(
-                f"session/{session_id}/seed/",
-                json=SeedSessionRequest(repo_archive=base64.b64encode(repo_archive)).model_dump(mode="json"),
-            )
-            if response.status_code == 409:
-                logger.info("Sandbox session %s already seeded; skipping", session_id)
-                return
-            response.raise_for_status()
+        files = {
+            name: (name, archive, "application/octet-stream")
+            for name, archive in (("repo_archive", repo_archive), ("skills_archive", skills_archive))
+            if archive is not None
+        }
+        if not files:
+            raise ValueError("seed_session requires at least one of repo_archive or skills_archive")
+        response = await self._client.post(f"session/{session_id}/seed/", files=files)
+        if response.status_code == 409:
+            logger.info("Sandbox session %s already seeded; skipping", session_id)
+            return
+        response.raise_for_status()
 
     async def apply_file_mutations(self, session_id: str, request: ApplyMutationsRequest) -> ApplyMutationsResponse:
         """
@@ -70,12 +98,9 @@ class DAIVSandboxClient:
         Caller (e.g. the sync wrapper) is responsible for rolling back local
         state when `ok=False` or when this method raises.
         """
-        async with httpx.AsyncClient(
-            timeout=site_settings.sandbox_timeout, base_url=self.url, headers=self._get_headers()
-        ) as client:
-            response = await client.post(f"session/{session_id}/files/", json=request.model_dump(mode="json"))
-            response.raise_for_status()
-            return ApplyMutationsResponse.model_validate(response.json())
+        response = await self._client.post(f"session/{session_id}/files/", json=request.model_dump(mode="json"))
+        response.raise_for_status()
+        return ApplyMutationsResponse.model_validate(response.json())
 
     async def run_commands(self, session_id: str, request: RunCommandsRequest) -> RunCommandsResponse:
         """
@@ -88,12 +113,9 @@ class DAIVSandboxClient:
         Returns:
             RunCommandResponse: The response from running the commands.
         """
-        async with httpx.AsyncClient(
-            timeout=site_settings.sandbox_timeout, base_url=self.url, headers=self._get_headers()
-        ) as client:
-            response = await client.post(f"session/{session_id}/", json=request.model_dump(mode="json"))
-            response.raise_for_status()
-            return RunCommandsResponse.model_validate(response.json())
+        response = await self._client.post(f"session/{session_id}/", json=request.model_dump(mode="json"))
+        response.raise_for_status()
+        return RunCommandsResponse.model_validate(response.json())
 
     async def close_session(self, session_id: str):
         """
@@ -102,11 +124,8 @@ class DAIVSandboxClient:
         Args:
             session_id (str): The session ID.
         """
-        async with httpx.AsyncClient(
-            timeout=site_settings.sandbox_timeout, base_url=self.url, headers=self._get_headers()
-        ) as client:
-            response = await client.delete(f"session/{session_id}/")
-            response.raise_for_status()
+        response = await self._client.delete(f"session/{session_id}/")
+        response.raise_for_status()
 
     def _get_headers(self) -> dict[str, str]:
         """

--- a/daiv/core/sandbox/schemas.dump.json
+++ b/daiv/core/sandbox/schemas.dump.json
@@ -294,22 +294,6 @@
     "title": "RunResult",
     "type": "object"
   },
-  "SeedSessionRequest": {
-    "description": "Initial state for a freshly-started session.\n\nFuture-extensible: e.g. a `skills_archive: Base64Bytes | None = None` field\nwill land here when skill seeding is implemented (spec \u00a73.15).",
-    "properties": {
-      "repo_archive": {
-        "description": "Tar archive that becomes the initial state of /repo.",
-        "format": "base64",
-        "title": "Repo Archive",
-        "type": "string"
-      }
-    },
-    "required": [
-      "repo_archive"
-    ],
-    "title": "SeedSessionRequest",
-    "type": "object"
-  },
   "StartSessionRequest": {
     "properties": {
       "base_image": {

--- a/daiv/core/sandbox/schemas.py
+++ b/daiv/core/sandbox/schemas.py
@@ -79,7 +79,3 @@ class MutationResult(BaseModel):
 
 class ApplyMutationsResponse(BaseModel):
     results: list[MutationResult]
-
-
-class SeedSessionRequest(BaseModel):
-    repo_archive: Base64Bytes = Field(description="Tar archive that becomes the initial state of /repo.")

--- a/tests/unit_tests/automation/agent/middlewares/test_file_system.py
+++ b/tests/unit_tests/automation/agent/middlewares/test_file_system.py
@@ -382,3 +382,44 @@ async def test_upstream_success_prefixes_remain_stable(working_repo):
     assert edit_result.startswith("Successfully replaced"), (
         f"upstream changed edit success format; update wrap_edit_tool prefix check: {edit_result!r}"
     )
+
+
+class TestSandboxSyncerLifecycle:
+    """Cover the open-once-on-first-mirror / close-once invariant of `_SandboxSyncer`."""
+
+    @staticmethod
+    def _make_syncer(working_repo, fake_client):
+        from automation.agent.middlewares.file_system import _SandboxSyncer
+
+        return _SandboxSyncer(backend=object(), working_dir=working_repo, client=fake_client)
+
+    async def test_aclose_is_noop_when_never_opened(self, fake_client, working_repo):
+        syncer = self._make_syncer(working_repo, fake_client)
+        await syncer.aclose()
+        fake_client.close.assert_not_awaited()
+
+    async def test_first_mirror_opens_client_then_aclose_closes_once(
+        self, fake_client, working_repo, tmp_path, monkeypatch
+    ):
+        from core.sandbox.schemas import ApplyMutationsResponse, MutationResult
+
+        fake_client.apply_file_mutations.return_value = ApplyMutationsResponse(
+            results=[MutationResult(path="/repo/foo.py", ok=True, error=None)]
+        )
+        target = working_repo / "foo.py"
+        target.write_text("hello")
+        syncer = self._make_syncer(working_repo, fake_client)
+        runtime = _make_runtime(state={"session_id": "sid"}, working_dir=working_repo)
+
+        async with syncer.lock:
+            await syncer.mirror(
+                runtime=runtime, resolved_path=target, content_bytes=b"hello", mode=0o644, rollback=lambda: True
+            )
+        fake_client.open.assert_awaited_once()
+
+        await syncer.aclose()
+        fake_client.close.assert_awaited_once()
+
+        # Second aclose must not re-close.
+        await syncer.aclose()
+        fake_client.close.assert_awaited_once()

--- a/tests/unit_tests/automation/agent/middlewares/test_sandbox.py
+++ b/tests/unit_tests/automation/agent/middlewares/test_sandbox.py
@@ -4,8 +4,9 @@ from unittest.mock import AsyncMock, Mock, patch
 
 from git import Repo
 
-from automation.agent.middlewares.sandbox import SANDBOX_SYSTEM_PROMPT, SandboxMiddleware, _run_bash_commands, bash_tool
+from automation.agent.middlewares.sandbox import SANDBOX_SYSTEM_PROMPT, SandboxMiddleware, _run_bash_commands
 from core.conf import settings as core_settings
+from core.sandbox.client import DAIVSandboxClient
 from core.sandbox.schemas import RunCommandsResponse
 
 if TYPE_CHECKING:
@@ -49,6 +50,13 @@ def _make_bash_runtime(repo: Repo, disallow=(), allow=()) -> Mock:
     return runtime
 
 
+def _bash_tool_with_fake_client(client: Mock):
+    """Build a fresh SandboxMiddleware with ``client`` pre-installed and return its bash tool."""
+    middleware = SandboxMiddleware(close_session=True)
+    middleware._client = client
+    return middleware.tools[0]
+
+
 class TestBashTool:
     async def test_bash_tool_applies_patch_and_returns_results_json(self, tmp_path: Path):
         repo_dir = tmp_path / "repoX"
@@ -78,9 +86,11 @@ class TestBashTool:
         response = RunCommandsResponse(results=[], patch=base64.b64encode(patch_text.encode("utf-8")).decode("utf-8"))
 
         runtime = _make_bash_runtime(repo)
+        client = Mock()
+        client.run_commands = AsyncMock(return_value=response)
+        bash_tool = _bash_tool_with_fake_client(client)
 
-        with patch("automation.agent.middlewares.sandbox._run_bash_commands", new=AsyncMock(return_value=response)):
-            output = await bash_tool.coroutine(command="echo ok", runtime=runtime)
+        output = await bash_tool.coroutine(command="echo ok", runtime=runtime)
 
         assert file_path.read_text() == "new\n"
         import json as _json
@@ -89,18 +99,38 @@ class TestBashTool:
         assert payload["commands"] == []
         # The patch just edits hello.txt — nothing added/deleted/renamed.
         assert payload["files_changed"] == [{"path": "hello.txt", "op": "modified"}]
+        client.run_commands.assert_awaited_once()
 
     async def test_bash_tool_returns_error_when_sandbox_call_fails(self, tmp_path: Path):
+        import httpx
+
         repo_dir = tmp_path / "repoX"
         repo_dir.mkdir(parents=True)
         repo = Repo.init(repo_dir)
 
         runtime = _make_bash_runtime(repo)
+        client = Mock()
+        client.run_commands = AsyncMock(side_effect=httpx.RequestError("boom"))
+        bash_tool = _bash_tool_with_fake_client(client)
 
-        with patch("automation.agent.middlewares.sandbox._run_bash_commands", new=AsyncMock(return_value=None)):
-            output = await bash_tool.coroutine(command="echo ok", runtime=runtime)
+        output = await bash_tool.coroutine(command="echo ok", runtime=runtime)
 
-        assert output.startswith("error: Failed to run command.")
+        assert output.startswith("error: Sandbox call failed")
+
+    async def test_bash_tool_raises_when_client_not_opened(self, tmp_path: Path):
+        """Calling the bash tool before ``abefore_agent`` opens the client must fail loud."""
+        import pytest
+
+        repo_dir = tmp_path / "repoX"
+        repo_dir.mkdir(parents=True)
+        repo = Repo.init(repo_dir)
+
+        runtime = _make_bash_runtime(repo)
+        middleware = SandboxMiddleware(close_session=True)
+        bash_tool = middleware.tools[0]
+
+        with pytest.raises(RuntimeError, match="bash tool invoked before abefore_agent"):
+            await bash_tool.coroutine(command="echo ok", runtime=runtime)
 
 
 class TestBashToolPolicyEnforcement:
@@ -119,11 +149,12 @@ class TestBashToolPolicyEnforcement:
         runtime.tool_call_id = "call_policy"
         runtime.state["session_id"] = "sess_policy"
 
+        client = Mock()
+        run_mock = AsyncMock(return_value=RunCommandsResponse(results=[], patch=None))
+        client.run_commands = run_mock
+        bash_tool = _bash_tool_with_fake_client(client)
+
         with (
-            patch(
-                "automation.agent.middlewares.sandbox._run_bash_commands",
-                new=AsyncMock(return_value=RunCommandsResponse(results=[], patch=None)),
-            ) as run_mock,
             patch.object(core_settings, "SANDBOX_COMMAND_POLICY_DISALLOW", ()),
             patch.object(core_settings, "SANDBOX_COMMAND_POLICY_ALLOW", ()),
         ):
@@ -253,8 +284,10 @@ class TestRunBashCommands:
     async def test_run_bash_commands_no_archive_field(self):
         """_run_bash_commands no longer tarballs the working dir; archive is gone from RunCommandsRequest."""
         run_commands_mock = AsyncMock(return_value=RunCommandsResponse(results=[], patch=None))
-        with patch("automation.agent.middlewares.sandbox.DAIVSandboxClient.run_commands", new=run_commands_mock):
-            response = await _run_bash_commands(["echo ok"], "sess_1")
+        client = Mock()
+        client.run_commands = run_commands_mock
+
+        response = await _run_bash_commands(client, ["echo ok"], "sess_1")
 
         assert response is not None
         run_commands_mock.assert_awaited_once()
@@ -267,13 +300,24 @@ class TestRunBashCommands:
 
 
 class TestSandboxMiddleware:
+    @staticmethod
+    def _patch_client_lifecycle():
+        """Stub ``DAIVSandboxClient.open``/``close`` so no real httpx.AsyncClient is created."""
+        return (
+            patch("automation.agent.middlewares.sandbox.DAIVSandboxClient.open", new=AsyncMock(return_value=None)),
+            patch("automation.agent.middlewares.sandbox.DAIVSandboxClient.close", new=AsyncMock(return_value=None)),
+        )
+
     async def test_abefore_agent_starts_session_and_sets_session_id(self, tmp_path: Path):
         repo_dir = tmp_path / "repoX"
         repo_dir.mkdir(parents=True)
         (repo_dir / "README.md").write_text("hello")
         runtime = _make_agent_runtime(repo_working_dir=str(repo_dir))
 
+        open_patch, close_patch = self._patch_client_lifecycle()
         with (
+            open_patch,
+            close_patch,
             patch(
                 "automation.agent.middlewares.sandbox.DAIVSandboxClient.start_session",
                 new=AsyncMock(return_value="sess_1"),
@@ -292,9 +336,10 @@ class TestSandboxMiddleware:
         _args, kwargs = seed_session_mock.call_args
         assert "repo_archive" in kwargs
         assert isinstance(kwargs["repo_archive"], (bytes, bytearray))
+        assert middleware._client is not None
 
     async def test_abefore_agent_closes_session_on_seed_failure(self, tmp_path: Path):
-        """If seed_session raises, the started session is closed (no leak)."""
+        """If seed_session raises, the started session is closed and the client is released (no leak)."""
         import pytest
 
         repo_dir = tmp_path / "repoX"
@@ -302,9 +347,12 @@ class TestSandboxMiddleware:
         (repo_dir / "README.md").write_text("hello")
         runtime = _make_agent_runtime(repo_working_dir=str(repo_dir))
 
-        close_mock = AsyncMock(return_value=None)
+        close_session_mock = AsyncMock(return_value=None)
+        client_close_mock = AsyncMock(return_value=None)
 
         with (
+            patch("automation.agent.middlewares.sandbox.DAIVSandboxClient.open", new=AsyncMock(return_value=None)),
+            patch("automation.agent.middlewares.sandbox.DAIVSandboxClient.close", new=client_close_mock),
             patch(
                 "automation.agent.middlewares.sandbox.DAIVSandboxClient.start_session",
                 new=AsyncMock(return_value="sess_leaky"),
@@ -313,52 +361,132 @@ class TestSandboxMiddleware:
                 "automation.agent.middlewares.sandbox.DAIVSandboxClient.seed_session",
                 new=AsyncMock(side_effect=RuntimeError("simulated seed failure")),
             ),
-            patch("automation.agent.middlewares.sandbox.DAIVSandboxClient.close_session", new=close_mock),
+            patch("automation.agent.middlewares.sandbox.DAIVSandboxClient.close_session", new=close_session_mock),
         ):
             middleware = SandboxMiddleware(close_session=True)
             with pytest.raises(RuntimeError, match="simulated seed failure"):
                 await middleware.abefore_agent({}, runtime)
 
-        close_mock.assert_awaited_once_with("sess_leaky")
+        close_session_mock.assert_awaited_once_with("sess_leaky")
+        client_close_mock.assert_awaited_once()
+        assert middleware._client is None
+
+    async def test_abefore_agent_releases_client_on_start_session_failure(self, tmp_path: Path):
+        """If start_session raises (sandbox unreachable / 5xx), the just-opened client is released."""
+        import pytest
+
+        repo_dir = tmp_path / "repoX"
+        repo_dir.mkdir(parents=True)
+        runtime = _make_agent_runtime(repo_working_dir=str(repo_dir))
+
+        close_session_mock = AsyncMock(return_value=None)
+        client_close_mock = AsyncMock(return_value=None)
+
+        with (
+            patch("automation.agent.middlewares.sandbox.DAIVSandboxClient.open", new=AsyncMock(return_value=None)),
+            patch("automation.agent.middlewares.sandbox.DAIVSandboxClient.close", new=client_close_mock),
+            patch(
+                "automation.agent.middlewares.sandbox.DAIVSandboxClient.start_session",
+                new=AsyncMock(side_effect=RuntimeError("sandbox unreachable")),
+            ),
+            patch("automation.agent.middlewares.sandbox.DAIVSandboxClient.close_session", new=close_session_mock),
+        ):
+            middleware = SandboxMiddleware(close_session=True)
+            with pytest.raises(RuntimeError, match="sandbox unreachable"):
+                await middleware.abefore_agent({}, runtime)
+
+        # No session was started, so close_session must NOT be called.
+        close_session_mock.assert_not_awaited()
+        # But the client we opened must be released.
+        client_close_mock.assert_awaited_once()
+        assert middleware._client is None
+
+    async def test_aafter_agent_releases_client_when_close_session_raises_unexpected(self, tmp_path: Path):
+        """``finally`` releases the client even when close_session raises an unhandled exception."""
+        import pytest
+
+        runtime = _make_agent_runtime(repo_working_dir=str(tmp_path / "repoX"))
+        state = {"session_id": "sess_1"}
+
+        client_close_mock = AsyncMock(return_value=None)
+        with (
+            patch("automation.agent.middlewares.sandbox.DAIVSandboxClient.open", new=AsyncMock(return_value=None)),
+            patch("automation.agent.middlewares.sandbox.DAIVSandboxClient.close", new=client_close_mock),
+            patch(
+                "automation.agent.middlewares.sandbox.DAIVSandboxClient.close_session",
+                new=AsyncMock(side_effect=RuntimeError("unexpected")),
+            ),
+        ):
+            middleware = SandboxMiddleware(close_session=True)
+            middleware._client = DAIVSandboxClient()
+            with pytest.raises(RuntimeError, match="unexpected"):
+                await middleware.aafter_agent(state, runtime)
+
+        client_close_mock.assert_awaited_once()
+        assert middleware._client is None
 
     async def test_abefore_agent_reuses_session_id_when_close_session_false(self, tmp_path: Path):
         runtime = _make_agent_runtime(repo_working_dir=str(tmp_path / "repoX"))
         state = {"session_id": "sess_existing"}
 
-        with patch(
-            "automation.agent.middlewares.sandbox.DAIVSandboxClient.start_session", new=AsyncMock(return_value="sess_1")
-        ) as start_session_mock:
+        open_patch, close_patch = self._patch_client_lifecycle()
+        with (
+            open_patch,
+            close_patch,
+            patch(
+                "automation.agent.middlewares.sandbox.DAIVSandboxClient.start_session",
+                new=AsyncMock(return_value="sess_1"),
+            ) as start_session_mock,
+        ):
             middleware = SandboxMiddleware(close_session=False)
             update = await middleware.abefore_agent(state, runtime)
 
         assert update is None
         start_session_mock.assert_not_awaited()
+        assert middleware._client is not None
 
     async def test_aafter_agent_closes_session_and_clears_session_id(self, tmp_path: Path):
         runtime = _make_agent_runtime(repo_working_dir=str(tmp_path / "repoX"))
         state = {"session_id": "sess_1"}
 
-        with patch(
-            "automation.agent.middlewares.sandbox.DAIVSandboxClient.close_session", new=AsyncMock(return_value=None)
-        ) as close_session_mock:
+        client_close_mock = AsyncMock(return_value=None)
+        with (
+            patch("automation.agent.middlewares.sandbox.DAIVSandboxClient.open", new=AsyncMock(return_value=None)),
+            patch("automation.agent.middlewares.sandbox.DAIVSandboxClient.close", new=client_close_mock),
+            patch(
+                "automation.agent.middlewares.sandbox.DAIVSandboxClient.close_session", new=AsyncMock(return_value=None)
+            ) as close_session_mock,
+        ):
             middleware = SandboxMiddleware(close_session=True)
+            middleware._client = DAIVSandboxClient()
             update = await middleware.aafter_agent(state, runtime)
 
         assert update == {"session_id": None}
         close_session_mock.assert_awaited_once_with("sess_1")
+        client_close_mock.assert_awaited_once()
+        assert middleware._client is None
 
     async def test_aafter_agent_does_not_close_session_when_close_session_false(self, tmp_path: Path):
         runtime = _make_agent_runtime(repo_working_dir=str(tmp_path / "repoX"))
         state = {"session_id": "sess_1"}
 
-        with patch(
-            "automation.agent.middlewares.sandbox.DAIVSandboxClient.close_session", new=AsyncMock(return_value=None)
-        ) as close_session_mock:
+        client_close_mock = AsyncMock(return_value=None)
+        with (
+            patch("automation.agent.middlewares.sandbox.DAIVSandboxClient.open", new=AsyncMock(return_value=None)),
+            patch("automation.agent.middlewares.sandbox.DAIVSandboxClient.close", new=client_close_mock),
+            patch(
+                "automation.agent.middlewares.sandbox.DAIVSandboxClient.close_session", new=AsyncMock(return_value=None)
+            ) as close_session_mock,
+        ):
             middleware = SandboxMiddleware(close_session=False)
+            middleware._client = DAIVSandboxClient()
             update = await middleware.aafter_agent(state, runtime)
 
         assert update is None
         close_session_mock.assert_not_awaited()
+        # Subagent path: session is the parent's, but the client we opened still must be released.
+        client_close_mock.assert_awaited_once()
+        assert middleware._client is None
 
     async def test_awrap_model_call_appends_sandbox_system_prompt(self, tmp_path: Path):
         from langchain.agents.middleware import ModelRequest, ModelResponse

--- a/tests/unit_tests/core/sandbox/test_client.py
+++ b/tests/unit_tests/core/sandbox/test_client.py
@@ -21,69 +21,124 @@ def fake_settings():
         yield
 
 
-async def test_seed_session_posts_repo_archive(fake_settings, monkeypatch):
-    from core.sandbox.client import DAIVSandboxClient
+@pytest.fixture
+def mock_post(monkeypatch):
+    """Capture every httpx.AsyncClient.post call; default reply is 200 OK with no body.
 
-    captured: dict = {}
+    Set ``status`` and ``json_body`` to customise the next reply.
+    """
+    state: dict = {"status": 200, "json_body": None, "client_ids": []}
 
-    async def fake_post(self, url, json):
-        captured["url"] = url
-        captured["json"] = json
-        return httpx.Response(204, request=httpx.Request("POST", url))
-
-    monkeypatch.setattr(httpx.AsyncClient, "post", fake_post)
-    await DAIVSandboxClient().seed_session("sid-123", repo_archive=b"tar-bytes")
-
-    assert captured["url"] == "session/sid-123/seed/"
-    assert captured["json"]["repo_archive"] == base64.b64encode(b"tar-bytes").decode()
-
-
-async def test_seed_session_treats_409_as_already_seeded(fake_settings, monkeypatch):
-    from core.sandbox.client import DAIVSandboxClient
-
-    async def fake_post(self, url, json):
-        return httpx.Response(409, json={"detail": "Session already seeded"}, request=httpx.Request("POST", url))
+    async def fake_post(self, url, **kwargs):
+        state["url"] = url
+        state["kwargs"] = kwargs
+        state["client_ids"].append(id(self))
+        return httpx.Response(state["status"], json=state["json_body"], request=httpx.Request("POST", url))
 
     monkeypatch.setattr(httpx.AsyncClient, "post", fake_post)
-    await DAIVSandboxClient().seed_session("sid-123", repo_archive=b"tar")
+    return state
 
 
-async def test_apply_file_mutations_posts_payload(fake_settings, monkeypatch):
+async def test_seed_session_posts_repo_archive(fake_settings, mock_post):
+    from core.sandbox.client import DAIVSandboxClient
+
+    async with DAIVSandboxClient() as client:
+        await client.seed_session("sid-123", repo_archive=b"tar-bytes")
+
+    assert mock_post["url"] == "session/sid-123/seed/"
+    field_name, (filename, content, content_type) = next(iter(mock_post["kwargs"]["files"].items()))
+    assert field_name == "repo_archive"
+    assert content == b"tar-bytes"
+    assert content_type == "application/octet-stream"
+
+
+async def test_seed_session_posts_both_archives(fake_settings, mock_post):
+    from core.sandbox.client import DAIVSandboxClient
+
+    async with DAIVSandboxClient() as client:
+        await client.seed_session("sid", repo_archive=b"r", skills_archive=b"s")
+
+    files = mock_post["kwargs"]["files"]
+    assert set(files.keys()) == {"repo_archive", "skills_archive"}
+    assert files["repo_archive"][1] == b"r"
+    assert files["skills_archive"][1] == b"s"
+
+
+async def test_seed_session_skills_only(fake_settings, mock_post):
+    from core.sandbox.client import DAIVSandboxClient
+
+    async with DAIVSandboxClient() as client:
+        await client.seed_session("sid", skills_archive=b"s")
+
+    assert set(mock_post["kwargs"]["files"].keys()) == {"skills_archive"}
+
+
+async def test_seed_session_treats_409_as_already_seeded(fake_settings, mock_post):
+    from core.sandbox.client import DAIVSandboxClient
+
+    mock_post["status"] = 409
+    mock_post["json_body"] = {"detail": "Session already seeded"}
+    async with DAIVSandboxClient() as client:
+        await client.seed_session("sid-123", repo_archive=b"tar")
+
+
+async def test_apply_file_mutations_posts_payload(fake_settings, mock_post):
     from core.sandbox.client import DAIVSandboxClient
     from core.sandbox.schemas import ApplyMutationsRequest, PutMutation
 
-    captured: dict = {}
-
-    async def fake_post(self, url, json):
-        captured["url"] = url
-        captured["json"] = json
-        return httpx.Response(
-            200,
-            json={"results": [{"path": "/repo/x.py", "ok": True, "error": None}]},
-            request=httpx.Request("POST", url),
-        )
-
-    monkeypatch.setattr(httpx.AsyncClient, "post", fake_post)
+    mock_post["json_body"] = {"results": [{"path": "/repo/x.py", "ok": True, "error": None}]}
     req = ApplyMutationsRequest(mutations=[PutMutation(path="/repo/x.py", content=base64.b64encode(b"hi"), mode=0o644)])
-    resp = await DAIVSandboxClient().apply_file_mutations("sid", req)
+    async with DAIVSandboxClient() as client:
+        resp = await client.apply_file_mutations("sid", req)
 
-    assert captured["url"] == "session/sid/files/"
+    assert mock_post["url"] == "session/sid/files/"
     assert resp.results[0].ok is True
 
 
-async def test_apply_file_mutations_returns_per_item_failures(fake_settings, monkeypatch):
+async def test_apply_file_mutations_returns_per_item_failures(fake_settings, mock_post):
     from core.sandbox.client import DAIVSandboxClient
     from core.sandbox.schemas import ApplyMutationsRequest, PutMutation
 
-    async def fake_post(self, url, json):
-        return httpx.Response(
-            200,
-            json={"results": [{"path": "/skills/x", "ok": False, "error": "must be under /repo"}]},
-            request=httpx.Request("POST", url),
-        )
-
-    monkeypatch.setattr(httpx.AsyncClient, "post", fake_post)
+    mock_post["json_body"] = {"results": [{"path": "/skills/x", "ok": False, "error": "must be under /repo"}]}
     req = ApplyMutationsRequest(mutations=[PutMutation(path="/skills/x", content=base64.b64encode(b""), mode=0o644)])
-    resp = await DAIVSandboxClient().apply_file_mutations("sid", req)
+    async with DAIVSandboxClient() as client:
+        resp = await client.apply_file_mutations("sid", req)
+
     assert resp.results[0].ok is False
     assert resp.results[0].error == "must be under /repo"
+
+
+async def test_connection_pool_reused_across_calls_in_one_block(fake_settings, mock_post):
+    """One ``async with`` block must reuse a single httpx.AsyncClient across N calls."""
+    from core.sandbox.client import DAIVSandboxClient
+
+    async with DAIVSandboxClient() as client:
+        await client.seed_session("sid", repo_archive=b"a")
+        await client.seed_session("sid", repo_archive=b"b")
+        await client.seed_session("sid", repo_archive=b"c")
+
+    assert len(mock_post["client_ids"]) == 3
+    assert len(set(mock_post["client_ids"])) == 1, "expected the same httpx.AsyncClient to handle all three calls"
+
+
+async def test_double_open_raises(fake_settings):
+    """Re-entering an already-open client would leak the previous httpx.AsyncClient."""
+    from core.sandbox.client import DAIVSandboxClient
+
+    client = DAIVSandboxClient()
+    await client.open()
+    try:
+        with pytest.raises(RuntimeError, match="already open"):
+            await client.open()
+    finally:
+        await client.close()
+
+
+async def test_call_before_open_raises(fake_settings):
+    """Calling a method on a never-opened client raises (it is a programmer error to skip ``open()``)."""
+    from core.sandbox.client import DAIVSandboxClient
+    from core.sandbox.schemas import RunCommandsRequest
+
+    client = DAIVSandboxClient()
+    with pytest.raises(AttributeError):
+        await client.run_commands("sid", RunCommandsRequest(commands=["echo"], fail_fast=True))

--- a/tests/unit_tests/core/sandbox/test_schema_consistency.py
+++ b/tests/unit_tests/core/sandbox/test_schema_consistency.py
@@ -26,13 +26,7 @@ def _normalize(schema):
 # differ between the two repos: daiv's RunCommands* keeps a stable client API,
 # StartSessionRequest accepts a Dockerfile alternative, and StartSessionResponse
 # isn't modelled on the daiv side.
-_SHARED_TYPES = [
-    "ApplyMutationsRequest",
-    "ApplyMutationsResponse",
-    "MutationResult",
-    "PutMutation",
-    "SeedSessionRequest",
-]
+_SHARED_TYPES = ["ApplyMutationsRequest", "ApplyMutationsResponse", "MutationResult", "PutMutation"]
 
 # Types that exist on both sides but are deliberately allowed to diverge.
 _INTENTIONALLY_DIVERGENT = {"RunCommandsRequest", "RunCommandsResponse", "RunCommandResult", "StartSessionRequest"}

--- a/tests/unit_tests/core/sandbox/test_schemas.py
+++ b/tests/unit_tests/core/sandbox/test_schemas.py
@@ -13,13 +13,6 @@ def test_put_mutation_validates_mode_range():
         PutMutation(path="/repo/foo.py", content=base64.b64encode(b"x"), mode=0o10000)
 
 
-def test_seed_session_request_carries_repo_archive():
-    from core.sandbox.schemas import SeedSessionRequest
-
-    req = SeedSessionRequest(repo_archive=base64.b64encode(b"tar"))
-    assert req.repo_archive == b"tar"
-
-
 def test_run_commands_request_no_archive():
     from core.sandbox.schemas import RunCommandsRequest
 


### PR DESCRIPTION
## Summary

`DAIVSandboxClient` was constructing a fresh `httpx.AsyncClient` on every method call, paying TCP+TLS handshake cost per sandbox API hit. This PR makes the client long-lived: opened once at agent start, shared across every seed/mutation/run/close call for the duration of the run.

- `SandboxMiddleware` opens the client in `abefore_agent` and releases it from `aafter_agent`. The bash tool is built by a closure binding `self._client` so each invocation reuses the live pool.
- `FilesystemMiddleware`'s `_SandboxSyncer` keeps its own client and opens it lazily on first mirror; `aclose()` releases it from `aafter_agent`. Open-once is guarded by an `_opened` flag — safe because the only call path is `mirror()`, which always runs under `syncer.lock`.
- `seed_session` moves from JSON-base64 to multipart/form-data so `skills_archive` can ride alongside `repo_archive`; the `SeedSessionRequest` schema is dropped client-side.
- `aafter_agent`'s `finally` wraps `client.close()` in `try/except` so a transport-level teardown failure can't mask whatever `close_session` was already raising.
- `_run_bash_commands` failure no longer surfaces as "verify the command is valid" — it now reports "Sandbox call failed (transport or HTTP error)" so the LLM stops misclassifying sandbox outages as bad input.
- `seed_session` fail-fasts on empty archives instead of round-tripping a 422.

### Known follow-ups (not in this PR)

- `SandboxMiddleware` and `_SandboxSyncer` each open their own `DAIVSandboxClient`, so an agent run with both middlewares opens two pools, not one. Threading a single client through both is a worthwhile follow-up.
- On agent failure, `aafter_agent` does not run; the client is left for GC. Acceptable today because agent runs are short-lived.

## Test plan

- [x] `uv run pytest tests/unit_tests/core/sandbox/ tests/unit_tests/automation/agent/middlewares/` — 304 pass
- [x] `uv run ruff check` on changed files — clean
- [x] New tests cover: `start_session` failure releases client, `aafter_agent` `finally` releases client when `close_session` raises an unhandled exception, `_SandboxSyncer.aclose` is idempotent and closes-once after a mirror, multipart `seed_session` (both archives, repo only, skills only), connection-pool reuse across calls, double-open rejected.
- [ ] Manual smoke against a live sandbox (sanity-check the multipart seed wire format)