### PR TITLE
fix(db): Add libpq TCP keepalives to prevent IPVS-induced reconnects

### DIFF
--- a/daiv/daiv/settings/components/database.py
+++ b/daiv/daiv/settings/components/database.py
@@ -10,6 +10,12 @@ DATABASES_OPTIONS = {
         cast=Choices(["disable", "allow", "prefer", "require", "verify-ca", "verify-full"]),
     ),
     "pool": {"max_size": config("DB_POOL_MAX_SIZE", default=15, cast=int)},
+    # Probe idle connections so middleboxes (e.g. Docker Swarm IPVS, default 15min)
+    # don't silently drop pooled connections, causing a reconnect on the next request.
+    "keepalives": 1,
+    "keepalives_idle": config("DB_KEEPALIVES_IDLE", default=60, cast=int),
+    "keepalives_interval": config("DB_KEEPALIVES_INTERVAL", default=10, cast=int),
+    "keepalives_count": config("DB_KEEPALIVES_COUNT", default=5, cast=int),
 }
 
 DATABASES = {


### PR DESCRIPTION
## Summary

- Add `keepalives*` libpq parameters to `DATABASES_OPTIONS` so idle connections in the psycopg pool send TCP probes well before any middlebox idle-drop kicks in.

## Why

Production deployment shows a "first page load is slow, subsequent loads are fast" pattern after periods of inactivity. Investigation:

- `postgresql.conf` has all idle-session timeouts disabled (`idle_session_timeout=0`, `idle_in_transaction_session_timeout=0`) and TCP keepalives at the system default (≈2 hours). So Postgres is **not** closing the sessions.
- `psycopg` pool is configured with `min_size=4` (default) and `CONN_HEALTH_CHECKS=True`, so the pool *should* always have warm connections waiting.
- The connections still go bad. The likely culprit is **Docker Swarm's IPVS** in the path between the app and `db` service (default `endpoint_mode: vip`). Linux IPVS `net.ipv4.vs.timeout_established` defaults to **15 minutes** — once IPVS forgets a flow, the next packet has nowhere to go and the socket is silently broken. The pool only notices on the next checkout, then pays a fresh TCP + TLS + auth handshake on `sslmode=require`.

## What changes

```python
"keepalives": 1,
"keepalives_idle": 60,        # DB_KEEPALIVES_IDLE
"keepalives_interval": 10,    # DB_KEEPALIVES_INTERVAL
"keepalives_count": 5,        # DB_KEEPALIVES_COUNT
```

A probe every 60s of idle keeps IPVS's conntrack entry alive, well below its 15-minute window. Probes are kernel-level, sub-byte traffic — imperceptible.

## Test plan

- [ ] Deploy to prod (`dip-daiv`).
- [ ] Leave the dashboard idle for >15 min.
- [ ] Reload — first request should now be as fast as subsequent ones.
- [ ] If still slow, sample with `time curl http://localhost:8000/dashboard/` from the host to localise (DB-leg vs nginx-leg).

## Notes

- The other DB-using management commands (`setup_checkpoint_saver`) are Redis-only, so this is the only PG-client config that needs to change.
- Defaults are env-overridable (`DB_KEEPALIVES_IDLE`, `DB_KEEPALIVES_INTERVAL`, `DB_KEEPALIVES_COUNT`) for tuning without a code change.
- Separate but worth noting: the `dipcode-rproxy` nginx upstream for daiv has no `keepalive` directive and no `proxy_http_version 1.1`, so nginx opens a fresh TCP connection to the app on every request. That's a per-request perf cost, not the cold-start cause, but worth tightening in a separate PR on the rproxy playbook.