### PR TITLE
docs(jobs-api): Adapt RT triage scrip and docs to batch endpoint

### DIFF
--- a/docs/features/jobs-api.md
+++ b/docs/features/jobs-api.md
@@ -54,12 +54,12 @@ POST /api/jobs
 
 **Request body:**
 
-| Field     | Type   | Required | Description |
-|-----------|--------|----------|-------------|
-| `repo_id` | string  | yes      | Repository identifier (e.g., `group/project`) |
-| `prompt`  | string  | yes      | The prompt to send to the agent |
-| `ref`     | string  | no       | Git ref (branch/tag). Defaults to the repository's default branch |
-| `use_max` | boolean | no       | Use the more capable model with thinking set to high. Defaults to `false` |
+| Field       | Type             | Required | Description |
+|-------------|------------------|----------|-------------|
+| `repos`     | array of objects | yes      | 1–20 repositories to run against. Each item: `{ "repo_id": "group/project", "ref": "branch-or-sha" }` — `ref` is optional and defaults to the repository's default branch. |
+| `prompt`    | string           | yes      | The prompt to send to the agent. The same prompt runs as an independent job against each repository in `repos`. |
+| `use_max`   | boolean          | no       | Use the more capable model with thinking set to high. Defaults to `false`. |
+| `notify_on` | string           | no       | Override the user's notification preference for this batch. One of `never`, `always`, `on_success`, `on_failure`. |
 
 **Example:**
 
@@ -68,7 +68,7 @@ curl -s -X POST https://daiv.example.com/api/jobs \
   -H "Authorization: Bearer $DAIV_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-    "repo_id": "mygroup/myproject",
+    "repos": [{"repo_id": "mygroup/myproject"}],
     "prompt": "List all Python files and summarize the project structure"
   }'
 ```
@@ -77,9 +77,19 @@ curl -s -X POST https://daiv.example.com/api/jobs \
 
 ```json
 {
-  "job_id": "1adfbf7a-917e-4f2e-8f54-17a27c006ec5"
+  "batch_id": "5b9e8a3c-9b7e-4c0d-a1f5-7e2c8d4b1a90",
+  "jobs": [
+    {
+      "job_id": "1adfbf7a-917e-4f2e-8f54-17a27c006ec5",
+      "repo_id": "mygroup/myproject",
+      "ref": null
+    }
+  ],
+  "failed": []
 }
 ```
+
+Each entry in `jobs` is an independent run — poll each `job_id` separately. Pre-enqueue rejections (e.g. unknown `repo_id`) are reported in `failed` as `{repo_id, ref, error}`; the rest of the batch still runs.
 
 ### Poll job status
 
@@ -94,12 +104,15 @@ GET /api/jobs/{job_id}
   "job_id": "1adfbf7a-917e-4f2e-8f54-17a27c006ec5",
   "status": "SUCCESSFUL",
   "result": "Here are the Python files...",
+  "merge_request_url": null,
   "error": null,
   "created_at": "2026-03-27T18:22:39.012Z",
   "started_at": "2026-03-27T18:22:39.401Z",
   "finished_at": "2026-03-27T18:22:52.402Z"
 }
 ```
+
+`merge_request_url` is populated when the agent produced code changes that were committed and pushed; `null` otherwise (e.g. read-only triage runs).
 
 **Status values:**
 
@@ -138,12 +151,12 @@ Once a job reaches `SUCCESSFUL` or `FAILED`, the status is final. The `result` f
 DAIV_URL="https://daiv.example.com"
 API_KEY="your-api-key"
 
-# Submit
+# Submit (single-repo batch)
 JOB_ID=$(curl -s -X POST "$DAIV_URL/api/jobs" \
   -H "Authorization: Bearer $API_KEY" \
   -H "Content-Type: application/json" \
-  -d '{"repo_id":"mygroup/myproject","prompt":"List all TODO comments"}' \
-  | jq -r '.job_id')
+  -d '{"repos":[{"repo_id":"mygroup/myproject"}],"prompt":"List all TODO comments"}' \
+  | jq -r '.jobs[0].job_id')
 
 echo "Job submitted: $JOB_ID"
 
@@ -177,9 +190,9 @@ triage-and-create-issues:
         -H "Authorization: Bearer $DAIV_API_KEY" \
         -H "Content-Type: application/json" \
         -d '{
-          "repo_id": "mygroup/myproject",
+          "repos": [{"repo_id": "mygroup/myproject"}],
           "prompt": "Triage the RT queue and identify code-related tickets. Return a summary with ticket IDs, descriptions, and priorities."
-        }' | jq -r '.job_id')
+        }' | jq -r '.jobs[0].job_id')
 
     # Step 2: Poll until done
     - |
@@ -199,7 +212,7 @@ triage-and-create-issues:
         -H "Authorization: Bearer $DAIV_API_KEY" \
         -H "Content-Type: application/json" \
         -d "$(jq -n --arg prompt "Based on this triage report, create GitLab issues for each actionable item: $TRIAGE" \
-          '{repo_id: "mygroup/myproject", prompt: $prompt}')"
+          '{repos: [{repo_id: "mygroup/myproject"}], prompt: $prompt}')"
 ```
 
 !!! tip

--- a/docs/integrations/rt/index.md
+++ b/docs/integrations/rt/index.md
@@ -61,7 +61,7 @@ Reload RT after editing: `apache2ctl graceful` (or whichever reload command your
    | Stage | `TransactionCreate` |
    | Applies To | *(leave empty for now — configured in step 3)* |
 
-3. Paste the body of [`rt-daiv-triage.scrip.pl`](rt-daiv-triage.scrip.pl) into the **Custom action preparation code** field. Leave **Custom condition** and **Custom action cleanup code** empty. Save.
+3. Put `return 1;` in the **Custom action preparation code** field and paste the body of [`rt-daiv-triage.scrip.pl`](rt-daiv-triage.scrip.pl) into the **Custom action cleanup code** field. Leave **Custom condition** empty. Save. (Cleanup runs after the ticket transaction is committed, so the agent can load the new ticket via the RT MCP.)
 
 4. Edit the `%QUEUE_REPO_MAP` hash at the top of the pasted code so each queue you care about maps to the correct DAIV `repo_id` (e.g. `group/project`).
 
@@ -77,7 +77,7 @@ Start with a single pilot queue. Expand only after the pilot looks healthy.
 2. `tail -f /var/log/request-tracker4/rt.log` (or your RT log path) — look for:
 
    ```
-   daiv-triage: submitted job <uuid> for ticket <id> (queue=... repo=...)
+   daiv-triage: submitted job <uuid> (batch <uuid>) for ticket <id> (queue=... repo=...)
    ```
 
 3. Open the DAIV **Activity** page and confirm a new `API_JOB` run exists for the target repo.

--- a/docs/integrations/rt/rt-daiv-triage.scrip.pl
+++ b/docs/integrations/rt/rt-daiv-triage.scrip.pl
@@ -10,8 +10,10 @@
 #     Stage:         TransactionCreate
 #     Applies To:    (select the queues you want triaged)
 #
-# Paste the body below into the "Custom action preparation code" field
-# (leave "Custom condition" and "Custom action cleanup code" empty).
+# Put `return 1;` in the "Custom action preparation code" field and paste
+# the body below into the "Custom action cleanup code" field (leave
+# "Custom condition" empty). Cleanup runs after the ticket transaction
+# is committed, so the agent can load the ticket via the RT MCP.
 #
 # Requires two entries in RT_SiteConfig.pm:
 #   Set($DAIV_URL,     'https://daiv.example.com');
@@ -89,7 +91,7 @@ End with a one-line **Recommendation** (e.g. "assign to backend",
 PROMPT
 
         my $payload = JSON::encode_json({
-            repo_id => $repo,
+            repos   => [ { repo_id => $repo } ],
             prompt  => $prompt,
             use_max => JSON::true,
         });
@@ -106,11 +108,15 @@ PROMPT
             # A malformed 2xx body must not masquerade as a submit failure —
             # the job was accepted. Guard decode_json separately and log a
             # warning instead of letting the outer eval call it an exception.
-            my $raw    = $res->decoded_content // '';
-            my $parsed = eval { JSON::decode_json($raw) };
-            my $job_id = (ref($parsed) eq 'HASH' && $parsed->{job_id}) || '?';
+            my $raw      = $res->decoded_content // '';
+            my $parsed   = eval { JSON::decode_json($raw) };
+            my $batch_id = (ref($parsed) eq 'HASH' && $parsed->{batch_id}) || '?';
+            my $job_id   = '?';
+            if (ref($parsed) eq 'HASH' && ref($parsed->{jobs}) eq 'ARRAY' && @{$parsed->{jobs}}) {
+                $job_id = $parsed->{jobs}[0]{job_id} // '?';
+            }
             $RT::Logger->info(
-                "daiv-triage: submitted job $job_id for ticket $id (queue=$queue repo=$repo)"
+                "daiv-triage: submitted job $job_id (batch $batch_id) for ticket $id (queue=$queue repo=$repo)"
             );
         }
         elsif ($res->code == 429) {


### PR DESCRIPTION
## Summary

- Update [`rt-daiv-triage.scrip.pl`](docs/integrations/rt/rt-daiv-triage.scrip.pl) to the batch payload (`repos: [{repo_id}]`) and parse the new `{batch_id, jobs[]}` response.
- Move install instructions from "Custom action preparation code" to "Custom action cleanup code" so the ticket transaction is committed before the agent loads the ticket via the RT MCP; the preparation field just returns `1`.
- Refresh [`docs/features/jobs-api.md`](docs/features/jobs-api.md): replace the single-repo schema and curl/jq examples with the batch shape, document `notify_on`, and add `merge_request_url` to the poll-status response.

## Test plan

- [ ] Visual review of the rendered docs (`mkdocs serve`) for both `Jobs API` and `Request Tracker Triage` pages.
- [ ] Smoke-test the updated scrip body against a dev DAIV deployment: file a test ticket and confirm the log line `daiv-triage: submitted job <uuid> (batch <uuid>) for ticket <id> ...` appears and the agent posts the internal comment.