### PR TITLE
fix(infra): Extend app healthcheck start-period to 120s

### DIFF
--- a/docker/production/app/Dockerfile
+++ b/docker/production/app/Dockerfile
@@ -103,7 +103,7 @@ RUN chmod +x entrypoint start-app start-worker start-crontask \
   && ./"tailwindcss-linux-${ARCH}" -i app/static_src/css/input.css -o app/static/css/styles.css --minify \
   && rm "tailwindcss-linux-${ARCH}"
 
-HEALTHCHECK --interval=10s --start-period=30s \
+HEALTHCHECK --interval=10s --start-period=120s --start-interval=5s \
   CMD curl --fail http://127.0.0.1:8000/-/alive/ || exit 1
 
 EXPOSE 8000


### PR DESCRIPTION
## Summary
- `start-app` runs `migrate` + `setup_default_site` + `setup_checkpoint_saver` + `collectstatic` before exec'ing uvicorn. Each Django boot is ~10s, so uvicorn binds the port only ~53s after container start.
- The current `HEALTHCHECK --start-period=30s` plus default 3 retries marks the task unhealthy at ~T+60s, swarm replaces it cleanly (exit 0), and the cycle repeats forever. Healthcheck logs showed `curl: (7) Failed to connect to 127.0.0.1 port 8000` for the entire window.
- Bump `--start-period` to `120s` (covers boot with margin) and add `--start-interval=5s` so healthy pickup is fast once uvicorn is up.

## Test plan
- [ ] Rebuild the `:main` image and redeploy the swarm stack.
- [ ] Verify `daiv_app` tasks reach `(healthy)` within ~60s of `uvicorn` binding (no shutdown loop).
- [ ] Confirm `/-/alive/` returns `OK` on the deployed app.