### PR TITLE
feat(chat): Tighten composer dock and add AI disclaimer

### DIFF
--- a/daiv/chat/templates/chat/_composer.html
+++ b/daiv/chat/templates/chat/_composer.html
@@ -1,92 +1,98 @@
 {% load i18n %}
-<form @submit.prevent="submit()"
-      class="chat-composer"
-      :class="{ 'chat-composer--sending': (streaming || resuming) }"
-      x-show="thread || draftRepoId"
-      x-transition.opacity.duration.300ms>
+<div class="chat-dock"
+     x-show="thread || draftRepoId"
+     x-transition.opacity.duration.300ms>
+  <form @submit.prevent="submit()"
+        class="chat-composer"
+        :class="{ 'chat-composer--sending': (streaming || resuming) }">
 
-  <button type="button"
-          class="chat-jump"
-          x-show="showJumpToLatest"
-          @click="scrollToBottom({force: true})"
-          x-transition.opacity>↓ {% trans "Jump to latest" %}</button>
+    <button type="button"
+            class="chat-jump"
+            x-show="showJumpToLatest"
+            @click="scrollToBottom({force: true})"
+            x-transition.opacity>↓ {% trans "Jump to latest" %}</button>
 
-  {% comment %}
-  Chip is suppressed while the user is still composing their first prompt — the picker's
-  own chip in the hero already advertises the selection. Once the first message is sent
-  the hero unmounts and `thread` becomes truthy, so the chip takes over here.
-  {% endcomment %}
-  <div class="chat-composer__meta" x-show="thread" x-cloak>
-    <span class="repo-chip">
-      <span class="repo-chip__btn">
-        <svg class="h-3.5 w-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-          <path d="M4 6h16M4 12h16M4 18h10"/>
-        </svg>
-        <span x-text="thread?.repo_id"></span>
-      </span>
-      <span class="repo-chip__btn"
-            :class="thread?.merge_request ? 'repo-chip__btn--accent' : ''">
-        <svg class="h-3.5 w-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-          <path d="M6 3v12a3 3 0 003 3h9m-3-3l3 3-3 3"/>
-          <circle cx="6" cy="18" r="3"/>
-          <circle cx="18" cy="6" r="3"/>
-        </svg>
-        <span class="repo-chip__btn--branch" x-text="thread?.ref"></span>
-      </span>
-    </span>
-
-    {# MR pill — only renders once the agent's commit has produced a merge request. #}
-    <template x-if="thread?.merge_request">
-      <a class="repo-chip repo-chip--mr"
-         :href="thread.merge_request.url || '#'"
-         :target="thread.merge_request.url ? '_blank' : '_self'"
-         rel="noopener noreferrer"
-         :title="thread.merge_request.title || ''">
+    {% comment %}
+    Chip is suppressed while the user is still composing their first prompt — the picker's
+    own chip in the hero already advertises the selection. Once the first message is sent
+    the hero unmounts and `thread` becomes truthy, so the chip takes over here.
+    {% endcomment %}
+    <div class="chat-composer__meta" x-show="thread" x-cloak>
+      <span class="repo-chip">
         <span class="repo-chip__btn">
-          <svg class="h-3.5 w-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <circle cx="6" cy="6" r="2.5"/>
-            <circle cx="6" cy="18" r="2.5"/>
-            <circle cx="18" cy="18" r="2.5"/>
-            <path d="M6 8.5v7"/>
-            <path d="M6 6h7a5 5 0 015 5v4.5"/>
+          <svg class="h-3.5 w-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M4 6h16M4 12h16M4 18h10"/>
           </svg>
-          <span x-text="thread.merge_request.id ? '!' + thread.merge_request.id : '{% trans "MR" %}'"></span>
-          <span x-show="thread.merge_request.draft"
-                class="repo-chip__badge"
-                x-cloak>{% trans "draft" %}</span>
+          <span x-text="thread?.repo_id"></span>
         </span>
-      </a>
-    </template>
-  </div>
+        <span class="repo-chip__btn"
+              :class="thread?.merge_request ? 'repo-chip__btn--accent' : ''">
+          <svg class="h-3.5 w-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <path d="M6 3v12a3 3 0 003 3h9m-3-3l3 3-3 3"/>
+            <circle cx="6" cy="18" r="3"/>
+            <circle cx="18" cy="6" r="3"/>
+          </svg>
+          <span class="repo-chip__btn--branch" x-text="thread?.ref"></span>
+        </span>
+      </span>
 
-  <label for="chat_prompt" class="sr-only">{% trans "Message DAIV" %}</label>
-  <textarea id="chat_prompt"
-            x-ref="prompt"
-            x-model="draftMessage"
-            @input="autosize()"
-            @keydown.meta.enter.prevent="submit()"
-            @keydown.ctrl.enter.prevent="submit()"
-            rows="2"
-            :disabled="(streaming || resuming)"
-            placeholder="{% trans 'Describe the change, the bug, or what to explore…' %}"
-            class="chat-composer__textarea"></textarea>
+      {# MR pill — only renders once the agent's commit has produced a merge request. #}
+      <template x-if="thread?.merge_request">
+        <a class="repo-chip repo-chip--mr"
+           :href="thread.merge_request.url || '#'"
+           :target="thread.merge_request.url ? '_blank' : '_self'"
+           rel="noopener noreferrer"
+           :title="thread.merge_request.title || ''">
+          <span class="repo-chip__btn">
+            <svg class="h-3.5 w-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <circle cx="6" cy="6" r="2.5"/>
+              <circle cx="6" cy="18" r="2.5"/>
+              <circle cx="18" cy="18" r="2.5"/>
+              <path d="M6 8.5v7"/>
+              <path d="M6 6h7a5 5 0 015 5v4.5"/>
+            </svg>
+            <span x-text="thread.merge_request.id ? '!' + thread.merge_request.id : '{% trans "MR" %}'"></span>
+            <span x-show="thread.merge_request.draft"
+                  class="repo-chip__badge"
+                  x-cloak>{% trans "draft" %}</span>
+          </span>
+        </a>
+      </template>
+    </div>
 
-  <div class="chat-composer__actions">
-    <div class="chat-composer__hint">
-      <kbd class="chat-composer__kbd">⌘</kbd>
-      <kbd class="chat-composer__kbd">↵</kbd>
-      <span>{% trans "to send" %}</span>
+    <label for="chat_prompt" class="sr-only">{% trans "Message DAIV" %}</label>
+    <textarea id="chat_prompt"
+              x-ref="prompt"
+              x-model="draftMessage"
+              @input="autosize()"
+              @keydown.meta.enter.prevent="submit()"
+              @keydown.ctrl.enter.prevent="submit()"
+              rows="2"
+              :disabled="(streaming || resuming)"
+              placeholder="{% trans 'Describe the change, the bug, or what to explore…' %}"
+              class="chat-composer__textarea"></textarea>
+
+    <div class="chat-composer__actions">
+      <div class="chat-composer__hint">
+        <kbd class="chat-composer__kbd">⌘</kbd>
+        <kbd class="chat-composer__kbd">↵</kbd>
+        <span>{% trans "to send" %}</span>
+      </div>
+      <div style="display: inline-flex; gap: 8px;">
+        <button type="button" x-show="(streaming || resuming)" @click="stop()"
+                class="chat-composer__btn chat-composer__btn--stop">{% trans "Stop" %}</button>
+        <button type="submit" :disabled="(streaming || resuming) || !canSend()"
+                class="chat-composer__btn chat-composer__btn--send">
+          <span x-text="(streaming || resuming) ? '{% trans 'Sending…' %}' : '{% trans 'Send' %}'"></span>
+          <svg x-show="!(streaming || resuming)" class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+            <path d="M10.22 16.78a.75.75 0 0 1-1.06-1.06l4.47-4.47H4a.75.75 0 0 1 0-1.5h9.63l-4.47-4.47a.75.75 0 1 1 1.06-1.06l5.75 5.75a.75.75 0 0 1 0 1.06l-5.75 5.75Z"/>
+          </svg>
+        </button>
+      </div>
     </div>
-    <div style="display: inline-flex; gap: 8px;">
-      <button type="button" x-show="(streaming || resuming)" @click="stop()"
-              class="chat-composer__btn chat-composer__btn--stop">{% trans "Stop" %}</button>
-      <button type="submit" :disabled="(streaming || resuming) || !canSend()"
-              class="chat-composer__btn chat-composer__btn--send">
-        <span x-text="(streaming || resuming) ? '{% trans 'Sending…' %}' : '{% trans 'Send' %}'"></span>
-        <svg x-show="!(streaming || resuming)" class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
-          <path d="M10.22 16.78a.75.75 0 0 1-1.06-1.06l4.47-4.47H4a.75.75 0 0 1 0-1.5h9.63l-4.47-4.47a.75.75 0 1 1 1.06-1.06l5.75 5.75a.75.75 0 0 1 0 1.06l-5.75 5.75Z"/>
-        </svg>
-      </button>
-    </div>
-  </div>
-</form>
+  </form>
+
+  <p class="chat-dock__disclaimer">
+    {% trans "DAIV can make mistakes. Verify important information." %}
+  </p>
+</div>

--- a/daiv/static_src/css/input.css
+++ b/daiv/static_src/css/input.css
@@ -19,6 +19,13 @@ a, button, [role="button"] {
   display: none !important;
 }
 
+/* Drop <main>'s bottom padding on chat detail so the sticky dock reaches
+   the actual viewport bottom. `!important` is needed to beat Tailwind's
+   `py-8`/`sm:py-10` utilities applied directly on <main>. */
+main:has(.chat-shell) {
+  padding-bottom: 0 !important;
+}
+
 .animate-fade-up {
   animation: fade-up 0.5s ease-out both;
 }
@@ -548,13 +555,15 @@ a, button, [role="button"] {
     z-index: 20;
   }
 
-  .chat-column--empty .chat-composer {
+  .chat-column--empty .chat-dock {
     position: relative;
     bottom: auto;
     margin-top: 12px;
+    padding: 0;
+    background: transparent;
   }
 
-  .chat-column--empty .chat-composer::before {
+  .chat-column--empty .chat-dock::before {
     display: none;
   }
 
@@ -1271,32 +1280,48 @@ a, button, [role="button"] {
 
   /* Composer */
 
-  .chat-composer {
+  /* Sticky dock that holds the composer and disclaimer. The dock supplies a
+     solid mask behind the composer so transcript content scrolling past
+     doesn't bleed through the composer's rounded corners. */
+  .chat-dock {
     position: sticky;
-    bottom: 16px;
+    bottom: 0;
     flex: 0 0 auto;
     margin: 0;
-    padding: 12px 14px;
-    border: 1px solid rgba(255, 255, 255, 0.06);
-    border-radius: 16px;
-    background: linear-gradient(180deg, rgba(20, 22, 40, 0.85), rgba(12, 14, 30, 0.85));
-    backdrop-filter: blur(14px);
-    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+    padding: 0 0 8px;
+    background: #030712;
     z-index: 10;
   }
 
-  /* Soft fade behind scrolled content above the sticky composer. Stops a few
-     pixels short of the composer's top border so it doesn't visually erase
-     the (intentionally faint) 1px top border. */
-  .chat-composer::before {
+  /* Soft fade above the dock so transcript content fades into the mask
+     instead of clipping abruptly at the dock's top edge. */
+  .chat-dock::before {
     content: "";
     position: absolute;
     left: 0;
     right: 0;
-    bottom: calc(100% + 2px);
+    bottom: 100%;
     height: 40px;
     pointer-events: none;
-    background: linear-gradient(180deg, rgba(3, 7, 18, 0), rgba(3, 7, 18, 0.45));
+    background: linear-gradient(180deg, rgba(3, 7, 18, 0), rgba(3, 7, 18, 1));
+  }
+
+  .chat-dock__disclaimer {
+    margin-top: 6px;
+    text-align: center;
+    font-size: 11px;
+    line-height: 1.4;
+    color: #64748b;
+  }
+
+  .chat-composer {
+    position: relative;
+    margin: 0;
+    padding: 12px 14px;
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    border-radius: 16px;
+    background: linear-gradient(180deg, rgba(20, 22, 40, 0.95), rgba(12, 14, 30, 0.95));
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
   }
 
   .chat-composer:focus-within {


### PR DESCRIPTION
## Summary
- Wrap the chat composer in a sticky `chat-dock` with a solid `#030712` mask so transcript content no longer bleeds through the composer's rounded corners.
- Strip `<main>`'s `py-8 sm:py-10` bottom padding on chat detail (`main:has(.chat-shell)`) so the dock reaches the actual viewport bottom — closing the gap that previously showed scrolled content below it.
- Add an "AI can make mistakes" disclaimer below the composer (matches the Claude.ai pattern).

## Test plan
- [ ] Open a chat with enough turns to scroll. Confirm the composer hugs the bottom of the viewport with no transcript bleed-through behind it or below the disclaimer.
- [ ] Empty state (`chat-column--empty`): composer renders centered in the hero with no sticky behavior; disclaimer still shows below it.
- [ ] Resize across the 1100px breakpoint to confirm the rail layout still works.
- [ ] Confirm the "Jump to latest" pill still anchors above the composer.