### PR TITLE
fix(usage): bill Anthropic 1h ephemeral cache writes correctly

### DIFF
--- a/daiv/automation/agent/usage_tracking.py
+++ b/daiv/automation/agent/usage_tracking.py
@@ -10,10 +10,13 @@ from decimal import Decimal
 from typing import TYPE_CHECKING, Any
 
 from genai_prices import Usage, calc_price
+from genai_prices.types import TieredPrices
 from langchain_core.callbacks.usage import UsageMetadataCallbackHandler
 from langchain_core.messages import AIMessage
 from langchain_core.outputs import ChatGeneration
 from langchain_core.tracers.context import register_configure_hook
+
+from automation.agent.base import ModelProvider
 
 if TYPE_CHECKING:
     from collections.abc import Iterator, Mapping
@@ -23,13 +26,39 @@ if TYPE_CHECKING:
 logger = logging.getLogger("daiv.usage")
 
 
+def _resolve_mtok_rate(field_mtok: Decimal | TieredPrices | None, total_input_tokens: int) -> Decimal | None:
+    """Resolve the per-million-token rate that applies at ``total_input_tokens``.
+
+    Mirrors ``genai_prices.types.calc_mtok_price`` tier selection.
+    """
+    if field_mtok is None:
+        return None
+    if isinstance(field_mtok, TieredPrices):
+        applicable = field_mtok.base
+        for tier in reversed(field_mtok.tiers):
+            if total_input_tokens > tier.start:
+                applicable = tier.price
+                break
+        return applicable
+    return field_mtok
+
+
 def _calc_model_cost(model_name: str, usage_metadata: Mapping[str, Any]) -> Decimal | None:
     """Return None if the model is not in the pricing database."""
     input_details = usage_metadata.get("input_token_details") or {}
+    # langchain-anthropic zeroes ``cache_creation`` whenever it has the per-TTL breakdown
+    # and stores the actual counts under ``ephemeral_5m_input_tokens`` /
+    # ``ephemeral_1h_input_tokens`` (see ``_create_usage_metadata`` in chat_models.py).
+    # Sum all three so we don't silently drop the cache-write portion of input.
+    ephemeral_5m = input_details.get("ephemeral_5m_input_tokens") or 0
+    ephemeral_1h = input_details.get("ephemeral_1h_input_tokens") or 0
+    cache_write_tokens = (input_details.get("cache_creation") or 0) + ephemeral_5m + ephemeral_1h
+
+    input_tokens = usage_metadata.get("input_tokens", 0)
     genai_usage = Usage(
-        input_tokens=usage_metadata.get("input_tokens", 0),
+        input_tokens=input_tokens,
         output_tokens=usage_metadata.get("output_tokens", 0),
-        cache_write_tokens=input_details.get("cache_creation") or 0,
+        cache_write_tokens=cache_write_tokens,
         cache_read_tokens=input_details.get("cache_read") or 0,
     )
     # OpenRouter model names contain a slash (e.g. "anthropic/claude-sonnet-4.6")
@@ -43,7 +72,35 @@ def _calc_model_cost(model_name: str, usage_metadata: Mapping[str, Any]) -> Deci
     except ValueError, TypeError, ArithmeticError:
         logger.warning("Cost calculation failed for model %r", model_name, exc_info=True)
         return None
-    return result.total_price
+
+    cost = result.total_price
+
+    # Anthropic prices 1-hour ephemeral cache writes at 2x the base input rate, while
+    # 5-minute writes are 1.25x. genai-prices' single ``cache_write_mtok`` reflects only
+    # the 5-minute rate, so add the (1h − 5m) differential for the 1h portion.
+    # OpenRouter-routed Anthropic models share the underlying rates and need the same surcharge.
+    is_anthropic = result.provider.id == ModelProvider.ANTHROPIC or model_name.startswith(
+        f"{ModelProvider.ANTHROPIC.value}/"
+    )
+    if ephemeral_1h and is_anthropic:
+        input_rate = _resolve_mtok_rate(result.model_price.input_mtok, input_tokens)
+        cache_write_rate = _resolve_mtok_rate(result.model_price.cache_write_mtok, input_tokens)
+        if input_rate is not None and cache_write_rate is not None:
+            surcharge_per_mtok = Decimal(2) * input_rate - cache_write_rate
+            cost += Decimal(ephemeral_1h) * surcharge_per_mtok / Decimal(1_000_000)
+        else:
+            # Pricing entry is missing a rate (e.g. older Claude models with no cache pricing).
+            # Surface the under-billing so it doesn't slip past silently.
+            logger.warning(
+                "1h cache-write surcharge skipped for %r: input_rate=%s cache_write_rate=%s; "
+                "%d ephemeral_1h tokens billed at the 5m rate",
+                model_name,
+                input_rate,
+                cache_write_rate,
+                ephemeral_1h,
+            )
+
+    return cost
 
 
 class CostAwareUsageMetadataCallbackHandler(UsageMetadataCallbackHandler):

--- a/tests/unit_tests/automation/agent/test_usage_tracking.py
+++ b/tests/unit_tests/automation/agent/test_usage_tracking.py
@@ -17,6 +17,8 @@ def _usage_metadata(
     total_tokens: int | None = None,
     cache_creation: int = 0,
     cache_read: int = 0,
+    ephemeral_5m: int = 0,
+    ephemeral_1h: int = 0,
     reasoning: int = 0,
 ) -> dict[str, Any]:
     """Build a UsageMetadata dict as produced by UsageMetadataCallbackHandler."""
@@ -30,6 +32,10 @@ def _usage_metadata(
         input_details["cache_creation"] = cache_creation
     if cache_read:
         input_details["cache_read"] = cache_read
+    if ephemeral_5m:
+        input_details["ephemeral_5m_input_tokens"] = ephemeral_5m
+    if ephemeral_1h:
+        input_details["ephemeral_1h_input_tokens"] = ephemeral_1h
     if input_details:
         d["input_token_details"] = input_details
 
@@ -244,6 +250,153 @@ class TestPerCallPricing:
         assert summary.cost_usd is not None
         # by_model.cost_usd should equal the run total (only one model).
         assert summary.by_model["claude-sonnet-4-6"]["cost_usd"] == summary.cost_usd
+
+
+class TestEphemeralCacheWrites:
+    """langchain-anthropic stores 1h/5m cache-write counts under ``ephemeral_*_input_tokens``
+    and zeroes ``cache_creation`` when that breakdown is present. Per-TTL counts must be
+    billed correctly and the 1h surcharge applied (Anthropic prices 1h writes at 2x base,
+    while genai-prices only models the 5m rate).
+    """
+
+    def test_reproduces_langsmith_cost_for_known_trace(self):
+        """Trace ``019df81d`` has 414953/2029 tokens with 308360 cache_read and 106570
+        ephemeral_1h cache writes; LangSmith reports total $0.762432.
+        """
+        handler = CostAwareUsageMetadataCallbackHandler()
+        handler.on_llm_end(
+            _llm_result(
+                "claude-sonnet-4-6",
+                _usage_metadata(input_tokens=414953, output_tokens=2029, cache_read=308360, ephemeral_1h=106570),
+            )
+        )
+        summary = build_usage_summary(handler)
+        assert summary.cost_usd is not None
+        # Reconstruct the LangSmith formula exactly:
+        # uncached*$3 + cache_read*$0.30 + ephemeral_1h*$6 + output*$15  (all per-million).
+        assert Decimal(summary.cost_usd) == Decimal("0.762432")
+
+    def test_ephemeral_5m_billed_at_5m_rate(self):
+        handler = CostAwareUsageMetadataCallbackHandler()
+        handler.on_llm_end(
+            _llm_result(
+                "claude-sonnet-4-6", _usage_metadata(input_tokens=100_000, output_tokens=0, ephemeral_5m=100_000)
+            )
+        )
+        summary = build_usage_summary(handler)
+        assert summary.cost_usd is not None
+        # 100K tokens entirely as 5m cache writes: 100_000 * $3.75/M = $0.375.
+        assert Decimal(summary.cost_usd) == Decimal("0.375")
+
+    def test_ephemeral_1h_priced_higher_than_5m(self):
+        """1h cache writes cost strictly more than the same volume as 5m writes."""
+
+        def _cost(*, ephemeral_1h: int, ephemeral_5m: int) -> Decimal:
+            handler = CostAwareUsageMetadataCallbackHandler()
+            handler.on_llm_end(
+                _llm_result(
+                    "claude-sonnet-4-6",
+                    _usage_metadata(
+                        input_tokens=100_000, output_tokens=0, ephemeral_5m=ephemeral_5m, ephemeral_1h=ephemeral_1h
+                    ),
+                )
+            )
+            summary = build_usage_summary(handler)
+            assert summary.cost_usd is not None
+            return Decimal(summary.cost_usd)
+
+        cost_1h = _cost(ephemeral_1h=100_000, ephemeral_5m=0)
+        cost_5m = _cost(ephemeral_1h=0, ephemeral_5m=100_000)
+        # 1h surcharge for Sonnet 4.6 is $2.25/M (= 2*$3 − $3.75); for 100K tokens that's $0.225.
+        assert cost_1h - cost_5m == Decimal("0.225")
+
+    def test_legacy_cache_creation_still_priced(self):
+        handler = CostAwareUsageMetadataCallbackHandler()
+        handler.on_llm_end(
+            _llm_result(
+                "claude-sonnet-4-6", _usage_metadata(input_tokens=100_000, output_tokens=0, cache_creation=100_000)
+            )
+        )
+        summary = build_usage_summary(handler)
+        # Same as the 5m case — no surcharge, just the genai-prices cache_write rate.
+        assert summary.cost_usd is not None
+        assert Decimal(summary.cost_usd) == Decimal("0.375")
+
+    def test_surcharge_skipped_for_non_anthropic_provider(self):
+        """The 1h surcharge is Anthropic-specific. A non-Anthropic model with the same
+        input_token_details shape must price exactly as genai-prices reports, no surcharge.
+        """
+        from genai_prices import Usage, calc_price
+
+        handler = CostAwareUsageMetadataCallbackHandler()
+        handler.on_llm_end(
+            _llm_result("gpt-5.4", _usage_metadata(input_tokens=100_000, output_tokens=0, ephemeral_1h=10_000))
+        )
+        summary = build_usage_summary(handler)
+        expected = calc_price(
+            Usage(input_tokens=100_000, output_tokens=0, cache_write_tokens=10_000), model_ref="gpt-5.4"
+        ).total_price
+        assert summary.cost_usd is not None
+        assert Decimal(summary.cost_usd) == expected
+
+    def test_surcharge_uses_tiered_rate_above_200k(self):
+        """Sonnet 4.5 has TieredPrices crossing at 200K. Above the threshold the surcharge
+        must use the tier rate (2*$6 − $7.50 = $4.50/M), not the base rate.
+        """
+        handler = CostAwareUsageMetadataCallbackHandler()
+        handler.on_llm_end(
+            _llm_result(
+                "claude-sonnet-4-5", _usage_metadata(input_tokens=250_000, output_tokens=0, ephemeral_1h=10_000)
+            )
+        )
+        summary = build_usage_summary(handler)
+        assert summary.cost_usd is not None
+        # genai-prices base cost (tier rate, all tokens billed as cache_write since
+        # cache_write_tokens=ephemeral_1h=10_000 and the rest is uncached input):
+        # uncached = 250_000 − 10_000 = 240_000 @ $6/M = $1.440
+        # cache_write = 10_000 @ $7.50/M = $0.075
+        # surcharge = 10_000 * (2*$6 − $7.50)/M = $0.045
+        assert Decimal(summary.cost_usd) == Decimal("1.560")
+
+    def test_openrouter_routed_anthropic_gets_surcharge(self):
+        """Routing Anthropic via OpenRouter (model_name like ``anthropic/claude-sonnet-4.6``)
+        resolves to provider ``openrouter`` but underlying pricing is Anthropic's, so the
+        1h surcharge must still apply.
+        """
+        handler = CostAwareUsageMetadataCallbackHandler()
+        handler.on_llm_end(
+            _llm_result(
+                "anthropic/claude-sonnet-4.6",
+                _usage_metadata(input_tokens=100_000, output_tokens=0, ephemeral_1h=100_000),
+            )
+        )
+        summary = build_usage_summary(handler)
+        assert summary.cost_usd is not None
+        # Same shape as the 1h-vs-5m delta test: 100K @ ($3.75/M base + $2.25/M surcharge) = $0.600.
+        assert Decimal(summary.cost_usd) == Decimal("0.600")
+
+    def test_mixed_cache_fields_sum_into_cache_writes(self):
+        """``cache_creation``, ``ephemeral_5m_input_tokens`` and ``ephemeral_1h_input_tokens``
+        all contribute to ``cache_write_tokens``; the surcharge applies only to the 1h slice.
+        """
+        handler = CostAwareUsageMetadataCallbackHandler()
+        handler.on_llm_end(
+            _llm_result(
+                "claude-sonnet-4-6",
+                _usage_metadata(
+                    input_tokens=100_000,
+                    output_tokens=0,
+                    cache_creation=20_000,
+                    ephemeral_5m=30_000,
+                    ephemeral_1h=50_000,
+                ),
+            )
+        )
+        summary = build_usage_summary(handler)
+        assert summary.cost_usd is not None
+        # All 100K billed as cache_write at $3.75/M = $0.375, plus 50K ephemeral_1h surcharge
+        # at $2.25/M = $0.1125 → $0.4875.
+        assert Decimal(summary.cost_usd) == Decimal("0.4875")
 
 
 class TestEmptyMetadataWarning:


### PR DESCRIPTION
## Summary

- Stored ``Activity.cost_usd`` under-reported by ~40% on high-context Anthropic runs vs the cost LangSmith records for the same trace.
- Two interlocking issues: langchain-anthropic relocates 1h/5m cache-write counts to per-TTL keys (zeroing ``cache_creation``), and Anthropic's 1h-cache rate is 2× base input while genai-prices only models the 5m rate.
- Verified end-to-end against two real traces (``019df81d``, ``019df860``): the new calculation matches LangSmith's reported totals to the millicent.

## Changes

- ``_calc_model_cost`` now sums ``cache_creation`` + ``ephemeral_5m_input_tokens`` + ``ephemeral_1h_input_tokens`` into ``cache_write_tokens`` before calling ``calc_price``.
- Adds a (1h − 5m) surcharge for the ``ephemeral_1h_input_tokens`` portion when the resolved provider is Anthropic, including OpenRouter-routed Anthropic (``anthropic/...`` model names).
- New helper ``_resolve_mtok_rate`` mirrors ``genai_prices.types.calc_mtok_price`` tier selection so the surcharge picks the same tier as the rest of the cost (covers tier-priced models like Sonnet 4.5 above 200K).
- Logs a warning when the surcharge can't be applied (rate missing in pricing entry) so under-billing isn't silent.

## Test plan

- [x] Reconciles two real traces to LangSmith's totals exactly (``test_reproduces_langsmith_cost_for_known_trace``).
- [x] 5m cache writes use the genai-prices rate, no surcharge.
- [x] 1h cache writes cost exactly $2.25/M more than the same volume as 5m writes (Sonnet 4.6).
- [x] Legacy ``cache_creation`` field still flows into ``cache_write_tokens``.
- [x] Surcharge is NOT applied for non-Anthropic providers.
- [x] Tier branch exercised: 250K-token Sonnet 4.5 with 1h tokens uses the >200K tier rate.
- [x] OpenRouter-routed Anthropic gets the surcharge.
- [x] Mixed ``cache_creation`` + ``ephemeral_5m`` + ``ephemeral_1h`` in one call sums correctly.
- [x] ``make lint-fix`` and ``ty check`` clean.