### PR TITLE
fix(chat): Repair parallel tool_call args during streaming

### DIFF
--- a/daiv/chat/api/event_filter.py
+++ b/daiv/chat/api/event_filter.py
@@ -50,8 +50,13 @@ class SubagentEventFilter:
       freshly-appended ToolMessages — never the parent AIMessage — so the
       snapshot path alone cannot recover parallel siblings,
     * drops misrouted natural ``TOOL_CALL_ARGS`` events whose underlying
-      chunk's ``tool_call_chunks[0].index > 0`` — the delta belongs to a
-      sibling, not to the tcid in the event,
+      chunk's ``tool_call_chunks[0].index`` doesn't match the chunk index
+      recorded when its natural TOOL_CALL_START fired. When case #1 drops
+      the index=0 tool's START, the first natural START fires at
+      chunk.index>0 and that tool's own args stream at the same index — a
+      blanket ``index>0`` drop would discard the only naturally-streamed
+      tool's body. Tracking each tcid's natural-start chunk index keeps its
+      own deltas while still dropping siblings ag_ui_langgraph misroutes,
     * drops every nested event (``|`` in ns),
     * drops the LATE OnToolEnd re-emitted START/ARGS/END for tool_calls we
       already synthesized (deduping by tool_call_id).
@@ -60,6 +65,7 @@ class SubagentEventFilter:
     def __init__(self) -> None:
         self._synthesized: set[str] = set()
         self._natural_started: set[str] = set()
+        self._natural_index: dict[str, int] = {}
 
     async def apply(self, stream: AsyncIterator[BaseEvent]) -> AsyncIterator[BaseEvent]:
         async for event in stream:
@@ -93,6 +99,9 @@ class SubagentEventFilter:
                     continue
                 if event.type == EventType.TOOL_CALL_START and isinstance(tcid, str):
                     self._natural_started.add(tcid)
+                    idx = self._chunk_index(event)
+                    if idx is not None:
+                        self._natural_index[tcid] = idx
 
             yield event
 
@@ -115,23 +124,49 @@ class SubagentEventFilter:
         md = raw.get("metadata") or {}
         return str(md.get("langgraph_checkpoint_ns", "") or "")
 
-    @classmethod
-    def _is_misrouted_arg(cls, event: BaseEvent) -> bool:
+    def _is_misrouted_arg(self, event: BaseEvent) -> bool:
         """True if a natural TOOL_CALL_ARGS event's underlying chunk belongs to a
-        sibling tool_call (chunk index > 0) but ag_ui_langgraph attributed it to
-        the first call's tool_call_id.
+        sibling tool_call. ag_ui_langgraph attributes every streamed arg delta
+        to the first naturally-started tcid (its ``current_stream``); the
+        chunk's ``tool_call_chunks[0].index`` identifies which tool the delta
+        actually belongs to. We compare against the index recorded when this
+        tcid's natural TOOL_CALL_START fired — the static "index > 0" rule
+        only holds when the natural START claimed index=0.
+        """
+        tcid = getattr(event, "tool_call_id", None)
+        if not isinstance(tcid, str):
+            return False
+        chunk_idx = self._chunk_index(event)
+        if chunk_idx is None:
+            return False
+        natural_idx = self._natural_index.get(tcid)
+        if natural_idx is None:
+            # No natural START recorded for this tcid yet (e.g. ag_ui_langgraph
+            # dropped it via the text→tool_call transition). Fall back to the
+            # original heuristic; synthesis at on_chat_model_end will still
+            # repair the tcid's args from the AIMessage output.
+            return chunk_idx > 0
+        return chunk_idx != natural_idx
+
+    @classmethod
+    def _chunk_index(cls, event: BaseEvent) -> int | None:
+        """Read ``raw_event.data.chunk.tool_call_chunks[0].index`` if present.
+
+        Returns ``None`` for any event whose payload doesn't carry a streaming
+        chunk (e.g. STATE_SNAPSHOT, RAW, the OnToolEnd re-emit whose raw_event
+        carries ``data.input``/``data.output`` but no ``chunk``).
         """
         raw = getattr(event, "raw_event", None)
         if not isinstance(raw, dict):
-            return False
+            return None
         chunk = (raw.get("data") or {}).get("chunk")
         if chunk is None:
-            return False
+            return None
         tcc = cls._field(chunk, "tool_call_chunks") or []
         if not tcc:
-            return False
+            return None
         idx = cls._field(tcc[0], "index")
-        return isinstance(idx, int) and idx > 0
+        return idx if isinstance(idx, int) else None
 
     def _synthesize_unstarted(self, tool_calls: Iterable[tuple[str, str, Any]]) -> list[BaseEvent]:
         """Build START + (optional ARGS) + END events for every tcid not yet

--- a/daiv/chat/api/event_filter.py
+++ b/daiv/chat/api/event_filter.py
@@ -42,17 +42,13 @@ class SubagentEventFilter:
 
     This filter:
 
-    * captures every top-level tool_call from STATE_SNAPSHOT events and
-      synthesizes TOOL_CALL_START + ARGS + END for any tcid that was *not*
+    * synthesizes TOOL_CALL_START + ARGS + END for any tcid that was *not*
       naturally started by ag_ui_langgraph (the dropped #1 case AND the
-      parallel-call siblings beyond the first in #3),
-    * additionally synthesizes from ``on_chat_model_end`` RAW events. The
-      ``tools`` node's STATE_SNAPSHOTs only carry the freshly-appended
-      ToolMessages — never the parent AIMessage with the unstarted tool_calls
-      — so the snapshot path alone misses the parallel-sibling case in
-      practice. The ``on_chat_model_end`` payload carries the full AIMessage
-      (with all tool_calls and finalized args) and fires before any tool
-      executes, so synthesis here lands before the first ``TOOL_CALL_RESULT``,
+      parallel-call siblings beyond the first in #3). Two sources are watched:
+      STATE_SNAPSHOT events, and ``on_chat_model_end`` RAW events. The latter
+      is required because the ``tools`` node's STATE_SNAPSHOTs only carry the
+      freshly-appended ToolMessages — never the parent AIMessage — so the
+      snapshot path alone cannot recover parallel siblings,
     * drops misrouted natural ``TOOL_CALL_ARGS`` events whose underlying
       chunk's ``tool_call_chunks[0].index > 0`` — the delta belongs to a
       sibling, not to the tcid in the event,
@@ -78,39 +74,14 @@ class SubagentEventFilter:
                 # (e.g. the merge-request pill) commit before the synthesized
                 # tool_call segments append to the same turn.
                 yield event
-
-                pending: dict[str, tuple[str, Any]] = {}
-                for tcid, name, args in self._iter_latest_tool_calls(event):
-                    if tcid in self._synthesized or tcid in self._natural_started:
-                        continue
-                    pending[tcid] = (name, args)
-
-                for tcid, (name, args) in pending.items():
-                    yield ToolCallStartEvent(type=EventType.TOOL_CALL_START, tool_call_id=tcid, tool_call_name=name)
-                    if args:
-                        # ``default=str`` so a Pydantic model / datetime / other
-                        # non-JSON-native object in args doesn't kill the entire
-                        # chat stream — better a stringified field than RUN_ERROR.
-                        delta = args if isinstance(args, str) else json.dumps(args, default=str)
-                        yield ToolCallArgsEvent(type=EventType.TOOL_CALL_ARGS, tool_call_id=tcid, delta=delta)
-                    yield ToolCallEndEvent(type=EventType.TOOL_CALL_END, tool_call_id=tcid)
-                    self._synthesized.add(tcid)
+                for synth in self._synthesize_unstarted(self._iter_latest_tool_calls(event)):
+                    yield synth
                 continue
 
             if event.type == EventType.RAW:
                 yield event
-                pending: dict[str, tuple[str, Any]] = {}
-                for tcid, name, args in self._iter_chat_model_end_tool_calls(event):
-                    if tcid in self._synthesized or tcid in self._natural_started:
-                        continue
-                    pending[tcid] = (name, args)
-                for tcid, (name, args) in pending.items():
-                    yield ToolCallStartEvent(type=EventType.TOOL_CALL_START, tool_call_id=tcid, tool_call_name=name)
-                    if args:
-                        delta = args if isinstance(args, str) else json.dumps(args, default=str)
-                        yield ToolCallArgsEvent(type=EventType.TOOL_CALL_ARGS, tool_call_id=tcid, delta=delta)
-                    yield ToolCallEndEvent(type=EventType.TOOL_CALL_END, tool_call_id=tcid)
-                    self._synthesized.add(tcid)
+                for synth in self._synthesize_unstarted(self._iter_chat_model_end_tool_calls(event)):
+                    yield synth
                 continue
 
             if event.type == EventType.TOOL_CALL_ARGS and self._is_misrouted_arg(event):
@@ -135,11 +106,7 @@ class SubagentEventFilter:
         ``"<node>:UUID"`` segment (e.g. ``"model:..."``, ``"tools:..."``) with no
         pipe.
         """
-        # Non-RAW events expose the LangChain payload as ``raw_event``; RAW
-        # events use ``event`` (their semantic payload). Try both so RAW events
-        # emitted from a nested subgraph still get filtered out by the ``|`` ns
-        # check — otherwise they'd reach the on_chat_model_end synthesis path
-        # below and synthesize subagent tool_calls into the parent stream.
+        # RAW events carry their LC payload on ``event``; others on ``raw_event``.
         raw = getattr(event, "raw_event", None)
         if not isinstance(raw, dict):
             raw = getattr(event, "event", None)
@@ -166,11 +133,43 @@ class SubagentEventFilter:
         idx = cls._field(tcc[0], "index")
         return isinstance(idx, int) and idx > 0
 
+    def _synthesize_unstarted(self, tool_calls: Iterable[tuple[str, str, Any]]) -> list[BaseEvent]:
+        """Build START + (optional ARGS) + END events for every tcid not yet
+        emitted, recording each in ``_synthesized``. Returns a list (not a
+        generator) so callers can simply iterate-and-yield without juggling
+        ``yield from`` inside an async generator.
+        """
+        events: list[BaseEvent] = []
+        for tcid, name, args in tool_calls:
+            if tcid in self._synthesized or tcid in self._natural_started:
+                continue
+            events.append(ToolCallStartEvent(type=EventType.TOOL_CALL_START, tool_call_id=tcid, tool_call_name=name))
+            if args:
+                # ``default=str`` so a Pydantic model / datetime / other
+                # non-JSON-native object in args doesn't kill the entire chat
+                # stream — better a stringified field than RUN_ERROR.
+                delta = args if isinstance(args, str) else json.dumps(args, default=str)
+                events.append(ToolCallArgsEvent(type=EventType.TOOL_CALL_ARGS, tool_call_id=tcid, delta=delta))
+            events.append(ToolCallEndEvent(type=EventType.TOOL_CALL_END, tool_call_id=tcid))
+            self._synthesized.add(tcid)
+        return events
+
+    @classmethod
+    def _iter_tool_calls_on(cls, message: Any) -> Iterable[tuple[str, str, Any]]:
+        """Yield ``(tool_call_id, name, args)`` for every well-formed tool_call
+        on a single AIMessage (dict or BaseMessage instance).
+        """
+        for tc in cls._field(message, "tool_calls") or []:
+            tcid = cls._field(tc, "id")
+            name = cls._field(tc, "name")
+            if isinstance(tcid, str) and isinstance(name, str):
+                yield tcid, name, cls._field(tc, "args")
+
     @classmethod
     def _iter_latest_tool_calls(cls, event: BaseEvent) -> Iterable[tuple[str, str, Any]]:
-        """Yield ``(tool_call_id, name, args)`` for every tool_call on the
-        snapshot's latest AIMessage. Caller is responsible for dedup against
-        already-emitted ids — this is just the per-snapshot scan.
+        """Yield tool_calls from the snapshot's latest AIMessage. Older AIMessages
+        are skipped — their tool_calls are already in ``_synthesized`` /
+        ``_natural_started`` from prior snapshots.
         """
         snap = getattr(event, "snapshot", None)
         if not isinstance(snap, dict):
@@ -178,26 +177,16 @@ class SubagentEventFilter:
         msgs = snap.get("messages")
         if not isinstance(msgs, list):
             return
-        # Only the latest AIMessage matters — older AIMessages' tool_calls are
-        # already in ``_synthesized`` / ``_natural_started`` from prior snapshots.
         for m in reversed(msgs):
             if cls._msg_role(m) not in ("ai", "assistant"):
                 continue
-            for tc in cls._field(m, "tool_calls") or []:
-                tcid = cls._field(tc, "id")
-                name = cls._field(tc, "name")
-                if isinstance(tcid, str) and isinstance(name, str):
-                    yield tcid, name, cls._field(tc, "args")
+            yield from cls._iter_tool_calls_on(m)
             return
 
     @classmethod
     def _iter_chat_model_end_tool_calls(cls, event: BaseEvent) -> Iterable[tuple[str, str, Any]]:
-        """Yield ``(tool_call_id, name, args)`` for every tool_call on the
-        AIMessage output of an ``on_chat_model_end`` RAW event.
-
-        Returns nothing for non-RAW events, RAW events for other LangChain
-        phases, or malformed payloads — the caller treats an empty iterator
-        as "no synthesis needed" and yields the original event unchanged.
+        """Yield tool_calls from the AIMessage output of an ``on_chat_model_end``
+        RAW event. Empty for any other event shape.
         """
         if event.type != EventType.RAW:
             return
@@ -205,13 +194,8 @@ class SubagentEventFilter:
         if not isinstance(raw, dict) or raw.get("event") != "on_chat_model_end":
             return
         output = (raw.get("data") or {}).get("output")
-        if output is None:
-            return
-        for tc in cls._field(output, "tool_calls") or []:
-            tcid = cls._field(tc, "id")
-            name = cls._field(tc, "name")
-            if isinstance(tcid, str) and isinstance(name, str):
-                yield tcid, name, cls._field(tc, "args")
+        if output is not None:
+            yield from cls._iter_tool_calls_on(output)
 
     @staticmethod
     def _field(obj: Any, name: str, default: Any = None) -> Any:

--- a/daiv/chat/api/event_filter.py
+++ b/daiv/chat/api/event_filter.py
@@ -46,6 +46,13 @@ class SubagentEventFilter:
       synthesizes TOOL_CALL_START + ARGS + END for any tcid that was *not*
       naturally started by ag_ui_langgraph (the dropped #1 case AND the
       parallel-call siblings beyond the first in #3),
+    * additionally synthesizes from ``on_chat_model_end`` RAW events. The
+      ``tools`` node's STATE_SNAPSHOTs only carry the freshly-appended
+      ToolMessages — never the parent AIMessage with the unstarted tool_calls
+      — so the snapshot path alone misses the parallel-sibling case in
+      practice. The ``on_chat_model_end`` payload carries the full AIMessage
+      (with all tool_calls and finalized args) and fires before any tool
+      executes, so synthesis here lands before the first ``TOOL_CALL_RESULT``,
     * drops misrouted natural ``TOOL_CALL_ARGS`` events whose underlying
       chunk's ``tool_call_chunks[0].index > 0`` — the delta belongs to a
       sibling, not to the tcid in the event,
@@ -90,6 +97,22 @@ class SubagentEventFilter:
                     self._synthesized.add(tcid)
                 continue
 
+            if event.type == EventType.RAW:
+                yield event
+                pending: dict[str, tuple[str, Any]] = {}
+                for tcid, name, args in self._iter_chat_model_end_tool_calls(event):
+                    if tcid in self._synthesized or tcid in self._natural_started:
+                        continue
+                    pending[tcid] = (name, args)
+                for tcid, (name, args) in pending.items():
+                    yield ToolCallStartEvent(type=EventType.TOOL_CALL_START, tool_call_id=tcid, tool_call_name=name)
+                    if args:
+                        delta = args if isinstance(args, str) else json.dumps(args, default=str)
+                        yield ToolCallArgsEvent(type=EventType.TOOL_CALL_ARGS, tool_call_id=tcid, delta=delta)
+                    yield ToolCallEndEvent(type=EventType.TOOL_CALL_END, tool_call_id=tcid)
+                    self._synthesized.add(tcid)
+                continue
+
             if event.type == EventType.TOOL_CALL_ARGS and self._is_misrouted_arg(event):
                 continue
 
@@ -112,7 +135,14 @@ class SubagentEventFilter:
         ``"<node>:UUID"`` segment (e.g. ``"model:..."``, ``"tools:..."``) with no
         pipe.
         """
+        # Non-RAW events expose the LangChain payload as ``raw_event``; RAW
+        # events use ``event`` (their semantic payload). Try both so RAW events
+        # emitted from a nested subgraph still get filtered out by the ``|`` ns
+        # check — otherwise they'd reach the on_chat_model_end synthesis path
+        # below and synthesize subagent tool_calls into the parent stream.
         raw = getattr(event, "raw_event", None)
+        if not isinstance(raw, dict):
+            raw = getattr(event, "event", None)
         if not isinstance(raw, dict):
             return ""
         md = raw.get("metadata") or {}
@@ -159,6 +189,29 @@ class SubagentEventFilter:
                 if isinstance(tcid, str) and isinstance(name, str):
                     yield tcid, name, cls._field(tc, "args")
             return
+
+    @classmethod
+    def _iter_chat_model_end_tool_calls(cls, event: BaseEvent) -> Iterable[tuple[str, str, Any]]:
+        """Yield ``(tool_call_id, name, args)`` for every tool_call on the
+        AIMessage output of an ``on_chat_model_end`` RAW event.
+
+        Returns nothing for non-RAW events, RAW events for other LangChain
+        phases, or malformed payloads — the caller treats an empty iterator
+        as "no synthesis needed" and yields the original event unchanged.
+        """
+        if event.type != EventType.RAW:
+            return
+        raw = getattr(event, "event", None)
+        if not isinstance(raw, dict) or raw.get("event") != "on_chat_model_end":
+            return
+        output = (raw.get("data") or {}).get("output")
+        if output is None:
+            return
+        for tc in cls._field(output, "tool_calls") or []:
+            tcid = cls._field(tc, "id")
+            name = cls._field(tc, "name")
+            if isinstance(tcid, str) and isinstance(name, str):
+                yield tcid, name, cls._field(tc, "args")
 
     @staticmethod
     def _field(obj: Any, name: str, default: Any = None) -> Any:

--- a/daiv/chat/static/chat/js/chat-stream.js
+++ b/daiv/chat/static/chat/js/chat-stream.js
@@ -651,7 +651,9 @@
         // args streaming finishes — to flip the phase chip to done.
         const idx = this._toolIndex.get(evt.toolCallId);
         const seg = idx != null ? turn.segments[idx] : null;
-        if (seg && seg.type === "publish_phase") {
+        if (!seg) {
+          console.warn("chat: TOOL_CALL_END for unknown tool_call_id", evt.toolCallId);
+        } else if (seg.type === "publish_phase") {
           seg.status = "done";
         }
       } else if (type === AGUI.TOOL_CALL_RESULT) {

--- a/daiv/chat/static/chat/js/chat-stream.js
+++ b/daiv/chat/static/chat/js/chat-stream.js
@@ -637,16 +637,11 @@
       } else if (type === AGUI.TOOL_CALL_ARGS) {
         const idx = this._toolIndex.get(evt.toolCallId);
         const seg = idx != null ? turn.segments[idx] : null;
-        // Orphan ARGS (no preceding START for this tcid) used to drop silently.
-        // Surface them so an upstream regression — e.g. ag_ui_langgraph skipping
-        // a parallel-tool_call sibling's START — is at least visible in the
-        // console instead of producing a card with empty args.
         if (!seg) {
           console.warn("chat: TOOL_CALL_ARGS for unknown tool_call_id", evt.toolCallId);
         } else if (seg.type === "tool_call" && !seg.sealed) {
           // Phase chips intentionally ignore args (the structured-response JSON
-          // is not user-facing); sealed segments already have their final args
-          // from the natural stream and must not be appended to by re-emits.
+          // is not user-facing).
           seg.args += evt.delta || "";
         }
       } else if (type === AGUI.TOOL_CALL_END) {
@@ -663,10 +658,6 @@
         const idx = this._toolIndex.get(evt.toolCallId);
         const seg = idx != null ? turn.segments[idx] : null;
         if (!seg) {
-          // Result without a preceding START — the tool card is missing from
-          // the UI. Logged so the underlying upstream gap (e.g. a skipped
-          // TOOL_CALL_START for a parallel sibling that finishes first) shows
-          // up in the console instead of presenting as a silently-dropped edit.
           console.warn("chat: TOOL_CALL_RESULT for unknown tool_call_id", evt.toolCallId);
           return;
         }

--- a/daiv/chat/static/chat/js/chat-stream.js
+++ b/daiv/chat/static/chat/js/chat-stream.js
@@ -637,9 +637,16 @@
       } else if (type === AGUI.TOOL_CALL_ARGS) {
         const idx = this._toolIndex.get(evt.toolCallId);
         const seg = idx != null ? turn.segments[idx] : null;
-        // Phase chips intentionally ignore args (the structured-response JSON
-        // is not user-facing).
-        if (seg && seg.type === "tool_call" && !seg.sealed) {
+        // Orphan ARGS (no preceding START for this tcid) used to drop silently.
+        // Surface them so an upstream regression — e.g. ag_ui_langgraph skipping
+        // a parallel-tool_call sibling's START — is at least visible in the
+        // console instead of producing a card with empty args.
+        if (!seg) {
+          console.warn("chat: TOOL_CALL_ARGS for unknown tool_call_id", evt.toolCallId);
+        } else if (seg.type === "tool_call" && !seg.sealed) {
+          // Phase chips intentionally ignore args (the structured-response JSON
+          // is not user-facing); sealed segments already have their final args
+          // from the natural stream and must not be appended to by re-emits.
           seg.args += evt.delta || "";
         }
       } else if (type === AGUI.TOOL_CALL_END) {
@@ -655,7 +662,14 @@
       } else if (type === AGUI.TOOL_CALL_RESULT) {
         const idx = this._toolIndex.get(evt.toolCallId);
         const seg = idx != null ? turn.segments[idx] : null;
-        if (!seg) return;
+        if (!seg) {
+          // Result without a preceding START — the tool card is missing from
+          // the UI. Logged so the underlying upstream gap (e.g. a skipped
+          // TOOL_CALL_START for a parallel sibling that finishes first) shows
+          // up in the console instead of presenting as a silently-dropped edit.
+          console.warn("chat: TOOL_CALL_RESULT for unknown tool_call_id", evt.toolCallId);
+          return;
+        }
         if (seg.type === "publish_phase") {
           seg.status = "done";
         } else {

--- a/tests/unit_tests/chat/api/test_event_filter.py
+++ b/tests/unit_tests/chat/api/test_event_filter.py
@@ -286,9 +286,10 @@ async def test_filter_synthesizes_args_string_passthrough_without_reencoding():
 
 async def test_filter_only_synthesizes_latest_ai_message_tool_calls():
     # Older AI messages in the snapshot have already been streamed (their
-    # tool_calls are in ``task_calls`` from a prior snapshot). The filter
-    # must only consider the latest AIMessage so a snapshot reissuing old
-    # history doesn't re-trigger synthesis for already-completed tasks.
+    # tcids are recorded in ``_synthesized`` / ``_natural_started`` from a
+    # prior snapshot). The filter must only consider the latest AIMessage so
+    # a snapshot reissuing old history doesn't re-trigger synthesis for
+    # already-completed tasks.
     snapshot = _ev(
         StateSnapshotEvent,
         ns="",
@@ -312,7 +313,7 @@ async def test_filter_drops_misrouted_args_for_sibling_tool_calls():
     # carry the *first* tool's id but the underlying chunk's
     # ``tool_call_chunks[0].index`` points at the sibling. Drop those so the
     # first tool's args don't get a concatenated JSON blob; the sibling is
-    # recovered via STATE_SNAPSHOT synthesis.
+    # recovered via synthesis (STATE_SNAPSHOT or on_chat_model_end RAW).
     natural_start = _ev(
         ToolCallStartEvent,
         ns="model:m",
@@ -340,6 +341,41 @@ async def test_filter_drops_misrouted_args_for_sibling_tool_calls():
     out = await _drain(_filter([natural_start, own_arg, sibling_arg]))
     assert [e.type for e in out] == [EventType.TOOL_CALL_START, EventType.TOOL_CALL_ARGS]
     assert out[1].delta == '{"path":"a.py"}'
+
+
+async def test_filter_keeps_own_args_when_natural_start_at_nonzero_index():
+    # When ag_ui_langgraph drops the index=0 sibling's TOOL_CALL_START via the
+    # text→tool_call transition, the first natural START fires for the *next*
+    # tool with chunk.index=1 (or higher). That tool's own args also stream at
+    # the same index — a blanket ``index > 0`` drop would discard them and
+    # leave the only naturally-streamed tool with no body. The recorded-index
+    # check must keep its own deltas while still dropping siblings the LLM
+    # streams afterwards.
+    natural_start = _ev(
+        ToolCallStartEvent,
+        ns="model:m",
+        chunk={"tool_call_chunks": [{"index": 1, "id": "tc-second", "name": "gitlab", "args": ""}]},
+        tool_call_id="tc-second",
+        tool_call_name="gitlab",
+    )
+    own_arg = _ev(
+        ToolCallArgsEvent,
+        ns="model:m",
+        chunk={"tool_call_chunks": [{"index": 1, "args": '{"path":"a"}'}]},
+        tool_call_id="tc-second",
+        delta='{"path":"a"}',
+    )
+    # Sibling at chunk.index=2 — ag_ui_langgraph still routes under tc-second.
+    sibling_arg = _ev(
+        ToolCallArgsEvent,
+        ns="model:m",
+        chunk={"tool_call_chunks": [{"index": 2, "args": '{"path":"b"}'}]},
+        tool_call_id="tc-second",
+        delta='{"path":"b"}',
+    )
+    out = await _drain(_filter([natural_start, own_arg, sibling_arg]))
+    assert [e.type for e in out] == [EventType.TOOL_CALL_START, EventType.TOOL_CALL_ARGS]
+    assert out[1].delta == '{"path":"a"}'
 
 
 async def test_filter_synthesizes_sibling_tool_calls_after_natural_first():

--- a/tests/unit_tests/chat/api/test_event_filter.py
+++ b/tests/unit_tests/chat/api/test_event_filter.py
@@ -9,6 +9,7 @@ subagent has already streamed events.
 
 from ag_ui.core.events import (
     EventType,
+    RawEvent,
     StateSnapshotEvent,
     TextMessageContentEvent,
     TextMessageStartEvent,
@@ -26,6 +27,21 @@ def _ev(klass, *, ns: str = "", chunk: dict | None = None, **kwargs):
     if chunk is not None:
         raw["data"] = {"chunk": chunk}
     return klass(raw_event=raw, **kwargs)
+
+
+def _chat_model_end(*, output: object | None, ns: str = "") -> RawEvent:
+    """Construct a ``RawEvent`` shaped like ag_ui_langgraph's ``on_chat_model_end``.
+
+    Mirrors the live stream: payload sits on ``event`` (not ``raw_event``), the
+    LangChain event name is ``on_chat_model_end``, and the AIMessage output is
+    under ``data.output``. ``ns`` lets tests assert nested-subgraph filtering.
+    """
+    payload: dict = {
+        "event": "on_chat_model_end",
+        "metadata": {"langgraph_checkpoint_ns": ns},
+        "data": {"output": output},
+    }
+    return RawEvent(event=payload)
 
 
 async def _drain(stream):
@@ -454,6 +470,164 @@ async def test_filter_drops_misrouted_args_for_already_synthesized_tcid():
     args_events = [e for e in out if e.type == EventType.TOOL_CALL_ARGS]
     # Only the synthesized ARGS for tc-s — the misrouted one is dropped.
     assert [a.delta for a in args_events] == ['{"x": 1}']
+
+
+async def test_filter_synthesizes_from_chat_model_end_for_parallel_siblings():
+    # The realistic parallel-edit scenario: the model streams natural
+    # START/ARGS/END for the first tool_call only, then on_chat_model_end
+    # arrives carrying all three tcids in its AIMessage output. Without this
+    # path the tools node's STATE_SNAPSHOT only contains the per-tool
+    # ToolMessages (no AIMessage), so the snapshot synthesis path can't catch
+    # the missing siblings — they have to be synthesized here.
+    natural_start = _ev(
+        ToolCallStartEvent,
+        ns="model:m",
+        chunk={"tool_call_chunks": [{"index": 0, "id": "tc1", "name": "edit_file", "args": ""}]},
+        tool_call_id="tc1",
+        tool_call_name="edit_file",
+    )
+    natural_end = _ev(ToolCallEndEvent, ns="model:m", tool_call_id="tc1")
+    model_end = _chat_model_end(
+        output={
+            "type": "ai",
+            "tool_calls": [
+                {"id": "tc1", "name": "edit_file", "args": {"path": "a.md"}},
+                {"id": "tc2", "name": "edit_file", "args": {"path": "b.md"}},
+                {"id": "tc3", "name": "edit_file", "args": {"path": "c.md"}},
+            ],
+        }
+    )
+    out = await _drain(_filter([natural_start, natural_end, model_end]))
+    starts = [(e.tool_call_id, e.tool_call_name) for e in out if e.type == EventType.TOOL_CALL_START]
+    # tc1 from the natural stream + tc2 and tc3 synthesized from on_chat_model_end.
+    assert starts == [("tc1", "edit_file"), ("tc2", "edit_file"), ("tc3", "edit_file")]
+    args = [(e.tool_call_id, e.delta) for e in out if e.type == EventType.TOOL_CALL_ARGS]
+    # Synthesized siblings carry their finalized args; the natural tc1 had no
+    # ARGS event in this minimal sequence so it doesn't appear here.
+    assert args == [("tc2", '{"path": "b.md"}'), ("tc3", '{"path": "c.md"}')]
+
+
+async def test_filter_chat_model_end_dedupes_late_reemit():
+    # After on_chat_model_end synthesizes a sibling's START/ARGS/END, the late
+    # OnToolEnd re-emit carrying the same tcid must be dropped — otherwise the
+    # chat UI sees duplicate START events and either renders two cards or has
+    # to seal the second one defensively.
+    model_end = _chat_model_end(
+        output={"type": "ai", "tool_calls": [{"id": "tc-x", "name": "edit_file", "args": {"k": 1}}]}
+    )
+    late_start = _ev(ToolCallStartEvent, ns="tools:p", tool_call_id="tc-x", tool_call_name="edit_file")
+    late_args = _ev(ToolCallArgsEvent, ns="tools:p", tool_call_id="tc-x", delta='{"k":1}')
+    late_end = _ev(ToolCallEndEvent, ns="tools:p", tool_call_id="tc-x")
+    result = _ev(ToolCallResultEvent, ns="", tool_call_id="tc-x", message_id="r", content="ok")
+
+    out = await _drain(_filter([model_end, late_start, late_args, late_end, result]))
+    types = [e.type for e in out]
+    # RAW (passes through) + synthesized START/ARGS/END + RESULT — late re-emit dropped.
+    assert types == [
+        EventType.RAW,
+        EventType.TOOL_CALL_START,
+        EventType.TOOL_CALL_ARGS,
+        EventType.TOOL_CALL_END,
+        EventType.TOOL_CALL_RESULT,
+    ]
+
+
+async def test_filter_chat_model_end_skips_naturally_started_tcid():
+    # If a tcid was naturally started during streaming, on_chat_model_end must
+    # NOT re-synthesize it — that would produce a duplicate START event for a
+    # tool whose card already exists.
+    natural = _ev(
+        ToolCallStartEvent,
+        ns="model:m",
+        chunk={"tool_call_chunks": [{"index": 0, "id": "tc1", "name": "edit_file", "args": ""}]},
+        tool_call_id="tc1",
+        tool_call_name="edit_file",
+    )
+    model_end = _chat_model_end(
+        output={"type": "ai", "tool_calls": [{"id": "tc1", "name": "edit_file", "args": {"x": 1}}]}
+    )
+    out = await _drain(_filter([natural, model_end]))
+    starts = [e for e in out if e.type == EventType.TOOL_CALL_START]
+    assert [s.tool_call_id for s in starts] == ["tc1"]
+
+
+async def test_filter_chat_model_end_skips_already_synthesized_tcid():
+    # Snapshot fires first (rare but possible) and synthesizes tc1; the
+    # subsequent on_chat_model_end must not re-synthesize the same tcid.
+    snapshot = _ev(
+        StateSnapshotEvent,
+        ns="",
+        snapshot={"messages": [{"type": "ai", "tool_calls": [{"id": "tc1", "name": "edit_file", "args": {}}]}]},
+    )
+    model_end = _chat_model_end(output={"type": "ai", "tool_calls": [{"id": "tc1", "name": "edit_file", "args": {}}]})
+    out = await _drain(_filter([snapshot, model_end]))
+    starts = [e for e in out if e.type == EventType.TOOL_CALL_START]
+    assert [s.tool_call_id for s in starts] == ["tc1"]
+
+
+async def test_filter_passes_unrelated_raw_events_through():
+    # RAW events for non-on_chat_model_end phases (on_chat_model_stream,
+    # on_tool_start, etc.) must pass through unchanged with no synthesis.
+    other_raw = RawEvent(event={"event": "on_tool_start", "metadata": {"langgraph_checkpoint_ns": ""}})
+    out = await _drain(_filter([other_raw]))
+    assert [e.type for e in out] == [EventType.RAW]
+
+
+async def test_filter_drops_nested_chat_model_end_raw():
+    # A RAW on_chat_model_end emitted from a nested subgraph must be dropped
+    # entirely — synthesizing the subagent's tool_calls into the parent stream
+    # would create phantom cards for tools the parent never invoked.
+    nested_model_end = _chat_model_end(
+        ns="tools:p|model:s",
+        output={"type": "ai", "tool_calls": [{"id": "tc-nested", "name": "edit_file", "args": {}}]},
+    )
+    out = await _drain(_filter([nested_model_end]))
+    assert out == []
+
+
+async def test_filter_chat_model_end_handles_malformed_payloads():
+    # Defensive: malformed RAW shapes must not crash the filter; the event
+    # passes through with no synthesis.
+    cases = [
+        # No data key at all.
+        RawEvent(event={"event": "on_chat_model_end", "metadata": {"langgraph_checkpoint_ns": ""}}),
+        # data.output is None.
+        RawEvent(
+            event={"event": "on_chat_model_end", "metadata": {"langgraph_checkpoint_ns": ""}, "data": {"output": None}}
+        ),
+        # tool_calls missing on the output.
+        RawEvent(
+            event={
+                "event": "on_chat_model_end",
+                "metadata": {"langgraph_checkpoint_ns": ""},
+                "data": {"output": {"type": "ai", "content": "no tools"}},
+            }
+        ),
+        # tool_call entry missing id.
+        RawEvent(
+            event={
+                "event": "on_chat_model_end",
+                "metadata": {"langgraph_checkpoint_ns": ""},
+                "data": {"output": {"type": "ai", "tool_calls": [{"name": "edit_file", "args": {}}]}},
+            }
+        ),
+    ]
+    for ev in cases:
+        out = await _drain(_filter([ev]))
+        assert [e.type for e in out] == [EventType.RAW], f"failed for raw={ev.event}"
+
+
+async def test_filter_chat_model_end_handles_aimessage_object():
+    # In the live stream the on_chat_model_end output is an AIMessage instance
+    # (the AGUI encoder serializes objects to dicts later, but this filter
+    # sits in front of the encoder). ``_field`` must read attributes too.
+    from langchain_core.messages import AIMessage
+
+    output = AIMessage(content="", id="m1", tool_calls=[{"id": "tc-obj", "name": "edit_file", "args": {"k": 1}}])
+    model_end = _chat_model_end(output=output)
+    out = await _drain(_filter([model_end]))
+    starts = [e for e in out if e.type == EventType.TOOL_CALL_START]
+    assert [(s.tool_call_id, s.tool_call_name) for s in starts] == [("tc-obj", "edit_file")]
 
 
 async def test_filter_skips_synthesis_when_latest_ai_has_no_tool_calls():

--- a/tests/unit_tests/chat/api/test_event_filter.py
+++ b/tests/unit_tests/chat/api/test_event_filter.py
@@ -30,11 +30,8 @@ def _ev(klass, *, ns: str = "", chunk: dict | None = None, **kwargs):
 
 
 def _chat_model_end(*, output: object | None, ns: str = "") -> RawEvent:
-    """Construct a ``RawEvent`` shaped like ag_ui_langgraph's ``on_chat_model_end``.
-
-    Mirrors the live stream: payload sits on ``event`` (not ``raw_event``), the
-    LangChain event name is ``on_chat_model_end``, and the AIMessage output is
-    under ``data.output``. ``ns`` lets tests assert nested-subgraph filtering.
+    """Mirror ag_ui_langgraph's ``on_chat_model_end`` shape: payload on ``event``
+    (not ``raw_event``), AIMessage output under ``data.output``.
     """
     payload: dict = {
         "event": "on_chat_model_end",
@@ -473,12 +470,8 @@ async def test_filter_drops_misrouted_args_for_already_synthesized_tcid():
 
 
 async def test_filter_synthesizes_from_chat_model_end_for_parallel_siblings():
-    # The realistic parallel-edit scenario: the model streams natural
-    # START/ARGS/END for the first tool_call only, then on_chat_model_end
-    # arrives carrying all three tcids in its AIMessage output. Without this
-    # path the tools node's STATE_SNAPSHOT only contains the per-tool
-    # ToolMessages (no AIMessage), so the snapshot synthesis path can't catch
-    # the missing siblings — they have to be synthesized here.
+    # Snapshot synthesis can't catch this case — the tools node's snapshots
+    # only carry the per-tool ToolMessages, not the parent AIMessage.
     natural_start = _ev(
         ToolCallStartEvent,
         ns="model:m",
@@ -508,10 +501,6 @@ async def test_filter_synthesizes_from_chat_model_end_for_parallel_siblings():
 
 
 async def test_filter_chat_model_end_dedupes_late_reemit():
-    # After on_chat_model_end synthesizes a sibling's START/ARGS/END, the late
-    # OnToolEnd re-emit carrying the same tcid must be dropped — otherwise the
-    # chat UI sees duplicate START events and either renders two cards or has
-    # to seal the second one defensively.
     model_end = _chat_model_end(
         output={"type": "ai", "tool_calls": [{"id": "tc-x", "name": "edit_file", "args": {"k": 1}}]}
     )
@@ -533,9 +522,6 @@ async def test_filter_chat_model_end_dedupes_late_reemit():
 
 
 async def test_filter_chat_model_end_skips_naturally_started_tcid():
-    # If a tcid was naturally started during streaming, on_chat_model_end must
-    # NOT re-synthesize it — that would produce a duplicate START event for a
-    # tool whose card already exists.
     natural = _ev(
         ToolCallStartEvent,
         ns="model:m",
@@ -552,8 +538,6 @@ async def test_filter_chat_model_end_skips_naturally_started_tcid():
 
 
 async def test_filter_chat_model_end_skips_already_synthesized_tcid():
-    # Snapshot fires first (rare but possible) and synthesizes tc1; the
-    # subsequent on_chat_model_end must not re-synthesize the same tcid.
     snapshot = _ev(
         StateSnapshotEvent,
         ns="",
@@ -566,17 +550,14 @@ async def test_filter_chat_model_end_skips_already_synthesized_tcid():
 
 
 async def test_filter_passes_unrelated_raw_events_through():
-    # RAW events for non-on_chat_model_end phases (on_chat_model_stream,
-    # on_tool_start, etc.) must pass through unchanged with no synthesis.
     other_raw = RawEvent(event={"event": "on_tool_start", "metadata": {"langgraph_checkpoint_ns": ""}})
     out = await _drain(_filter([other_raw]))
     assert [e.type for e in out] == [EventType.RAW]
 
 
 async def test_filter_drops_nested_chat_model_end_raw():
-    # A RAW on_chat_model_end emitted from a nested subgraph must be dropped
-    # entirely — synthesizing the subagent's tool_calls into the parent stream
-    # would create phantom cards for tools the parent never invoked.
+    # Synthesizing a subagent's tool_calls into the parent stream would create
+    # phantom cards for tools the parent never invoked.
     nested_model_end = _chat_model_end(
         ns="tools:p|model:s",
         output={"type": "ai", "tool_calls": [{"id": "tc-nested", "name": "edit_file", "args": {}}]},
@@ -586,8 +567,6 @@ async def test_filter_drops_nested_chat_model_end_raw():
 
 
 async def test_filter_chat_model_end_handles_malformed_payloads():
-    # Defensive: malformed RAW shapes must not crash the filter; the event
-    # passes through with no synthesis.
     cases = [
         # No data key at all.
         RawEvent(event={"event": "on_chat_model_end", "metadata": {"langgraph_checkpoint_ns": ""}}),
@@ -618,9 +597,8 @@ async def test_filter_chat_model_end_handles_malformed_payloads():
 
 
 async def test_filter_chat_model_end_handles_aimessage_object():
-    # In the live stream the on_chat_model_end output is an AIMessage instance
-    # (the AGUI encoder serializes objects to dicts later, but this filter
-    # sits in front of the encoder). ``_field`` must read attributes too.
+    # In the live stream output arrives as an AIMessage instance (this filter
+    # runs in front of the AGUI encoder that serializes to dicts).
     from langchain_core.messages import AIMessage
 
     output = AIMessage(content="", id="m1", tool_calls=[{"id": "tc-obj", "name": "edit_file", "args": {"k": 1}}])


### PR DESCRIPTION
## Summary

Follow-up to #1161 — addresses two remaining cases where parallel tool_call cards rendered empty (or out of order) during streaming but loaded correctly after a page reload.

- **Synthesize TOOL_CALL_START/ARGS/END from `on_chat_model_end`.** The tools-node STATE_SNAPSHOTs only carry the freshly-appended ToolMessages — never the parent AIMessage — so the snapshot synthesis path alone cannot recover parallel siblings. Watching `on_chat_model_end` RAW events lets the filter emit the missing siblings as soon as the parent's AIMessage is finalized.
- **Track each natural-started tcid's chunk.index.** When `ag_ui_langgraph` drops the index=0 sibling's TOOL_CALL_START on the text→tool_call transition, the first natural START fires for the *next* tool at chunk.index>0 — and that tool's own args also stream at that index. The previous blanket `index > 0` rule discarded them, leaving the only naturally-streamed tool with empty args.
- **Surface orphan tool_call lifecycle events.** Server-side filter drift would have silently lost tool cards before; the JS dispatcher now `console.warn`s on orphan ARGS/END/RESULT instead of swallowing them.

## Test plan

- [x] \`uv run pytest tests/unit_tests/chat/api/test_event_filter.py\` — 27/27 pass, 91.85% file coverage
- [x] \`make lint-fix\` — clean
- [ ] Live verification: parallel \`gitlab project-pipeline-job list\` / \`project-job trace\` calls render with full subcommand summaries (\`detailed\` badge, expanded body) during streaming, not only after reload