### PR TITLE
fix(deferred-tools): Register extra_tools with the runtime ToolNode

### DIFF
--- a/daiv/automation/agent/middlewares/deferred_tools.py
+++ b/daiv/automation/agent/middlewares/deferred_tools.py
@@ -45,7 +45,14 @@ class DeferredToolsMiddleware(AgentMiddleware):
         self._always_loaded: set[str] = {*always_loaded, TOOL_SEARCH_NAME}
         self._extra_tools: list[BaseTool] = list(extra_tools)
         self._index: DeferredToolsIndex | None = None
-        self.tools = [make_tool_search(self._get_index, top_k_default=top_k_default, top_k_max=top_k_max)]
+        # Expose extra_tools to the agent factory so they are registered with the runtime ToolNode
+        # at build time (langchain/agents/factory.py collects middleware.tools into available_tools).
+        # awrap_model_call still filters them out of the model's view until they're loaded via
+        # tool_search — registration here only makes them executable when the model calls them.
+        self.tools = [
+            make_tool_search(self._get_index, top_k_default=top_k_default, top_k_max=top_k_max),
+            *self._extra_tools,
+        ]
 
     def _get_index(self) -> DeferredToolsIndex:
         if self._index is None:

--- a/daiv/automation/agent/prompts.py
+++ b/daiv/automation/agent/prompts.py
@@ -33,6 +33,7 @@ The user will primarily request you perform software engineering tasks. This inc
 - Pre-existing test failures unrelated to your changes should be reported to the user but do not block your task.
 - After fixing targeted test failures, run a broader test suite (e.g., the full module or package) to check for unintended regressions. If the full suite is too large, at minimum run tests for all modules you touched and their direct dependents.
 - "Verify your changes" means: run tests, review the results, and confirm all failures caused by your changes are resolved before reporting completion.
+- If you fell back to static verification (lint/type-check/syntax-check/code review) because the test environment was unavailable, say so explicitly in your final report. State which checks you ran and that runtime correctness is unconfirmed. Do not phrase the outcome the same way you would after a passing test run.
 
 ## Executing actions with care
 

--- a/tests/unit_tests/automation/agent/middlewares/test_deferred_tools.py
+++ b/tests/unit_tests/automation/agent/middlewares/test_deferred_tools.py
@@ -33,6 +33,16 @@ class TestDeferredToolsMiddleware:
         assert len(middleware.tools) == 1
         assert middleware.tools[0].name == "tool_search"
 
+    def test_extra_tools_registered_via_tools_attr(self):
+        # langchain.agents.factory collects middleware.tools into the runtime ToolNode.
+        # If extra_tools (e.g. MCP tools) aren't exposed here, the model can "load" them via
+        # tool_search but the ToolNode rejects the subsequent call as "not a valid tool".
+        github = _make_tool("github_create_issue", "Create issue")
+        sentry = _make_tool("sentry_find_orgs", "List orgs")
+        middleware = DeferredToolsMiddleware(always_loaded=set(), extra_tools=[github, sentry])
+        names = [t.name for t in middleware.tools]
+        assert names == ["tool_search", "github_create_issue", "sentry_find_orgs"]
+
     def test_state_schema_is_deferred_state(self):
         from automation.agent.deferred.state import DeferredToolsState
 


### PR DESCRIPTION
## Summary

- Fixes a harness bug where deferred MCP tools loaded via `tool_search(select=[...])` were rejected by langgraph's `ToolNode` with `"is not a valid tool"` on the very next call. `DeferredToolsMiddleware` stored them privately in `_extra_tools` and only exposed `[tool_search]` via `self.tools`, so `langchain.agents.factory` built the `ToolNode` without them. Now `self.tools` includes `extra_tools`; the per-call visibility filter in `awrap_model_call` is unchanged, so the model still only sees `always_loaded ∪ loaded_tool_names`.
- Adds a regression test asserting `extra_tools` are exposed through `middleware.tools`.
- Adds one bullet to the Verification & Testing system prompt: when the agent falls back to static verification because the test environment is unavailable, it must say so explicitly rather than framing the outcome like a passing test run.

## Evidence

Trace analysis across 17 unique runs surfaced four `/rt-daily-report` runs (`019df1e4`, `019df200`, `019de7cf`, `019df75b-9d02`) where the agent correctly called `tool_search(select=["rt_search_tickets", ...])`, the tool returned `Loaded N tool(s)`, and the immediate next call failed with langgraph's canonical `"Error: rt_search_tickets is not a valid tool, try one of [...]"`. In `019df1e4` the deliverable was abandoned entirely — the success bucket masked a fully-failed run.

## Test plan

- [x] `uv run pytest tests/unit_tests/automation/agent/middlewares/test_deferred_tools.py tests/unit_tests/automation/agent/test_graph_deferred.py tests/unit_tests/automation/agent/test_graph_construction.py` — 23 passed
- [x] `make lint-fix` — clean
- [ ] Re-run `/rt-daily-report` end-to-end and confirm the deliverable is produced