### PR TITLE
refactor(agent): Migrate harness to deepagents create_deep_agent

### DIFF
--- a/daiv/automation/agent/deferred/prompt.py
+++ b/daiv/automation/agent/deferred/prompt.py
@@ -6,28 +6,23 @@ if TYPE_CHECKING:
     from automation.agent.deferred.index import DeferredToolsIndex
 
 _INSTRUCTIONS = """\
-You have access to additional tools that are deferred — their names and
-summaries are listed below but their full schemas are not loaded by default.
-To use one, call `tool_search` first to load it. Once loaded, the tool stays
-available for the rest of this session and its full schema appears in your
-loaded tools.
+## `tool_search` (deferred tools)
 
-Prefer `select=[<name>]` with the exact tool name from the list — that is
-faster and more precise than a query. Use `query=` only when you can't
-identify the right tool from the list and want to search by capability.
+Some tools are deferred — only their names and summaries are loaded into your context. Their full schemas are not loaded until you call `tool_search` to load them. Once loaded, the tool stays available for the rest of the session and appears in your loaded tools.
 
-Do not call a deferred tool by name without loading it first; the call will fail.
-The list below is exhaustive and stable across the conversation — entries do
-not disappear once loaded, so use your loaded-tools view (not this list) to
-tell what is currently available.
+How to use:
+- Prefer `select=["<name>"]` with the exact tool name from `<available-deferred-tools>` below — fastest and most precise.
+- Use `query="<capability>"` only when you can't identify the right tool from its name.
+- Do NOT call a deferred tool by name without loading it first — the call will fail.
 
-When the user asks what tools or capabilities you have, include the deferred
-tools listed below alongside your loaded tools — note they are deferred and
-will be loaded on demand.
+Notes:
+- The list below is exhaustive and stable across the conversation. Use your loaded-tools view (not this list) to tell what is currently available.
+- When the user asks what tools or capabilities you have, include the deferred tools alongside your loaded tools, marked as deferred.
 
-Examples:
-  - tool_search(select=["gitlab"])              # preferred when the name is known
-  - tool_search(query="open pull request")      # only when browsing for capability"""
+<example>
+tool_search(select=["gitlab"])           # preferred when the name is known
+tool_search(query="open pull request")    # only when browsing by capability
+</example>"""  # noqa: E501
 
 
 def build_deferred_tools_block(index: DeferredToolsIndex) -> str:

--- a/daiv/automation/agent/graph.py
+++ b/daiv/automation/agent/graph.py
@@ -26,7 +26,7 @@ from automation.agent.deferred.conf import settings as deferred_settings
 from automation.agent.mcp.toolkits import MCPToolkit
 from automation.agent.middlewares.deferred_tools import DeferredToolsMiddleware
 from automation.agent.middlewares.ensure_response import ensure_non_empty_response
-from automation.agent.middlewares.file_system import FILESYSTEM_ABSOLUTE_PATH_DIRECTIVE, FilesystemSandboxSyncMiddleware
+from automation.agent.middlewares.file_system import FILESYSTEM_ABSOLUTE_PATH_DIRECTIVE
 from automation.agent.middlewares.git import GitMiddleware
 from automation.agent.middlewares.git_platform import GitPlatformMiddleware
 from automation.agent.middlewares.logging import ToolCallLoggingMiddleware
@@ -219,11 +219,7 @@ async def create_daiv_agent(
             sources=[GLOBAL_SKILLS_PATH, *[f"/{agent_path.name}/{source}" for source in SKILLS_SOURCES]],
             subagents=subagents,
         ),
-        *(
-            [FilesystemSandboxSyncMiddleware(backend=backend, working_dir=agent_path), SandboxMiddleware()]
-            if _sandbox_enabled
-            else []
-        ),
+        *([SandboxMiddleware(backend=backend, working_dir=agent_path)] if _sandbox_enabled else []),
         *([WebSearchMiddleware()] if _web_search_enabled else []),
         *([WebFetchMiddleware()] if _web_fetch_enabled else []),
         *([ModelFallbackMiddleware(fallback_models[0], *fallback_models[1:])] if fallback_models else []),

--- a/daiv/automation/agent/graph.py
+++ b/daiv/automation/agent/graph.py
@@ -1,23 +1,16 @@
 import logging
 from pathlib import Path
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from django.utils import timezone
 
+from deepagents import create_deep_agent
 from deepagents.backends.filesystem import FilesystemBackend
-from deepagents.middleware.memory import MemoryMiddleware
-from deepagents.middleware.patch_tool_calls import PatchToolCallsMiddleware
-from deepagents.middleware.subagents import SubAgentMiddleware
-from deepagents.middleware.summarization import compute_summarization_defaults
-from langchain.agents import create_agent
 from langchain.agents.middleware import (
     AgentMiddleware,
-    HumanInTheLoopMiddleware,
     InterruptOnConfig,
     ModelFallbackMiddleware,
     ModelRequest,
-    SummarizationMiddleware,
-    TodoListMiddleware,
     dynamic_prompt,
 )
 
@@ -33,7 +26,7 @@ from automation.agent.deferred.conf import settings as deferred_settings
 from automation.agent.mcp.toolkits import MCPToolkit
 from automation.agent.middlewares.deferred_tools import DeferredToolsMiddleware
 from automation.agent.middlewares.ensure_response import ensure_non_empty_response
-from automation.agent.middlewares.file_system import FilesystemMiddleware
+from automation.agent.middlewares.file_system import FILESYSTEM_ABSOLUTE_PATH_DIRECTIVE, FilesystemSandboxSyncMiddleware
 from automation.agent.middlewares.git import GitMiddleware
 from automation.agent.middlewares.git_platform import GitPlatformMiddleware
 from automation.agent.middlewares.logging import ToolCallLoggingMiddleware
@@ -79,7 +72,7 @@ class _Unset:
     """Sentinel to distinguish 'not provided' from ``None`` in function defaults."""
 
 
-OUTPUT_INVARIANTS_SYSTEM_PROMPT = """\
+OUTPUT_INVARIANTS_SYSTEM_PROMPT = f"""\
 <output_invariants>
 Applies to ALL user-visible text:
 
@@ -88,6 +81,8 @@ Applies to ALL user-visible text:
   <example>/repo/daiv/core/utils.py -> daiv/core/utils.py</example>
 - Code reference labels MUST be repo-relative paths (e.g. `daiv/core/utils.py:42`), but hrefs should use platform-native blob URLs with branch refs.
 - Before emitting any user-visible text, check for "/repo/" and rewrite to repo-relative form.
+
+{FILESYSTEM_ABSOLUTE_PATH_DIRECTIVE}
 </output_invariants>"""  # noqa: E501
 
 
@@ -184,7 +179,6 @@ async def create_daiv_agent(
         BaseAgent.get_model(model=model_name, thinking_level=thinking_level) for model_name in model_names[1:]
     ]
 
-    _summarization_defaults = compute_summarization_defaults(model)
     _sandbox_enabled = sandbox_enabled if sandbox_enabled is not None else ctx.config.sandbox.enabled
     _web_fetch_enabled = web_fetch_enabled if web_fetch_enabled is not None else site_settings.web_fetch_enabled
     _web_search_enabled = web_search_enabled if web_search_enabled is not None else site_settings.web_search_enabled
@@ -192,7 +186,6 @@ async def create_daiv_agent(
     agent_path = Path(ctx.gitrepo.working_dir)
     backend = FilesystemBackend(root_dir=agent_path.parent, virtual_mode=True)
 
-    # Create subagents list to be shared between middlewares
     subagents = [
         create_general_purpose_subagent(
             model,
@@ -206,7 +199,6 @@ async def create_daiv_agent(
         create_explore_subagent(backend),
     ]
 
-    # Load custom subagents from the repository
     custom_subagents = await load_custom_subagents(
         model=model,
         backend=backend,
@@ -221,75 +213,56 @@ async def create_daiv_agent(
 
     mcp_tools = await MCPToolkit.get_tools()
 
-    agent_conditional_middlewares = []
-
-    if _web_search_enabled:
-        agent_conditional_middlewares.append(WebSearchMiddleware())
-    if _web_fetch_enabled:
-        agent_conditional_middlewares.append(WebFetchMiddleware())
-    if _sandbox_enabled:
-        agent_conditional_middlewares.append(SandboxMiddleware())
-    if fallback_models:
-        agent_conditional_middlewares.append(ModelFallbackMiddleware(fallback_models[0], *fallback_models[1:]))
-    if deferred_settings.ENABLED:
-        agent_conditional_middlewares.append(
-            DeferredToolsMiddleware(
-                always_loaded=ALWAYS_LOADED_TOOLS,
-                extra_tools=mcp_tools,
-                top_k_default=deferred_settings.TOP_K_DEFAULT,
-                top_k_max=deferred_settings.TOP_K_MAX,
-            )
-        )
-    if middleware:
-        agent_conditional_middlewares += middleware
-    if interrupt_on is not None:
-        agent_conditional_middlewares.append(HumanInTheLoopMiddleware(interrupt_on=interrupt_on))
-
-    agent_middleware = [
-        TodoListMiddleware(system_prompt=dynamic_write_todos_system_prompt(bash_tool_enabled=_sandbox_enabled)),
-        MemoryMiddleware(
-            backend=backend,
-            sources=[f"/{agent_path.name}/{ctx.config.context_file_name}", f"/{agent_path.name}/{AGENTS_MEMORY_PATH}"],
-            add_cache_control=True,
-        ),
+    user_middleware: list[AgentMiddleware[Any, Any, Any]] = [
         SkillsMiddleware(
             backend=backend,
             sources=[GLOBAL_SKILLS_PATH, *[f"/{agent_path.name}/{source}" for source in SKILLS_SOURCES]],
             subagents=subagents,
         ),
-        SubAgentMiddleware(backend=backend, subagents=subagents),
-        *agent_conditional_middlewares,
-        FilesystemMiddleware(
-            backend=backend,
-            sandbox_sync=_sandbox_enabled,
-            working_dir=Path(ctx.gitrepo.working_dir) if _sandbox_enabled else None,
+        *(
+            [FilesystemSandboxSyncMiddleware(backend=backend, working_dir=agent_path), SandboxMiddleware()]
+            if _sandbox_enabled
+            else []
         ),
-        GitMiddleware(auto_commit_changes=auto_commit_changes),
-        GitPlatformMiddleware(git_platform=ctx.git_platform),
-        SummarizationMiddleware(
-            model=model,
-            backend=backend,
-            trigger=_summarization_defaults["trigger"],
-            keep=_summarization_defaults["keep"],
-            trim_tokens_to_summarize=None,
-            truncate_args_settings=_summarization_defaults["truncate_args_settings"],
+        *([WebSearchMiddleware()] if _web_search_enabled else []),
+        *([WebFetchMiddleware()] if _web_fetch_enabled else []),
+        *([ModelFallbackMiddleware(fallback_models[0], *fallback_models[1:])] if fallback_models else []),
+        *(
+            [
+                DeferredToolsMiddleware(
+                    always_loaded=ALWAYS_LOADED_TOOLS,
+                    extra_tools=mcp_tools,
+                    top_k_default=deferred_settings.TOP_K_DEFAULT,
+                    top_k_max=deferred_settings.TOP_K_MAX,
+                )
+            ]
+            if deferred_settings.ENABLED
+            else []
         ),
         AnthropicPromptCachingMiddleware(),
         ToolCallLoggingMiddleware(),
         ensure_non_empty_response,
-        PatchToolCallsMiddleware(),
+        GitMiddleware(auto_commit_changes=auto_commit_changes),
+        GitPlatformMiddleware(git_platform=ctx.git_platform),
         dynamic_daiv_system_prompt,
+        *(middleware or []),
     ]
 
     initial_tools = [] if deferred_settings.ENABLED else mcp_tools
 
-    return create_agent(
-        model,
+    deep_agent = create_deep_agent(
+        model=model,
         tools=initial_tools,
-        middleware=agent_middleware,
+        system_prompt=None,
+        middleware=user_middleware,
+        subagents=subagents,
+        memory=[f"/{agent_path.name}/{ctx.config.context_file_name}", f"/{agent_path.name}/{AGENTS_MEMORY_PATH}"],
+        backend=backend,
+        interrupt_on=interrupt_on,
         context_schema=RuntimeCtx,
         checkpointer=checkpointer,
         store=store,
         debug=debug,
         name="DAIV Agent",
-    ).with_config({"recursion_limit": site_settings.agent_recursion_limit})
+    )
+    return deep_agent.with_config({"recursion_limit": site_settings.agent_recursion_limit})

--- a/daiv/automation/agent/graph.py
+++ b/daiv/automation/agent/graph.py
@@ -11,6 +11,7 @@ from langchain.agents.middleware import (
     InterruptOnConfig,
     ModelFallbackMiddleware,
     ModelRequest,
+    TodoListMiddleware,
     dynamic_prompt,
 )
 
@@ -112,9 +113,12 @@ async def dynamic_daiv_system_prompt(request: ModelRequest) -> str:
         current_branch=get_repo_ref(context.gitrepo),
     )
 
-    inherited_system_prompt = ""
-    if request.system_prompt:
-        inherited_system_prompt = request.system_prompt + "\n\n"
+    # The harness profile sets ``base_system_prompt=""`` to suppress upstream's
+    # BASE_AGENT_PROMPT, but model-level profiles (e.g. anthropic:claude-opus-4-7)
+    # still contribute a ``system_prompt_suffix`` we want to keep. Strip to drop
+    # leading whitespace introduced by an empty base + suffix concat.
+    inherited = (request.system_prompt or "").strip()
+    inherited_system_prompt = f"{inherited}\n\n" if inherited else ""
 
     return (
         OUTPUT_INVARIANTS_SYSTEM_PROMPT
@@ -214,6 +218,7 @@ async def create_daiv_agent(
     mcp_tools = await MCPToolkit.get_tools()
 
     user_middleware: list[AgentMiddleware[Any, Any, Any]] = [
+        TodoListMiddleware(system_prompt=dynamic_write_todos_system_prompt(bash_tool_enabled=_sandbox_enabled)),
         SkillsMiddleware(
             backend=backend,
             sources=[GLOBAL_SKILLS_PATH, *[f"/{agent_path.name}/{source}" for source in SKILLS_SOURCES]],

--- a/daiv/automation/agent/middlewares/file_system.py
+++ b/daiv/automation/agent/middlewares/file_system.py
@@ -16,17 +16,18 @@ from deepagents.middleware.filesystem import GREP_TOOL_DESCRIPTION as GREP_TOOL_
 from deepagents.middleware.filesystem import LIST_FILES_TOOL_DESCRIPTION as LIST_FILES_TOOL_DESCRIPTION_BASE
 from deepagents.middleware.filesystem import READ_FILE_TOOL_DESCRIPTION as READ_FILE_TOOL_DESCRIPTION_BASE
 from deepagents.middleware.filesystem import WRITE_FILE_TOOL_DESCRIPTION as WRITE_FILE_TOOL_DESCRIPTION_BASE
-from deepagents.middleware.filesystem import FilesystemMiddleware as BaseFilesystemMiddleware
 from deepagents.middleware.filesystem import FilesystemState
+from langchain.agents.middleware.types import AgentMiddleware
 from langchain.tools import ToolRuntime  # noqa: TC002
-from langchain_core.prompts import SystemMessagePromptTemplate
 from langchain_core.tools import BaseTool, StructuredTool
 
 from core.sandbox.client import DAIVSandboxClient
 from core.sandbox.schemas import ApplyMutationsRequest, PutMutation
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Awaitable, Callable
+
+    from langchain.agents.middleware.types import ModelRequest, ModelResponse
 
 logger = logging.getLogger("daiv.tools")
 
@@ -62,23 +63,21 @@ READ_FILE_TOOL_DESCRIPTION = _with_path_reminder(READ_FILE_TOOL_DESCRIPTION_BASE
 WRITE_FILE_TOOL_DESCRIPTION = _with_path_reminder(WRITE_FILE_TOOL_DESCRIPTION_BASE, _WRITE_FILE_EXTRA)
 EDIT_FILE_TOOL_DESCRIPTION = _with_path_reminder(EDIT_FILE_TOOL_DESCRIPTION_BASE)
 
-DAIV_FILESYSTEM_SYSTEM_PROMPT = SystemMessagePromptTemplate.from_template(
-    """\
-## Filesystem Tools
+WRITE_FILE_TOOL = "write_file"
+EDIT_FILE_TOOL = "edit_file"
+WRITE_TOOL_NAMES = frozenset({WRITE_FILE_TOOL, EDIT_FILE_TOOL})
 
-You have access to a filesystem which you can interact with using these tools.
-Tool-call arguments (ls/read_file{{^read_only}}/edit_file{{/read_only}}/etc.) MUST use absolute paths (start with "/").
-User-visible output MUST NEVER contain "/repo/" and MUST use repo-relative paths (e.g. daiv/core/utils.py).""",
-    "mustache",
+FILESYSTEM_ABSOLUTE_PATH_DIRECTIVE = (
+    'Filesystem tool-call arguments (ls/read_file/edit_file/etc.) MUST use absolute paths (start with "/").'
 )
 
-_CUSTOM_TOOL_DESCRIPTIONS = {
+CUSTOM_TOOL_DESCRIPTIONS = {
     "grep": GREP_TOOL_DESCRIPTION,
     "glob": GLOB_TOOL_DESCRIPTION,
     "ls": LIST_FILES_TOOL_DESCRIPTION,
     "read_file": READ_FILE_TOOL_DESCRIPTION,
-    "write_file": WRITE_FILE_TOOL_DESCRIPTION,
-    "edit_file": EDIT_FILE_TOOL_DESCRIPTION,
+    WRITE_FILE_TOOL: WRITE_FILE_TOOL_DESCRIPTION,
+    EDIT_FILE_TOOL: EDIT_FILE_TOOL_DESCRIPTION,
 }
 
 
@@ -289,87 +288,55 @@ def _require_coroutine(tool: BaseTool):
 # ---------------------------------------------------------------------------
 
 
-class FilesystemMiddleware(BaseFilesystemMiddleware):
-    """DAIV's FilesystemMiddleware customisation.
+class FilesystemSandboxSyncMiddleware(AgentMiddleware):
+    """Mirrors successful local ``write_file``/``edit_file`` calls to the daiv-sandbox session.
 
-    Adds:
-    - Custom tool descriptions referencing absolute paths.
-    - A `read_only` mode that strips the write/edit tools.
-    - When `sandbox_sync=True`, wraps upstream's `write_file` and `edit_file`
-      so each successful local write is mirrored to the daiv-sandbox session
-      named by `state["session_id"]`. Reads still go against local disk for
-      speed; bash-induced changes flow back via the patch extractor's per-turn
-      diff.
+    Wraps upstream's ``write_file`` and ``edit_file`` tools at ``wrap_model_call`` time.
+    Reads still go against local disk for speed; bash-induced changes flow back via the
+    patch extractor's per-turn diff.
 
     Args:
-        backend: Backend for file storage. Should be a deepagents `FilesystemBackend`.
-        read_only: When True, removes write_file and edit_file from the exposed tools.
-        sandbox_sync: When True, replace write_file/edit_file with sync-aware versions.
-        working_dir: Required when sandbox_sync=True. The on-disk repo root used to
-            map local paths to sandbox paths (`/<rel>` from `<working_dir>` →
-            `/repo/<rel>`).
-        sandbox_client_factory: Optional override of the DAIVSandboxClient factory.
+        backend: Backend used to resolve ``/repo``-relative paths to on-disk paths.
+            Must be the same instance that backs upstream's ``FilesystemMiddleware``.
+        working_dir: The on-disk repo root used to map local paths to sandbox paths
+            (``<working_dir>/<rel>`` → ``/repo/<rel>``).
+        sandbox_client_factory: Optional override of the ``DAIVSandboxClient`` factory.
             Useful for tests.
-
-    Example:
-        ```python
-        from deepagents.backends.filesystem import FilesystemBackend
-        from automation.agent.middlewares.file_system import FilesystemMiddleware
-
-        backend = FilesystemBackend(root_dir="/workspace", virtual_mode=True)
-        middleware = FilesystemMiddleware(backend=backend, sandbox_sync=True, working_dir="/workspace/repo")
-        ```
     """
 
     def __init__(
         self,
-        *args,
-        read_only: bool = False,
-        sandbox_sync: bool = False,
-        working_dir: Path | str | None = None,
+        *,
+        backend: Any,
+        working_dir: Path | str,
         sandbox_client_factory: Callable[[], DAIVSandboxClient] | None = None,
-        **kwargs,
     ) -> None:
-        kwargs.setdefault("system_prompt", DAIV_FILESYSTEM_SYSTEM_PROMPT.format(read_only=read_only).content)
-        kwargs.setdefault("custom_tool_descriptions", _CUSTOM_TOOL_DESCRIPTIONS)
-
-        # The syncer must exist before `super().__init__` because the base class calls
-        # `self._create_write_file_tool()` and `self._create_edit_file_tool()` directly during
-        # init; our overrides consult `self._syncer` to decide whether to wrap.
-        self._syncer = (
-            self._build_syncer(kwargs, working_dir, sandbox_client_factory) if sandbox_sync and not read_only else None
-        )
-
-        super().__init__(*args, **kwargs)
-
-        excluded = {"execute"} | ({"edit_file", "write_file"} if read_only else set())
-        self.tools = [tool for tool in self.tools if tool.name not in excluded]
-
-    @staticmethod
-    def _build_syncer(
-        kwargs: dict, working_dir: Path | str | None, sandbox_client_factory: Callable[[], DAIVSandboxClient] | None
-    ) -> _SandboxSyncer:
-        if working_dir is None:
-            raise ValueError("sandbox_sync=True requires working_dir to be provided")
-        # `BaseFilesystemMiddleware.__init__` is keyword-only, so backend always lands in kwargs.
-        backend = kwargs.get("backend")
-        if backend is None:
-            raise ValueError("sandbox_sync=True requires the backend to be provided")
+        super().__init__()
         # Resolve the factory at construction time so test monkeypatching of
-        # `DAIVSandboxClient` on this module sticks (default args are captured
+        # ``DAIVSandboxClient`` on this module sticks (default args are captured
         # at function-definition time, which would defeat the monkeypatch).
         factory = sandbox_client_factory or DAIVSandboxClient
-        return _SandboxSyncer(backend=backend, working_dir=Path(working_dir), client=factory())
+        self._syncer = _SandboxSyncer(backend=backend, working_dir=Path(working_dir), client=factory())
+        self._wrap_cache: dict[str, BaseTool] = {}
 
-    def _create_write_file_tool(self) -> BaseTool:
-        original = super()._create_write_file_tool()
-        return self._syncer.wrap_write_tool(original) if self._syncer is not None else original
+    def _wrap_if_needed(self, tool: BaseTool | dict[str, Any]) -> BaseTool | dict[str, Any]:
+        if not isinstance(tool, BaseTool) or tool.name not in WRITE_TOOL_NAMES:
+            return tool
+        cached = self._wrap_cache.get(tool.name)
+        if cached is not None:
+            return cached
+        wrapped = (
+            self._syncer.wrap_write_tool(tool) if tool.name == WRITE_FILE_TOOL else self._syncer.wrap_edit_tool(tool)
+        )
+        self._wrap_cache[tool.name] = wrapped
+        return wrapped
 
-    def _create_edit_file_tool(self) -> BaseTool:
-        original = super()._create_edit_file_tool()
-        return self._syncer.wrap_edit_tool(original) if self._syncer is not None else original
+    async def awrap_model_call(
+        self, request: ModelRequest, handler: Callable[[ModelRequest], Awaitable[ModelResponse]]
+    ) -> ModelResponse:
+        new_tools: list[BaseTool | dict[str, Any]] = [self._wrap_if_needed(tool) for tool in request.tools]
+        return await handler(request.override(tools=new_tools))
 
     async def aafter_agent(self, state, runtime) -> dict | None:
-        if self._syncer is not None:
-            await self._syncer.aclose()
-        return await super().aafter_agent(state, runtime)
+        await self._syncer.aclose()
+        return None

--- a/daiv/automation/agent/middlewares/file_system.py
+++ b/daiv/automation/agent/middlewares/file_system.py
@@ -17,17 +17,14 @@ from deepagents.middleware.filesystem import LIST_FILES_TOOL_DESCRIPTION as LIST
 from deepagents.middleware.filesystem import READ_FILE_TOOL_DESCRIPTION as READ_FILE_TOOL_DESCRIPTION_BASE
 from deepagents.middleware.filesystem import WRITE_FILE_TOOL_DESCRIPTION as WRITE_FILE_TOOL_DESCRIPTION_BASE
 from deepagents.middleware.filesystem import FilesystemState
-from langchain.agents.middleware.types import AgentMiddleware
 from langchain.tools import ToolRuntime  # noqa: TC002
 from langchain_core.tools import BaseTool, StructuredTool
 
-from core.sandbox.client import DAIVSandboxClient
+from core.sandbox.client import DAIVSandboxClient  # noqa: TC001
 from core.sandbox.schemas import ApplyMutationsRequest, PutMutation
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable, Callable
-
-    from langchain.agents.middleware.types import ModelRequest, ModelResponse
+    from collections.abc import Callable
 
 logger = logging.getLogger("daiv.tools")
 
@@ -93,16 +90,15 @@ def _format_sync_error(reason: str, *, rollback_ok: bool) -> str:
 
 
 @dataclass
-class _SandboxSyncer:
+class SandboxSyncer:
     """Mirrors successful local writes to the sandbox session associated with the agent run.
 
-    Bundles the backend, the working_dir → /repo mapping, a long-lived sandbox client (opened
-    lazily on first mirror so its TCP+TLS pool is reused across every write/edit in the run),
-    and a single lock that serialises the upstream-write→sandbox-sync critical section across
-    all concurrent write_file/edit_file calls in one agent run, so rollback can never overwrite
-    a sibling tool call's edit. The edit-path snapshot is taken outside the lock — if it fails
-    we short-circuit to upstream's canonical "not found" error rather than acquiring the lock
-    for a doomed call.
+    Bundles the backend, the working_dir → /repo mapping, the sandbox client (owned and
+    lifecycle-managed by ``SandboxMiddleware``), and a single lock that serialises the
+    upstream-write→sandbox-sync critical section across all concurrent write_file/edit_file
+    calls in one agent run, so rollback can never overwrite a sibling tool call's edit.
+    The edit-path snapshot is taken outside the lock — if it fails we short-circuit to
+    upstream's canonical "not found" error rather than acquiring the lock for a doomed call.
     """
 
     backend: Any
@@ -110,23 +106,9 @@ class _SandboxSyncer:
     client: DAIVSandboxClient
     lock: asyncio.Lock = field(default_factory=asyncio.Lock)
     _resolved_working_dir: Path = field(init=False, repr=False)
-    _opened: bool = field(default=False, init=False, repr=False)
 
     def __post_init__(self) -> None:
         self._resolved_working_dir = self.working_dir.resolve()
-
-    async def _ensure_client(self) -> DAIVSandboxClient:
-        # Callers always invoke this from inside ``self.lock`` (via ``mirror``),
-        # so the open-once flag does not need its own guard.
-        if not self._opened:
-            await self.client.open()
-            self._opened = True
-        return self.client
-
-    async def aclose(self) -> None:
-        if self._opened:
-            self._opened = False
-            await self.client.close()
 
     def sandbox_path(self, local_path: str | Path) -> str:
         """Map ``<working_dir>/<rel>`` → ``/repo/<rel>``. Raises ``ValueError`` if outside ``working_dir``."""
@@ -153,8 +135,7 @@ class _SandboxSyncer:
             mutations=[PutMutation(path=sandbox_path, content=base64.b64encode(content_bytes), mode=mode)]
         )
         try:
-            client = await self._ensure_client()
-            response = await client.apply_file_mutations(session_id, request)
+            response = await self.client.apply_file_mutations(session_id, request)
         except Exception as exc:
             logger.exception("sandbox apply_file_mutations failed for %s", sandbox_path)
             return _format_sync_error(f"sandbox sync raised: {exc}", rollback_ok=rollback())
@@ -281,62 +262,3 @@ def _require_coroutine(tool: BaseTool):
     if tool.coroutine is None:
         raise TypeError(f"upstream tool {tool.name!r} has no async coroutine to wrap")
     return tool.coroutine
-
-
-# ---------------------------------------------------------------------------
-# Middleware
-# ---------------------------------------------------------------------------
-
-
-class FilesystemSandboxSyncMiddleware(AgentMiddleware):
-    """Mirrors successful local ``write_file``/``edit_file`` calls to the daiv-sandbox session.
-
-    Wraps upstream's ``write_file`` and ``edit_file`` tools at ``wrap_model_call`` time.
-    Reads still go against local disk for speed; bash-induced changes flow back via the
-    patch extractor's per-turn diff.
-
-    Args:
-        backend: Backend used to resolve ``/repo``-relative paths to on-disk paths.
-            Must be the same instance that backs upstream's ``FilesystemMiddleware``.
-        working_dir: The on-disk repo root used to map local paths to sandbox paths
-            (``<working_dir>/<rel>`` → ``/repo/<rel>``).
-        sandbox_client_factory: Optional override of the ``DAIVSandboxClient`` factory.
-            Useful for tests.
-    """
-
-    def __init__(
-        self,
-        *,
-        backend: Any,
-        working_dir: Path | str,
-        sandbox_client_factory: Callable[[], DAIVSandboxClient] | None = None,
-    ) -> None:
-        super().__init__()
-        # Resolve the factory at construction time so test monkeypatching of
-        # ``DAIVSandboxClient`` on this module sticks (default args are captured
-        # at function-definition time, which would defeat the monkeypatch).
-        factory = sandbox_client_factory or DAIVSandboxClient
-        self._syncer = _SandboxSyncer(backend=backend, working_dir=Path(working_dir), client=factory())
-        self._wrap_cache: dict[str, BaseTool] = {}
-
-    def _wrap_if_needed(self, tool: BaseTool | dict[str, Any]) -> BaseTool | dict[str, Any]:
-        if not isinstance(tool, BaseTool) or tool.name not in WRITE_TOOL_NAMES:
-            return tool
-        cached = self._wrap_cache.get(tool.name)
-        if cached is not None:
-            return cached
-        wrapped = (
-            self._syncer.wrap_write_tool(tool) if tool.name == WRITE_FILE_TOOL else self._syncer.wrap_edit_tool(tool)
-        )
-        self._wrap_cache[tool.name] = wrapped
-        return wrapped
-
-    async def awrap_model_call(
-        self, request: ModelRequest, handler: Callable[[ModelRequest], Awaitable[ModelResponse]]
-    ) -> ModelResponse:
-        new_tools: list[BaseTool | dict[str, Any]] = [self._wrap_if_needed(tool) for tool in request.tools]
-        return await handler(request.override(tools=new_tools))
-
-    async def aafter_agent(self, state, runtime) -> dict | None:
-        await self._syncer.aclose()
-        return None

--- a/daiv/automation/agent/middlewares/file_system.py
+++ b/daiv/automation/agent/middlewares/file_system.py
@@ -3,11 +3,12 @@ from __future__ import annotations
 import asyncio
 import base64
 import logging
-import os
-import stat
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Annotated, Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 from deepagents.backends.utils import validate_path
 from deepagents.middleware.filesystem import EDIT_FILE_TOOL_DESCRIPTION as EDIT_FILE_TOOL_DESCRIPTION_BASE
@@ -16,15 +17,9 @@ from deepagents.middleware.filesystem import GREP_TOOL_DESCRIPTION as GREP_TOOL_
 from deepagents.middleware.filesystem import LIST_FILES_TOOL_DESCRIPTION as LIST_FILES_TOOL_DESCRIPTION_BASE
 from deepagents.middleware.filesystem import READ_FILE_TOOL_DESCRIPTION as READ_FILE_TOOL_DESCRIPTION_BASE
 from deepagents.middleware.filesystem import WRITE_FILE_TOOL_DESCRIPTION as WRITE_FILE_TOOL_DESCRIPTION_BASE
-from deepagents.middleware.filesystem import FilesystemState
-from langchain.tools import ToolRuntime  # noqa: TC002
-from langchain_core.tools import BaseTool, StructuredTool
 
 from core.sandbox.client import DAIVSandboxClient  # noqa: TC001
 from core.sandbox.schemas import ApplyMutationsRequest, PutMutation
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
 
 logger = logging.getLogger("daiv.tools")
 
@@ -64,6 +59,12 @@ WRITE_FILE_TOOL = "write_file"
 EDIT_FILE_TOOL = "edit_file"
 WRITE_TOOL_NAMES = frozenset({WRITE_FILE_TOOL, EDIT_FILE_TOOL})
 
+# A deepagents bump that rewords either prefix would silently disable sandbox sync.
+# Pinned by tests/unit_tests/automation/agent/middlewares/test_file_system.py
+# (test_upstream_success_prefixes_remain_stable).
+WRITE_SUCCESS_PREFIX = "Updated file"
+EDIT_SUCCESS_PREFIX = "Successfully replaced"
+
 FILESYSTEM_ABSOLUTE_PATH_DIRECTIVE = (
     'Filesystem tool-call arguments (ls/read_file/edit_file/etc.) MUST use absolute paths (start with "/").'
 )
@@ -83,7 +84,7 @@ CUSTOM_TOOL_DESCRIPTIONS = {
 # ---------------------------------------------------------------------------
 
 
-def _format_sync_error(reason: str, *, rollback_ok: bool) -> str:
+def format_sync_error(reason: str, *, rollback_ok: bool) -> str:
     if rollback_ok:
         return f"Error: {reason}"
     return f"CRITICAL: {reason}; rollback also failed — local state is desynced from sandbox"
@@ -97,8 +98,6 @@ class SandboxSyncer:
     lifecycle-managed by ``SandboxMiddleware``), and a single lock that serialises the
     upstream-write→sandbox-sync critical section across all concurrent write_file/edit_file
     calls in one agent run, so rollback can never overwrite a sibling tool call's edit.
-    The edit-path snapshot is taken outside the lock — if it fails we short-circuit to
-    upstream's canonical "not found" error rather than acquiring the lock for a doomed call.
     """
 
     backend: Any
@@ -115,6 +114,10 @@ class SandboxSyncer:
         rel = Path(local_path).resolve().relative_to(self._resolved_working_dir)
         return str(Path(SANDBOX_PATH_ROOT) / rel)
 
+    def resolve_target(self, file_path: str) -> Path:
+        """Re-run upstream's path validation + backend resolution to obtain the on-disk target."""
+        return Path(self.backend._resolve_path(validate_path(file_path)))
+
     async def mirror(
         self, *, runtime, resolved_path: Path | str, content_bytes: bytes, mode: int, rollback: Callable[[], bool]
     ) -> str | None:
@@ -125,11 +128,11 @@ class SandboxSyncer:
         try:
             sandbox_path = self.sandbox_path(resolved_path)
         except ValueError as exc:
-            return _format_sync_error(f"failed to prepare sandbox sync: {exc}", rollback_ok=rollback())
+            return format_sync_error(f"failed to prepare sandbox sync: {exc}", rollback_ok=rollback())
 
         session_id = runtime.state.get("session_id") if runtime.state else None
         if not session_id:
-            return _format_sync_error("sandbox session not started", rollback_ok=rollback())
+            return format_sync_error("sandbox session not started", rollback_ok=rollback())
 
         request = ApplyMutationsRequest(
             mutations=[PutMutation(path=sandbox_path, content=base64.b64encode(content_bytes), mode=mode)]
@@ -138,127 +141,9 @@ class SandboxSyncer:
             response = await self.client.apply_file_mutations(session_id, request)
         except Exception as exc:
             logger.exception("sandbox apply_file_mutations failed for %s", sandbox_path)
-            return _format_sync_error(f"sandbox sync raised: {exc}", rollback_ok=rollback())
+            return format_sync_error(f"sandbox sync raised: {exc}", rollback_ok=rollback())
 
         result = response.results[0]
         if not result.ok:
-            return _format_sync_error(f"failed to sync to sandbox: {result.error}", rollback_ok=rollback())
+            return format_sync_error(f"failed to sync to sandbox: {result.error}", rollback_ok=rollback())
         return None
-
-    def _resolve_target(self, file_path: str) -> Path:
-        """Re-run upstream's path validation + backend resolution to obtain the on-disk target."""
-        return Path(self.backend._resolve_path(validate_path(file_path)))
-
-    def wrap_write_tool(self, original: BaseTool) -> StructuredTool:
-        """Wrap an upstream ``write_file`` tool so each successful write is mirrored to the sandbox."""
-        syncer = self
-        original_coroutine = _require_coroutine(original)
-
-        async def wrapped(
-            file_path: Annotated[
-                str, "Absolute path where the file should be created. Must be absolute, not relative."
-            ],
-            content: Annotated[str, "The text content to write to the file. This parameter is required."],
-            runtime: ToolRuntime[None, FilesystemState],
-        ) -> str:
-            async with syncer.lock:
-                upstream_result = await original_coroutine(file_path=file_path, content=content, runtime=runtime)
-                if not upstream_result.startswith("Updated file"):
-                    return upstream_result
-
-                target = syncer._resolve_target(file_path)
-
-                def _rollback() -> bool:
-                    try:
-                        target.unlink(missing_ok=True)
-                    except OSError:
-                        logger.exception("rollback unlink failed for %s", target)
-                        return False
-                    return True
-
-                try:
-                    mode = stat.S_IMODE(target.stat().st_mode)
-                except OSError as exc:
-                    return _format_sync_error(f"failed to prepare sandbox sync: {exc}", rollback_ok=_rollback())
-
-                error = await syncer.mirror(
-                    runtime=runtime, resolved_path=target, content_bytes=content.encode(), mode=mode, rollback=_rollback
-                )
-                return error or upstream_result
-
-        return StructuredTool.from_function(
-            name=original.name, description=original.description, coroutine=wrapped, infer_schema=True
-        )
-
-    def wrap_edit_tool(self, original: BaseTool) -> StructuredTool:
-        """Wrap an upstream ``edit_file`` tool so each successful edit is mirrored to the sandbox."""
-        syncer = self
-        original_coroutine = _require_coroutine(original)
-
-        async def wrapped(
-            file_path: Annotated[str, "Absolute path to the file to edit. Must be absolute, not relative."],
-            old_string: Annotated[
-                str, "The exact text to find and replace. Must be unique in the file unless replace_all is True."
-            ],
-            new_string: Annotated[str, "The text to replace old_string with. Must be different from old_string."],
-            runtime: ToolRuntime[None, FilesystemState],
-            *,
-            replace_all: Annotated[
-                bool, "If True, replace all occurrences of old_string. If False (default), old_string must be unique."
-            ] = False,
-        ) -> str:
-            # Snapshot must happen before delegating, so we resolve + read the target up front.
-            # If anything fails here (invalid path, missing file), let upstream produce the
-            # canonical error instead of inventing our own.
-            try:
-                target = syncer._resolve_target(file_path)
-                pre_bytes = target.read_bytes()
-                pre_mode = stat.S_IMODE(target.stat().st_mode)
-            except ValueError, OSError:
-                return await original_coroutine(
-                    file_path=file_path,
-                    old_string=old_string,
-                    new_string=new_string,
-                    runtime=runtime,
-                    replace_all=replace_all,
-                )
-
-            async with syncer.lock:
-                upstream_result = await original_coroutine(
-                    file_path=file_path,
-                    old_string=old_string,
-                    new_string=new_string,
-                    runtime=runtime,
-                    replace_all=replace_all,
-                )
-                if not upstream_result.startswith("Successfully replaced"):
-                    return upstream_result
-
-                def _rollback() -> bool:
-                    try:
-                        target.write_bytes(pre_bytes)
-                        os.chmod(target, pre_mode)  # noqa: PTH101
-                    except OSError:
-                        logger.exception("rollback restore failed for %s", target)
-                        return False
-                    return True
-
-                try:
-                    post_bytes = target.read_bytes()
-                except OSError as exc:
-                    return _format_sync_error(f"failed to prepare sandbox sync: {exc}", rollback_ok=_rollback())
-
-                error = await syncer.mirror(
-                    runtime=runtime, resolved_path=target, content_bytes=post_bytes, mode=pre_mode, rollback=_rollback
-                )
-                return error or upstream_result
-
-        return StructuredTool.from_function(
-            name=original.name, description=original.description, coroutine=wrapped, infer_schema=True
-        )
-
-
-def _require_coroutine(tool: BaseTool):
-    if tool.coroutine is None:
-        raise TypeError(f"upstream tool {tool.name!r} has no async coroutine to wrap")
-    return tool.coroutine

--- a/daiv/automation/agent/middlewares/sandbox.py
+++ b/daiv/automation/agent/middlewares/sandbox.py
@@ -16,6 +16,7 @@ from langchain_core.tools import BaseTool, tool
 from langgraph.typing import StateT  # noqa: TC002
 
 from automation.agent.constants import GLOBAL_SKILLS_PATH
+from automation.agent.middlewares.file_system import WRITE_FILE_TOOL, WRITE_TOOL_NAMES, SandboxSyncer
 from codebase.context import RuntimeCtx  # noqa: TC001
 from codebase.utils import GitManager, files_changed_from_patch
 from core.conf import settings
@@ -27,7 +28,9 @@ from core.site_settings import site_settings
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
+    from typing import Any
 
+    from deepagents.backends import BackendProtocol
     from langgraph.runtime import Runtime
 
 
@@ -295,10 +298,27 @@ class SandboxState(AgentState):
 
 class SandboxMiddleware(AgentMiddleware):
     """
-    Middleware to manage a sandbox session for running commands.
+    Middleware to manage a sandbox session for running commands and mirroring filesystem writes.
 
-    This middleware lazily starts a sandbox session the first time the bash tool is called and
-    closes it after the agent finishes the execution loop. It also adds the sandbox tools to the agent.
+    Owns the per-run sandbox session lifecycle (start in ``abefore_agent``, close in
+    ``aafter_agent``) and exposes:
+
+    - The ``bash`` tool for running shell commands inside the sandbox.
+    - A wrapper around upstream's ``write_file``/``edit_file`` tools that mirrors each
+      successful local write to the sandbox so subsequent ``bash`` invocations see a
+      coherent filesystem.
+
+    A single ``DAIVSandboxClient`` is opened in ``abefore_agent`` and reused for both
+    bash execution and write mirroring.
+
+    Args:
+        backend: Filesystem backend used to resolve ``/repo``-relative paths to on-disk
+            paths. Must be the same instance that backs upstream's ``FilesystemMiddleware``.
+        working_dir: On-disk repo root used to map local paths to sandbox paths
+            (``<working_dir>/<rel>`` → ``/repo/<rel>``).
+        close_session: Whether to close the session after the agent finishes the execution
+            loop. Set to ``False`` when used in subagents so the parent agent owns session
+            lifecycle.
 
     Example:
         ```python
@@ -306,26 +326,23 @@ class SandboxMiddleware(AgentMiddleware):
 
         agent = create_agent(
             model="openai:gpt-4o",
-            middleware=[SandboxMiddleware()],
+            middleware=[SandboxMiddleware(backend=backend, working_dir="/workspace/repo")],
         )
         ```
     """
 
     state_schema = SandboxState
 
-    def __init__(self, *, close_session: bool = True):
-        """
-        Initialize the middleware.
-
-        Args:
-            close_session: Whether to close the session after the agent finishes the execution loop.
-                Useful when using the sandbox in subagents to avoid closing the session in the parent agent.
-        """
+    def __init__(self, *, backend: BackendProtocol, working_dir: Path | str, close_session: bool = True):
         if site_settings.sandbox_api_key is None:
             raise RuntimeError("Sandbox API key is not configured. Set DAIV_SANDBOX_API_KEY or use the config UI.")
 
+        self._backend = backend
+        self._working_dir = Path(working_dir)
         self.close_session = close_session
         self._client: DAIVSandboxClient | None = None
+        self._syncer: SandboxSyncer | None = None
+        self._wrap_cache: dict[str, BaseTool] = {}
         self.tools = [self._build_bash_tool()]
 
     def _build_bash_tool(self) -> BaseTool:
@@ -384,6 +401,7 @@ class SandboxMiddleware(AgentMiddleware):
         client = DAIVSandboxClient()
         await client.open()
         self._client = client
+        self._syncer = SandboxSyncer(backend=self._backend, working_dir=self._working_dir, client=client)
 
         try:
             if not self.close_session and "session_id" in state:
@@ -417,6 +435,7 @@ class SandboxMiddleware(AgentMiddleware):
             # Release the client we just opened; otherwise its httpx pool leaks for the run.
             await client.close()
             self._client = None
+            self._syncer = None
             raise
         return {"session_id": session_id}
 
@@ -463,12 +482,26 @@ class SandboxMiddleware(AgentMiddleware):
                 except Exception:
                     logger.exception("Failed to close sandbox httpx client; pool may have leaked")
                 self._client = None
+                self._syncer = None
+
+    def _wrap_if_needed(self, tool: BaseTool | dict[str, Any]) -> BaseTool | dict[str, Any]:
+        """Wrap upstream's ``write_file``/``edit_file`` so successful writes are mirrored to the sandbox."""
+        if self._syncer is None or not isinstance(tool, BaseTool) or tool.name not in WRITE_TOOL_NAMES:
+            return tool
+        cached = self._wrap_cache.get(tool.name)
+        if cached is not None:
+            return cached
+        wrapped = (
+            self._syncer.wrap_write_tool(tool) if tool.name == WRITE_FILE_TOOL else self._syncer.wrap_edit_tool(tool)
+        )
+        self._wrap_cache[tool.name] = wrapped
+        return wrapped
 
     async def awrap_model_call(
         self, request: ModelRequest, handler: Callable[[ModelRequest], Awaitable[ModelResponse]]
     ) -> ModelResponse:
         """
-        Update the system prompt with the sandbox system prompts.
+        Append the sandbox system prompt and re-wrap write/edit tools to mirror to the sandbox.
 
         Args:
             request: The model request being processed.
@@ -477,6 +510,7 @@ class SandboxMiddleware(AgentMiddleware):
         Returns:
             The model response from the handler.
         """
-        request = request.override(system_prompt=request.system_prompt + "\n\n" + SANDBOX_SYSTEM_PROMPT)
-
-        return await handler(request)
+        new_tools: list[BaseTool | dict[str, Any]] = [self._wrap_if_needed(tool) for tool in request.tools]
+        return await handler(
+            request.override(system_prompt=request.system_prompt + "\n\n" + SANDBOX_SYSTEM_PROMPT, tools=new_tools)
+        )

--- a/daiv/automation/agent/middlewares/sandbox.py
+++ b/daiv/automation/agent/middlewares/sandbox.py
@@ -4,19 +4,29 @@ import asyncio
 import io
 import json
 import logging
+import os
+import stat
 import tarfile
 from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, NotRequired
 
 import httpx
-from langchain.agents.middleware import AgentMiddleware, AgentState, ModelRequest, ModelResponse
+from langchain.agents.middleware import AgentMiddleware, AgentState, ModelRequest, ModelResponse, ToolCallRequest
 from langchain.agents.middleware.types import OmitFromOutput
 from langchain.tools import ToolRuntime  # noqa: TC002
+from langchain_core.messages import ToolMessage
 from langchain_core.tools import BaseTool, tool
 from langgraph.typing import StateT  # noqa: TC002
 
 from automation.agent.constants import GLOBAL_SKILLS_PATH
-from automation.agent.middlewares.file_system import WRITE_FILE_TOOL, WRITE_TOOL_NAMES, SandboxSyncer
+from automation.agent.middlewares.file_system import (
+    EDIT_FILE_TOOL,
+    EDIT_SUCCESS_PREFIX,
+    WRITE_SUCCESS_PREFIX,
+    WRITE_TOOL_NAMES,
+    SandboxSyncer,
+    format_sync_error,
+)
 from codebase.context import RuntimeCtx  # noqa: TC001
 from codebase.utils import GitManager, files_changed_from_patch
 from core.conf import settings
@@ -32,6 +42,7 @@ if TYPE_CHECKING:
 
     from deepagents.backends import BackendProtocol
     from langgraph.runtime import Runtime
+    from langgraph.types import Command
 
 
 logger = logging.getLogger("daiv.tools")
@@ -342,7 +353,6 @@ class SandboxMiddleware(AgentMiddleware):
         self.close_session = close_session
         self._client: DAIVSandboxClient | None = None
         self._syncer: SandboxSyncer | None = None
-        self._wrap_cache: dict[str, BaseTool] = {}
         self.tools = [self._build_bash_tool()]
 
     def _build_bash_tool(self) -> BaseTool:
@@ -484,24 +494,11 @@ class SandboxMiddleware(AgentMiddleware):
                 self._client = None
                 self._syncer = None
 
-    def _wrap_if_needed(self, tool: BaseTool | dict[str, Any]) -> BaseTool | dict[str, Any]:
-        """Wrap upstream's ``write_file``/``edit_file`` so successful writes are mirrored to the sandbox."""
-        if self._syncer is None or not isinstance(tool, BaseTool) or tool.name not in WRITE_TOOL_NAMES:
-            return tool
-        cached = self._wrap_cache.get(tool.name)
-        if cached is not None:
-            return cached
-        wrapped = (
-            self._syncer.wrap_write_tool(tool) if tool.name == WRITE_FILE_TOOL else self._syncer.wrap_edit_tool(tool)
-        )
-        self._wrap_cache[tool.name] = wrapped
-        return wrapped
-
     async def awrap_model_call(
         self, request: ModelRequest, handler: Callable[[ModelRequest], Awaitable[ModelResponse]]
     ) -> ModelResponse:
         """
-        Append the sandbox system prompt and re-wrap write/edit tools to mirror to the sandbox.
+        Append the sandbox system prompt to the request.
 
         Args:
             request: The model request being processed.
@@ -510,7 +507,152 @@ class SandboxMiddleware(AgentMiddleware):
         Returns:
             The model response from the handler.
         """
-        new_tools: list[BaseTool | dict[str, Any]] = [self._wrap_if_needed(tool) for tool in request.tools]
-        return await handler(
-            request.override(system_prompt=request.system_prompt + "\n\n" + SANDBOX_SYSTEM_PROMPT, tools=new_tools)
-        )
+        return await handler(request.override(system_prompt=request.system_prompt + "\n\n" + SANDBOX_SYSTEM_PROMPT))
+
+    async def awrap_tool_call(
+        self, request: ToolCallRequest, handler: Callable[[ToolCallRequest], Awaitable[ToolMessage | Command[Any]]]
+    ) -> ToolMessage | Command[Any]:
+        """
+        Mirror successful local ``write_file``/``edit_file`` results to the sandbox session.
+
+        Tool dispatch happens through ``ToolNode.tools_by_name``, which is built once at
+        agent-creation time. Wrapping the tool object in ``awrap_model_call`` only changes
+        what is bound to the model — the dispatched tool is still upstream's. ``awrap_tool_call``
+        intercepts the actual dispatch, so the mirror runs whenever the model calls the tool.
+
+        Args:
+            request: The tool call request.
+            handler: The handler executing the tool.
+
+        Returns:
+            The tool result, or a replacement ``ToolMessage`` describing a sync error.
+        """
+        if request.tool is None or request.tool.name not in WRITE_TOOL_NAMES or self._syncer is None:
+            return await handler(request)
+
+        if request.tool.name == EDIT_FILE_TOOL:
+            return await self._mirror_edit(request, handler)
+        return await self._mirror_write(request, handler)
+
+    async def _mirror_write(
+        self, request: ToolCallRequest, handler: Callable[[ToolCallRequest], Awaitable[ToolMessage | Command[Any]]]
+    ) -> ToolMessage | Command[Any]:
+        """Dispatch ``write_file`` and mirror the new file to the sandbox under the syncer lock.
+
+        The lock serialises with concurrent writes/edits in the same run so a rollback
+        (unlink) cannot race with a sibling tool's edit on the same path.
+        """
+        assert self._syncer is not None  # guarded by awrap_tool_call
+        syncer = self._syncer
+        args = request.tool_call["args"]
+        file_path = args["file_path"]
+        content = args["content"]
+
+        async with syncer.lock:
+            result = await handler(request)
+            if not _is_text_success(result, WRITE_SUCCESS_PREFIX):
+                return result
+
+            try:
+                target = syncer.resolve_target(file_path)
+            except (OSError, ValueError) as exc:
+                # Upstream succeeded so the file is on disk, but we can't determine where —
+                # surface CRITICAL so the agent knows local state may be desynced.
+                return _replace_tool_message(
+                    result, format_sync_error(f"failed to prepare sandbox sync: {exc}", rollback_ok=False)
+                )
+
+            def _rollback() -> bool:
+                try:
+                    target.unlink(missing_ok=True)
+                except OSError:
+                    logger.exception("rollback unlink failed for %s", target)
+                    return False
+                return True
+
+            try:
+                mode = stat.S_IMODE(target.stat().st_mode)
+            except OSError as exc:
+                return _replace_tool_message(
+                    result, format_sync_error(f"failed to prepare sandbox sync: {exc}", rollback_ok=_rollback())
+                )
+
+            error = await syncer.mirror(
+                runtime=request.runtime,
+                resolved_path=target,
+                content_bytes=content.encode(),
+                mode=mode,
+                rollback=_rollback,
+            )
+            return _replace_tool_message(result, error) if error else result
+
+    async def _mirror_edit(
+        self, request: ToolCallRequest, handler: Callable[[ToolCallRequest], Awaitable[ToolMessage | Command[Any]]]
+    ) -> ToolMessage | Command[Any]:
+        """Dispatch ``edit_file`` and mirror the post-edit file under the syncer lock.
+
+        Snapshots pre-edit bytes + mode outside the lock so rollback can restore them on
+        sync failure. The lock then serialises dispatch through mirror so a sibling write
+        cannot interleave with our restore.
+        """
+        assert self._syncer is not None  # guarded by awrap_tool_call
+        syncer = self._syncer
+        args = request.tool_call["args"]
+        file_path = args["file_path"]
+
+        # Snapshot must happen before dispatch so we can rebuild the file on sync failure.
+        # If anything fails here (invalid path, missing file), let upstream produce the
+        # canonical "not found" error instead of inventing our own.
+        try:
+            target = syncer.resolve_target(file_path)
+            pre_bytes = target.read_bytes()
+            pre_mode = stat.S_IMODE(target.stat().st_mode)
+        except ValueError, OSError:
+            return await handler(request)
+
+        async with syncer.lock:
+            result = await handler(request)
+            if not _is_text_success(result, EDIT_SUCCESS_PREFIX):
+                return result
+
+            def _rollback() -> bool:
+                try:
+                    target.write_bytes(pre_bytes)
+                    os.chmod(target, pre_mode)  # noqa: PTH101
+                except OSError:
+                    logger.exception("rollback restore failed for %s", target)
+                    return False
+                return True
+
+            try:
+                post_bytes = target.read_bytes()
+            except OSError as exc:
+                return _replace_tool_message(
+                    result, format_sync_error(f"failed to prepare sandbox sync: {exc}", rollback_ok=_rollback())
+                )
+
+            error = await syncer.mirror(
+                runtime=request.runtime,
+                resolved_path=target,
+                content_bytes=post_bytes,
+                mode=pre_mode,
+                rollback=_rollback,
+            )
+            return _replace_tool_message(result, error) if error else result
+
+
+def _is_text_success(result: ToolMessage | Command[Any], prefix: str) -> bool:
+    """True iff ``result`` is a non-error ToolMessage whose text content starts with ``prefix``."""
+    if not isinstance(result, ToolMessage) or result.status == "error":
+        return False
+    return isinstance(result.content, str) and result.content.startswith(prefix)
+
+
+def _replace_tool_message(original: ToolMessage | Command[Any], error_text: str) -> ToolMessage:
+    """Return a new ``ToolMessage`` carrying ``error_text`` keyed to the same tool call.
+
+    Caller must have verified ``original`` is a successful ``ToolMessage``; only used after
+    upstream dispatch succeeded but the post-dispatch sync step failed.
+    """
+    assert isinstance(original, ToolMessage)
+    return ToolMessage(content=error_text, tool_call_id=original.tool_call_id, name=original.name, status="error")

--- a/daiv/automation/agent/middlewares/skills.py
+++ b/daiv/automation/agent/middlewares/skills.py
@@ -17,15 +17,17 @@ from langgraph.types import Command
 
 from automation.agent.conf import settings as agent_settings
 from automation.agent.constants import BUILTIN_SKILLS_PATH, GLOBAL_SKILLS_PATH
+from automation.agent.middlewares.file_system import WRITE_TOOL_NAMES
 from automation.agent.utils import extract_body_from_frontmatter, extract_text_content
 from codebase.context import RuntimeCtx  # noqa: TC001
 from slash_commands.parser import SlashCommandCommand, parse_slash_command
 from slash_commands.registry import slash_command_registry
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable, Callable
+    from collections.abc import Awaitable, Callable, Sequence
 
     from deepagents.graph import SubAgent
+    from deepagents.middleware.subagents import CompiledSubAgent
     from langchain.agents.middleware.types import ToolCallRequest
     from langchain_core.runnables import RunnableConfig
     from langchain_core.tools import BaseTool
@@ -35,7 +37,6 @@ logger = logging.getLogger("daiv.tools")
 
 SKILL_ARGUMENTS_PLACEHOLDER = "$ARGUMENTS"
 SKILL_MODE_READ_ONLY = "read-only"
-WRITE_TOOL_NAMES = frozenset({"edit_file", "write_file"})
 
 
 class DAIVSkillsState(SkillsState):
@@ -114,7 +115,7 @@ class SkillsMiddleware(DeepAgentsSkillsMiddleware):
 
     state_schema = DAIVSkillsState
 
-    def __init__(self, *args, subagents: list[SubAgent] | None = None, **kwargs):
+    def __init__(self, *args, subagents: Sequence[SubAgent | CompiledSubAgent] | None = None, **kwargs):
         super().__init__(*args, **kwargs)
         self.system_prompt_template = SKILLS_SYSTEM_PROMPT
         self.tools = [self._skill_tool_generator()]

--- a/daiv/automation/agent/profile.py
+++ b/daiv/automation/agent/profile.py
@@ -1,10 +1,21 @@
 """DAIV harness profile registration.
 
 Carries DAIV's customizations to upstream ``deepagents.create_deep_agent``:
-filesystem tool description overrides, exclusion of upstream's
+suppression of upstream's ``BASE_AGENT_PROMPT`` (DAIV ships its own system
+prompt via ``dynamic_daiv_system_prompt`` and the upstream content would
+otherwise be appended verbatim, causing duplicate identity/Core-Behavior/
+Doing-Tasks sections), exclusion of the auto-added ``TodoListMiddleware``
+(DAIV supplies its own instance with a custom ``system_prompt`` so main
+agent and subagents share the same todo guidance), filesystem tool
+description overrides, exclusion of upstream's
 ``AnthropicPromptCachingMiddleware`` (DAIV ships its own OpenRouter-aware
-subclass), and disabling the auto-added ``general-purpose`` subagent (DAIV
-provides its own pre-compiled one).
+subclass), and disabling the auto-added ``general-purpose`` subagent
+(DAIV provides its own pre-compiled one).
+
+Setting ``base_system_prompt=""`` only suppresses the ``BASE`` slot; built-in
+model-level profiles (e.g. ``anthropic:claude-opus-4-7``) only populate
+``system_prompt_suffix``, so ``_merge_profiles`` keeps their suffix on top
+of the empty base.
 """
 
 from __future__ import annotations
@@ -14,13 +25,15 @@ from deepagents import GeneralPurposeSubagentProfile, HarnessProfile, register_h
 # Class-form exclusion (exact-type match). DAIV's subclass shares the same
 # ``__name__`` as upstream, so string-form would match both — class-form is
 # mandatory here.
+from langchain.agents.middleware import TodoListMiddleware
 from langchain_anthropic.middleware import AnthropicPromptCachingMiddleware as _UpstreamAnthropicPromptCachingMiddleware
 
 from automation.agent.middlewares.file_system import CUSTOM_TOOL_DESCRIPTIONS
 
 DAIV_HARNESS_PROFILE = HarnessProfile(
+    base_system_prompt="",
     tool_description_overrides=CUSTOM_TOOL_DESCRIPTIONS,
-    excluded_middleware=frozenset({_UpstreamAnthropicPromptCachingMiddleware}),
+    excluded_middleware=frozenset({_UpstreamAnthropicPromptCachingMiddleware, TodoListMiddleware}),
     general_purpose_subagent=GeneralPurposeSubagentProfile(enabled=False),
 )
 
@@ -34,3 +47,4 @@ def register() -> None:
     """
     register_harness_profile("anthropic", DAIV_HARNESS_PROFILE)
     register_harness_profile("openai", DAIV_HARNESS_PROFILE)
+    register_harness_profile("google_genai", DAIV_HARNESS_PROFILE)

--- a/daiv/automation/agent/profile.py
+++ b/daiv/automation/agent/profile.py
@@ -1,0 +1,36 @@
+"""DAIV harness profile registration.
+
+Carries DAIV's customizations to upstream ``deepagents.create_deep_agent``:
+filesystem tool description overrides, exclusion of upstream's
+``AnthropicPromptCachingMiddleware`` (DAIV ships its own OpenRouter-aware
+subclass), and disabling the auto-added ``general-purpose`` subagent (DAIV
+provides its own pre-compiled one).
+"""
+
+from __future__ import annotations
+
+from deepagents import GeneralPurposeSubagentProfile, HarnessProfile, register_harness_profile
+
+# Class-form exclusion (exact-type match). DAIV's subclass shares the same
+# ``__name__`` as upstream, so string-form would match both — class-form is
+# mandatory here.
+from langchain_anthropic.middleware import AnthropicPromptCachingMiddleware as _UpstreamAnthropicPromptCachingMiddleware
+
+from automation.agent.middlewares.file_system import CUSTOM_TOOL_DESCRIPTIONS
+
+DAIV_HARNESS_PROFILE = HarnessProfile(
+    tool_description_overrides=CUSTOM_TOOL_DESCRIPTIONS,
+    excluded_middleware=frozenset({_UpstreamAnthropicPromptCachingMiddleware}),
+    general_purpose_subagent=GeneralPurposeSubagentProfile(enabled=False),
+)
+
+
+def register() -> None:
+    """Register the DAIV harness profile under every provider DAIV uses.
+
+    DAIV reaches Anthropic models directly (``anthropic`` provider) and via
+    OpenRouter (``openai`` provider, since OpenRouter speaks the OpenAI API).
+    Both need the same overrides.
+    """
+    register_harness_profile("anthropic", DAIV_HARNESS_PROFILE)
+    register_harness_profile("openai", DAIV_HARNESS_PROFILE)

--- a/daiv/automation/agent/prompts.py
+++ b/daiv/automation/agent/prompts.py
@@ -16,7 +16,7 @@ The user will primarily request you perform software engineering tasks. This inc
 
 - In general, do not propose changes to code you haven't read. If a user asks about or wants you to modify a file, read it first. Understand existing code before suggesting modifications.
 - Do not create files unless they're absolutely necessary for achieving your goal. Generally prefer editing an existing file to creating a new one, as this prevents file bloat and builds on existing work more effectively.
-- When making changes to files, first understand the file's code conventions. Mimic code style, use existing libraries and utilities, and follow existing patterns.
+- When making changes, prefer libraries and utilities already in use over introducing new dependencies.
 - If your approach is blocked, do not attempt to brute force your way to the outcome. For example, if an API call or test fails, do not wait and retry the same action repeatedly. Instead, consider alternative approaches or other ways you might unblock yourself, or consider using the AskUserQuestion to align with the user on the right path forward.
 - After editing a file, consider its new state to include your changes. Do not attempt to re-apply edits you have already made. If you are unsure whether a previous edit succeeded, re-read the file once — do not retry the same edit without verifying the current file content first.
 - Avoid over-engineering. Only make changes that are directly requested or clearly necessary. Fixing test failures caused by your changes is always clearly necessary.
@@ -51,7 +51,7 @@ Prioritize technical accuracy and truthfulness over validating the user's belief
 - You can call multiple tools in a single response. If you intend to call multiple tools and there are no dependencies between them, make all independent tool calls in parallel. Maximize use of parallel tool calls where possible to increase efficiency. However, if some tool calls depend on previous calls to inform dependent values, do NOT call these tools in parallel and instead call them sequentially. For instance, if one operation must complete before another starts, run these operations sequentially instead.
 - Never paste filesystem tool outputs verbatim into user-visible messages; always rewrite paths to repo-relative form.
 {{#bash_tool_enabled}}
-- Do NOT use the Bash to run commands when a relevant dedicated tool is provided. Using dedicated tools allows the user to better understand and review your work. This is CRITICAL to assisting the user. Use dedicated tools such as `read_file` for reading files instead of cat/head/tail, `edit_file` for editing instead of sed/awk, and `write_file` for creating files instead of cat with heredoc or echo redirection, `glob` searching files, and `grep` searching file contents. Reserve bash tools exclusively for actual system commands and terminal operations that require shell execution.
+- Do NOT use Bash when a dedicated tool exists. Substitutions: cat/head/tail → `read_file`, sed/awk → `edit_file`, cat-heredoc/echo-redirect → `write_file`, find → `glob`, grep -r → `grep`. Reserve Bash for actual shell ops (tests, builds, package managers).
 {{/bash_tool_enabled}}
 
 {{^bash_tool_enabled}}

--- a/daiv/automation/agent/subagents.py
+++ b/daiv/automation/agent/subagents.py
@@ -1,17 +1,24 @@
 import logging
 import re
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import yaml
-from deepagents.graph import SubAgent
 from deepagents.middleware import SummarizationMiddleware
+from deepagents.middleware.filesystem import FilesystemMiddleware
 from deepagents.middleware.patch_tool_calls import PatchToolCallsMiddleware
+from deepagents.middleware.subagents import CompiledSubAgent
 from deepagents.middleware.summarization import compute_summarization_defaults
-from langchain.agents.middleware import ModelFallbackMiddleware, TodoListMiddleware
+from langchain.agents import create_agent
+from langchain.agents.middleware import AgentMiddleware, ModelFallbackMiddleware, TodoListMiddleware
 
 from automation.agent import BaseAgent
-from automation.agent.middlewares.file_system import FilesystemMiddleware
+from automation.agent.middlewares.file_system import (
+    CUSTOM_TOOL_DESCRIPTIONS,
+    FILESYSTEM_ABSOLUTE_PATH_DIRECTIVE,
+    WRITE_TOOL_NAMES,
+    FilesystemSandboxSyncMiddleware,
+)
 from automation.agent.middlewares.git_platform import GitPlatformMiddleware
 from automation.agent.middlewares.logging import ToolCallLoggingMiddleware
 from automation.agent.middlewares.prompt_cache import AnthropicPromptCachingMiddleware
@@ -26,15 +33,20 @@ if TYPE_CHECKING:
 
     from codebase.context import RuntimeCtx
 
+GENERAL_PURPOSE_NAME = "general-purpose"
+EXPLORE_NAME = "explore"
+
 logger = logging.getLogger("daiv.agent")
 
 GENERAL_PURPOSE_DESCRIPTION = "General-purpose agent for researching complex questions, searching for code, and executing multi-step tasks. When you are searching for a keyword or file and are not confident that you will find the right match in the first few tries use this agent to perform the search for you. This agent has access to all tools as the main agent."  # noqa: E501
 
-GENERAL_PURPOSE_SYSTEM_PROMPT = """You are an agent for DAIV. Given the user's message, you should use the tools available to complete the task. Do exactly what has been asked. When you complete the task respond with a detailed writeup.
+GENERAL_PURPOSE_SYSTEM_PROMPT = f"""You are an agent for DAIV. Given the user's message, you should use the tools available to complete the task. Do exactly what has been asked. When you complete the task respond with a detailed writeup.
 
 - For file searches: Use `grep` or `glob` when you need to search broadly. Use `read_file` when you know the specific file path.
 - NEVER proactively create documentation files (*.md) or README files. Only create documentation files if explicitly requested.
 - CRITICAL: All file paths in your response MUST be absolute paths exactly as returned by the tools (e.g., /repo/src/app/utils.py). Never strip prefixes or convert to relative paths — the caller uses your paths directly in tool calls.
+
+{FILESYSTEM_ABSOLUTE_PATH_DIRECTIVE}
 """  # noqa: E501
 
 
@@ -50,17 +62,22 @@ def _build_general_purpose_middleware(
     """
     Build the middleware stack for a general-purpose subagent.
     """
+    # Local import to break a circular dependency: graph.py imports this module.
     from automation.agent.graph import dynamic_write_todos_system_prompt
 
     _summarization_defaults = compute_summarization_defaults(model)
 
-    middleware = [
+    middleware: list[AgentMiddleware[Any, Any, Any]] = [
         TodoListMiddleware(system_prompt=dynamic_write_todos_system_prompt(bash_tool_enabled=sandbox_enabled)),
-        FilesystemMiddleware(
-            backend=backend,
-            sandbox_sync=sandbox_enabled,
-            working_dir=Path(runtime.gitrepo.working_dir) if sandbox_enabled else None,
-        ),
+        FilesystemMiddleware(backend=backend, custom_tool_descriptions=CUSTOM_TOOL_DESCRIPTIONS),
+    ]
+
+    if sandbox_enabled:
+        middleware.append(
+            FilesystemSandboxSyncMiddleware(backend=backend, working_dir=Path(runtime.gitrepo.working_dir))
+        )
+
+    middleware.extend([
         GitPlatformMiddleware(git_platform=runtime.git_platform),
         SummarizationMiddleware(
             model=model,
@@ -73,7 +90,7 @@ def _build_general_purpose_middleware(
         AnthropicPromptCachingMiddleware(),
         ToolCallLoggingMiddleware(),
         PatchToolCallsMiddleware(),
-    ]
+    ])
 
     if web_search_enabled:
         middleware.append(WebSearchMiddleware())
@@ -98,26 +115,27 @@ def create_general_purpose_subagent(
     web_search_enabled: bool = True,
     web_fetch_enabled: bool = True,
     fallback_models: list[BaseChatModel] | None = None,
-) -> SubAgent:
+) -> CompiledSubAgent:
     """
     Create the general purpose subagent for the DAIV agent.
     """
-    return SubAgent(
-        name="general-purpose",
-        description=GENERAL_PURPOSE_DESCRIPTION,
+    runnable = create_agent(
+        model=model,
+        tools=[],
         system_prompt=GENERAL_PURPOSE_SYSTEM_PROMPT,
         middleware=_build_general_purpose_middleware(
             model, backend, runtime, sandbox_enabled, web_search_enabled, web_fetch_enabled, fallback_models
         ),
-        model=model,
-        tools=[],
+        name=GENERAL_PURPOSE_NAME,
     )
+    return CompiledSubAgent(name=GENERAL_PURPOSE_NAME, description=GENERAL_PURPOSE_DESCRIPTION, runnable=runnable)
 
 
-EXPLORE_SYSTEM_PROMPT = """\
+EXPLORE_SYSTEM_PROMPT = f"""\
 You are a file search specialist for DAIV. You excel at thoroughly navigating and exploring codebases.
 
-=== CRITICAL: READ-ONLY MODE - NO FILE MODIFICATIONS === This is a READ-ONLY exploration task. You are STRICTLY PROHIBITED from:
+=== CRITICAL: READ-ONLY MODE - NO FILE MODIFICATIONS ===
+This is a READ-ONLY exploration task. You are STRICTLY PROHIBITED from:
 - Creating new files (no write_file, touch, or file creation of any kind)
 - Modifying existing files (no edit_file operations)
 - Deleting files (no rm or deletion)
@@ -145,23 +163,43 @@ NOTE: You are meant to be a fast agent that returns output as quickly as possibl
 - Make efficient use of the tools that you have at your disposal: be smart about how you search for files and implementations
 - Wherever possible you should try to spawn multiple parallel tool calls for grepping and reading files
 
-Complete the user's search request efficiently and report your findings clearly."""  # noqa: E501
+Complete the user's search request efficiently and report your findings clearly.
+
+{FILESYSTEM_ABSOLUTE_PATH_DIRECTIVE}
+"""  # noqa: E501
 
 EXPLORE_SUBAGENT_DESCRIPTION = """Fast agent specialized for exploring codebases. Use this when you need to quickly find files by patterns (eg. "src/components/**/*.tsx"), search code for keywords (eg. "API endpoints"), or answer questions about the codebase (eg. "how do API endpoints work?"). When calling this agent, specify the desired thoroughness level: "quick" for basic searches, "medium" for moderate exploration, or "very thorough" for comprehensive analysis across multiple locations and naming conventions."""  # noqa: E501
 
 
-def create_explore_subagent(backend: BackendProtocol, **kwargs) -> SubAgent:
+def _build_read_only_filesystem_middleware(backend: BackendProtocol) -> FilesystemMiddleware:
+    """Build a FilesystemMiddleware with write_file/edit_file stripped from its tool list."""
+    fs_mw = FilesystemMiddleware(backend=backend, custom_tool_descriptions=CUSTOM_TOOL_DESCRIPTIONS)
+    original_names = {tool.name for tool in fs_mw.tools}
+    # Read-only is a security contract; if upstream renames the write tools, the filter would
+    # silently match nothing and the explore subagent would regain write capability. Fail loud.
+    missing = WRITE_TOOL_NAMES - original_names
+    if missing:
+        raise RuntimeError(
+            f"Upstream FilesystemMiddleware no longer exposes expected write tools: {sorted(missing)}; "
+            f"got tools: {sorted(original_names)}"
+        )
+    fs_mw.tools = [tool for tool in fs_mw.tools if tool.name not in WRITE_TOOL_NAMES]
+    return fs_mw
+
+
+def create_explore_subagent(backend: BackendProtocol, **kwargs) -> CompiledSubAgent:
     """
     Create the explore subagent.
     """
+    # Local import to break a circular dependency: graph.py imports this module.
     from automation.agent.graph import dynamic_write_todos_system_prompt
 
     model = BaseAgent.get_model(model=site_settings.agent_explore_model_name)
     _summarization_defaults = compute_summarization_defaults(model)
 
-    middleware = [
+    middleware: list[AgentMiddleware[Any, Any, Any]] = [
         TodoListMiddleware(system_prompt=dynamic_write_todos_system_prompt(bash_tool_enabled=False)),
-        FilesystemMiddleware(backend=backend, read_only=True),
+        _build_read_only_filesystem_middleware(backend),
         SummarizationMiddleware(
             model=model,
             backend=backend,
@@ -184,18 +222,14 @@ def create_explore_subagent(backend: BackendProtocol, **kwargs) -> SubAgent:
                 "Could not initialize explore fallback model '%s', proceeding without fallback", fallback_model_name
             )
 
-    return SubAgent(
-        name="explore",
-        description=EXPLORE_SUBAGENT_DESCRIPTION,
-        system_prompt=EXPLORE_SYSTEM_PROMPT,
-        middleware=middleware,
-        model=model,
-        tools=[],
+    runnable = create_agent(
+        model=model, tools=[], system_prompt=EXPLORE_SYSTEM_PROMPT, middleware=middleware, name=EXPLORE_NAME
     )
+    return CompiledSubAgent(name=EXPLORE_NAME, description=EXPLORE_SUBAGENT_DESCRIPTION, runnable=runnable)
 
 
 # Names reserved for built-in subagents. Custom subagents may not use these names.
-BUILTIN_SUBAGENT_NAMES: frozenset[str] = frozenset({"general-purpose", "explore"})
+BUILTIN_SUBAGENT_NAMES: frozenset[str] = frozenset({GENERAL_PURPOSE_NAME, EXPLORE_NAME})
 
 FRONTMATTER_PATTERN = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
 
@@ -256,7 +290,7 @@ async def load_custom_subagents(
     web_search_enabled: bool = True,
     web_fetch_enabled: bool = True,
     fallback_models: list[BaseChatModel] | None = None,
-) -> list[SubAgent]:
+) -> list[CompiledSubAgent]:
     """
     Load custom subagents from markdown files in the given source paths.
 
@@ -274,9 +308,9 @@ async def load_custom_subagents(
         fallback_models: Optional fallback models for model failover.
 
     Returns:
-        List of SubAgent dicts for the loaded custom subagents.
+        List of CompiledSubAgent dicts for the loaded custom subagents.
     """
-    subagents: list[SubAgent] = []
+    subagents: list[CompiledSubAgent] = []
 
     for source_path in sources:
         try:
@@ -319,23 +353,23 @@ async def load_custom_subagents(
                     logger.warning("Skipping %s: invalid model '%s'", file_path, frontmatter_model)
                     continue
 
+            runnable = create_agent(
+                model=subagent_model,
+                tools=[],
+                system_prompt=f"{body}\n\n{FILESYSTEM_ABSOLUTE_PATH_DIRECTIVE}",
+                middleware=_build_general_purpose_middleware(
+                    subagent_model,
+                    backend,
+                    runtime,
+                    sandbox_enabled,
+                    web_search_enabled,
+                    web_fetch_enabled,
+                    fallback_models,
+                ),
+                name=frontmatter["name"],
+            )
             subagents.append(
-                SubAgent(
-                    name=frontmatter["name"],
-                    description=frontmatter["description"],
-                    system_prompt=body,
-                    middleware=_build_general_purpose_middleware(
-                        subagent_model,
-                        backend,
-                        runtime,
-                        sandbox_enabled,
-                        web_search_enabled,
-                        web_fetch_enabled,
-                        fallback_models,
-                    ),
-                    model=subagent_model,
-                    tools=[],
-                )
+                CompiledSubAgent(name=frontmatter["name"], description=frontmatter["description"], runnable=runnable)
             )
 
             logger.info("Loaded custom subagent '%s' from %s", frontmatter["name"], file_path)

--- a/daiv/automation/agent/subagents.py
+++ b/daiv/automation/agent/subagents.py
@@ -17,7 +17,6 @@ from automation.agent.middlewares.file_system import (
     CUSTOM_TOOL_DESCRIPTIONS,
     FILESYSTEM_ABSOLUTE_PATH_DIRECTIVE,
     WRITE_TOOL_NAMES,
-    FilesystemSandboxSyncMiddleware,
 )
 from automation.agent.middlewares.git_platform import GitPlatformMiddleware
 from automation.agent.middlewares.logging import ToolCallLoggingMiddleware
@@ -70,14 +69,6 @@ def _build_general_purpose_middleware(
     middleware: list[AgentMiddleware[Any, Any, Any]] = [
         TodoListMiddleware(system_prompt=dynamic_write_todos_system_prompt(bash_tool_enabled=sandbox_enabled)),
         FilesystemMiddleware(backend=backend, custom_tool_descriptions=CUSTOM_TOOL_DESCRIPTIONS),
-    ]
-
-    if sandbox_enabled:
-        middleware.append(
-            FilesystemSandboxSyncMiddleware(backend=backend, working_dir=Path(runtime.gitrepo.working_dir))
-        )
-
-    middleware.extend([
         GitPlatformMiddleware(git_platform=runtime.git_platform),
         SummarizationMiddleware(
             model=model,
@@ -90,7 +81,7 @@ def _build_general_purpose_middleware(
         AnthropicPromptCachingMiddleware(),
         ToolCallLoggingMiddleware(),
         PatchToolCallsMiddleware(),
-    ])
+    ]
 
     if web_search_enabled:
         middleware.append(WebSearchMiddleware())
@@ -99,7 +90,9 @@ def _build_general_purpose_middleware(
         middleware.append(WebFetchMiddleware())
 
     if sandbox_enabled:
-        middleware.append(SandboxMiddleware(close_session=False))
+        middleware.append(
+            SandboxMiddleware(backend=backend, working_dir=Path(runtime.gitrepo.working_dir), close_session=False)
+        )
 
     if fallback_models:
         middleware.append(ModelFallbackMiddleware(*fallback_models))

--- a/daiv/automation/agent/subagents.py
+++ b/daiv/automation/agent/subagents.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any
 
 import yaml
 from deepagents.middleware import SummarizationMiddleware
-from deepagents.middleware.filesystem import FilesystemMiddleware
+from deepagents.middleware.filesystem import FilesystemMiddleware, FilesystemPermission
 from deepagents.middleware.patch_tool_calls import PatchToolCallsMiddleware
 from deepagents.middleware.subagents import CompiledSubAgent
 from deepagents.middleware.summarization import compute_summarization_defaults
@@ -13,11 +13,7 @@ from langchain.agents import create_agent
 from langchain.agents.middleware import AgentMiddleware, ModelFallbackMiddleware, TodoListMiddleware
 
 from automation.agent import BaseAgent
-from automation.agent.middlewares.file_system import (
-    CUSTOM_TOOL_DESCRIPTIONS,
-    FILESYSTEM_ABSOLUTE_PATH_DIRECTIVE,
-    WRITE_TOOL_NAMES,
-)
+from automation.agent.middlewares.file_system import CUSTOM_TOOL_DESCRIPTIONS, FILESYSTEM_ABSOLUTE_PATH_DIRECTIVE
 from automation.agent.middlewares.git_platform import GitPlatformMiddleware
 from automation.agent.middlewares.logging import ToolCallLoggingMiddleware
 from automation.agent.middlewares.prompt_cache import AnthropicPromptCachingMiddleware
@@ -164,20 +160,12 @@ Complete the user's search request efficiently and report your findings clearly.
 EXPLORE_SUBAGENT_DESCRIPTION = """Fast agent specialized for exploring codebases. Use this when you need to quickly find files by patterns (eg. "src/components/**/*.tsx"), search code for keywords (eg. "API endpoints"), or answer questions about the codebase (eg. "how do API endpoints work?"). When calling this agent, specify the desired thoroughness level: "quick" for basic searches, "medium" for moderate exploration, or "very thorough" for comprehensive analysis across multiple locations and naming conventions."""  # noqa: E501
 
 
-def _build_read_only_filesystem_middleware(backend: BackendProtocol) -> FilesystemMiddleware:
-    """Build a FilesystemMiddleware with write_file/edit_file stripped from its tool list."""
-    fs_mw = FilesystemMiddleware(backend=backend, custom_tool_descriptions=CUSTOM_TOOL_DESCRIPTIONS)
-    original_names = {tool.name for tool in fs_mw.tools}
-    # Read-only is a security contract; if upstream renames the write tools, the filter would
-    # silently match nothing and the explore subagent would regain write capability. Fail loud.
-    missing = WRITE_TOOL_NAMES - original_names
-    if missing:
-        raise RuntimeError(
-            f"Upstream FilesystemMiddleware no longer exposes expected write tools: {sorted(missing)}; "
-            f"got tools: {sorted(original_names)}"
-        )
-    fs_mw.tools = [tool for tool in fs_mw.tools if tool.name not in WRITE_TOOL_NAMES]
-    return fs_mw
+# Deny rule that makes every filesystem write operation fail for the explore subagent.
+# Enforced inside the deepagents filesystem tools against the validated path, so renaming
+# tools upstream cannot silently restore write capability.
+READ_ONLY_PERMISSIONS: list[FilesystemPermission] = [
+    FilesystemPermission(operations=["write"], paths=["/**"], mode="deny")
+]
 
 
 def create_explore_subagent(backend: BackendProtocol, **kwargs) -> CompiledSubAgent:
@@ -192,7 +180,9 @@ def create_explore_subagent(backend: BackendProtocol, **kwargs) -> CompiledSubAg
 
     middleware: list[AgentMiddleware[Any, Any, Any]] = [
         TodoListMiddleware(system_prompt=dynamic_write_todos_system_prompt(bash_tool_enabled=False)),
-        _build_read_only_filesystem_middleware(backend),
+        FilesystemMiddleware(
+            backend=backend, custom_tool_descriptions=CUSTOM_TOOL_DESCRIPTIONS, _permissions=READ_ONLY_PERMISSIONS
+        ),
         SummarizationMiddleware(
             model=model,
             backend=backend,

--- a/daiv/automation/apps.py
+++ b/daiv/automation/apps.py
@@ -9,4 +9,7 @@ class AutomationConfig(AppConfig):
     verbose_name = _("Automation")
 
     def ready(self):
+        from automation.agent.profile import register as register_harness_profile
+
+        register_harness_profile()
         autodiscover_modules("agent.mcp.servers")

--- a/daiv/slash_commands/actions/agents.py
+++ b/daiv/slash_commands/actions/agents.py
@@ -7,7 +7,10 @@ from slash_commands.base import SlashCommand
 from slash_commands.decorator import slash_command
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from deepagents.graph import SubAgent
+    from deepagents.middleware.subagents import CompiledSubAgent
 
 
 @slash_command(command="agents", scopes=[Scope.GLOBAL, Scope.ISSUE, Scope.MERGE_REQUEST])
@@ -18,7 +21,9 @@ class AgentsSlashCommand(SlashCommand):
 
     description: str = "Shows the list of available sub-agents with their names and descriptions."
 
-    async def execute_for_agent(self, *, args: str, available_subagents: list[SubAgent], **kwargs) -> str:
+    async def execute_for_agent(
+        self, *, args: str, available_subagents: Sequence[SubAgent | CompiledSubAgent], **kwargs
+    ) -> str:
         """
         Execute agents command for agent middleware.
 

--- a/tests/unit_tests/automation/agent/middlewares/test_file_system.py
+++ b/tests/unit_tests/automation/agent/middlewares/test_file_system.py
@@ -14,6 +14,39 @@ def _make_runtime(state, working_dir, gitrepo=None):
     )
 
 
+def _build_synced_filesystem(*, backend, working_dir=None, read_only=False, sandbox_sync=False):
+    """Test helper: build upstream ``FilesystemMiddleware`` and apply DAIV's syncer wrappers.
+
+    Mirrors the old DAIV ``FilesystemMiddleware`` subclass shape so the per-tool tests
+    can keep iterating ``mw.tools``. Production code uses upstream's middleware plus
+    ``FilesystemSandboxSyncMiddleware`` directly.
+    """
+    from deepagents.middleware.filesystem import FilesystemMiddleware as UpstreamFilesystemMiddleware
+
+    from automation.agent.middlewares import file_system as fs_module
+
+    fs = UpstreamFilesystemMiddleware(backend=backend, custom_tool_descriptions=fs_module.CUSTOM_TOOL_DESCRIPTIONS)
+
+    if read_only:
+        fs.tools = [t for t in fs.tools if t.name not in fs_module.WRITE_TOOL_NAMES]
+        return fs
+
+    if sandbox_sync:
+        client = fs_module.DAIVSandboxClient()
+        syncer = fs_module._SandboxSyncer(backend=backend, working_dir=working_dir, client=client)
+        new_tools = []
+        for tool in fs.tools:
+            if tool.name == fs_module.WRITE_FILE_TOOL:
+                new_tools.append(syncer.wrap_write_tool(tool))
+            elif tool.name == fs_module.EDIT_FILE_TOOL:
+                new_tools.append(syncer.wrap_edit_tool(tool))
+            else:
+                new_tools.append(tool)
+        fs.tools = new_tools
+
+    return fs
+
+
 @pytest.fixture
 def fake_client(monkeypatch):
     """Patch DAIVSandboxClient with an AsyncMock and yield the mock."""
@@ -35,14 +68,13 @@ def working_repo(tmp_path):
 async def test_sync_write_file_writes_locally_and_syncs(fake_client, working_repo):
     from deepagents.backends.filesystem import FilesystemBackend
 
-    from automation.agent.middlewares.file_system import FilesystemMiddleware
     from core.sandbox.schemas import ApplyMutationsResponse, MutationResult
 
     fake_client.apply_file_mutations.return_value = ApplyMutationsResponse(
         results=[MutationResult(path="/repo/foo.py", ok=True, error=None)]
     )
     backend = FilesystemBackend(root_dir=working_repo.parent, virtual_mode=True)
-    mw = FilesystemMiddleware(backend=backend, sandbox_sync=True, working_dir=working_repo)
+    mw = _build_synced_filesystem(backend=backend, sandbox_sync=True, working_dir=working_repo)
 
     write = next(t for t in mw.tools if t.name == "write_file")
     runtime = _make_runtime(state={"session_id": "sid"}, working_dir=working_repo)
@@ -65,11 +97,9 @@ async def test_sync_write_file_writes_locally_and_syncs(fake_client, working_rep
 async def test_sync_write_file_rolls_back_on_sync_failure(fake_client, working_repo):
     from deepagents.backends.filesystem import FilesystemBackend
 
-    from automation.agent.middlewares.file_system import FilesystemMiddleware
-
     fake_client.apply_file_mutations.side_effect = RuntimeError("network down")
     backend = FilesystemBackend(root_dir=working_repo.parent, virtual_mode=True)
-    mw = FilesystemMiddleware(backend=backend, sandbox_sync=True, working_dir=working_repo)
+    mw = _build_synced_filesystem(backend=backend, sandbox_sync=True, working_dir=working_repo)
 
     write = next(t for t in mw.tools if t.name == "write_file")
     runtime = _make_runtime(state={"session_id": "sid"}, working_dir=working_repo)
@@ -84,14 +114,13 @@ async def test_sync_write_file_rolls_back_on_sync_failure(fake_client, working_r
 async def test_sync_write_file_rolls_back_on_per_item_failure(fake_client, working_repo):
     from deepagents.backends.filesystem import FilesystemBackend
 
-    from automation.agent.middlewares.file_system import FilesystemMiddleware
     from core.sandbox.schemas import ApplyMutationsResponse, MutationResult
 
     fake_client.apply_file_mutations.return_value = ApplyMutationsResponse(
         results=[MutationResult(path="/repo/foo.py", ok=False, error="server-side validation failed")]
     )
     backend = FilesystemBackend(root_dir=working_repo.parent, virtual_mode=True)
-    mw = FilesystemMiddleware(backend=backend, sandbox_sync=True, working_dir=working_repo)
+    mw = _build_synced_filesystem(backend=backend, sandbox_sync=True, working_dir=working_repo)
 
     write = next(t for t in mw.tools if t.name == "write_file")
     runtime = _make_runtime(state={"session_id": "sid"}, working_dir=working_repo)
@@ -105,10 +134,8 @@ async def test_sync_write_file_rolls_back_on_per_item_failure(fake_client, worki
 async def test_sync_write_file_missing_session_id(fake_client, working_repo):
     from deepagents.backends.filesystem import FilesystemBackend
 
-    from automation.agent.middlewares.file_system import FilesystemMiddleware
-
     backend = FilesystemBackend(root_dir=working_repo.parent, virtual_mode=True)
-    mw = FilesystemMiddleware(backend=backend, sandbox_sync=True, working_dir=working_repo)
+    mw = _build_synced_filesystem(backend=backend, sandbox_sync=True, working_dir=working_repo)
 
     write = next(t for t in mw.tools if t.name == "write_file")
     runtime = _make_runtime(state={}, working_dir=working_repo)  # no session_id
@@ -122,7 +149,6 @@ async def test_sync_write_file_missing_session_id(fake_client, working_repo):
 async def test_sync_edit_file_writes_locally_and_syncs(fake_client, working_repo):
     from deepagents.backends.filesystem import FilesystemBackend
 
-    from automation.agent.middlewares.file_system import FilesystemMiddleware
     from core.sandbox.schemas import ApplyMutationsResponse, MutationResult
 
     target = working_repo / "foo.py"
@@ -133,7 +159,7 @@ async def test_sync_edit_file_writes_locally_and_syncs(fake_client, working_repo
         results=[MutationResult(path="/repo/foo.py", ok=True, error=None)]
     )
     backend = FilesystemBackend(root_dir=working_repo.parent, virtual_mode=True)
-    mw = FilesystemMiddleware(backend=backend, sandbox_sync=True, working_dir=working_repo)
+    mw = _build_synced_filesystem(backend=backend, sandbox_sync=True, working_dir=working_repo)
 
     edit = next(t for t in mw.tools if t.name == "edit_file")
     runtime = _make_runtime(state={"session_id": "sid"}, working_dir=working_repo)
@@ -155,15 +181,13 @@ async def test_sync_edit_file_writes_locally_and_syncs(fake_client, working_repo
 async def test_sync_edit_file_rolls_back_on_sync_failure(fake_client, working_repo):
     from deepagents.backends.filesystem import FilesystemBackend
 
-    from automation.agent.middlewares.file_system import FilesystemMiddleware
-
     target = working_repo / "foo.py"
     target.write_text("original\n")
     os.chmod(target, 0o644)  # noqa: PTH101
 
     fake_client.apply_file_mutations.side_effect = RuntimeError("network down")
     backend = FilesystemBackend(root_dir=working_repo.parent, virtual_mode=True)
-    mw = FilesystemMiddleware(backend=backend, sandbox_sync=True, working_dir=working_repo)
+    mw = _build_synced_filesystem(backend=backend, sandbox_sync=True, working_dir=working_repo)
 
     edit = next(t for t in mw.tools if t.name == "edit_file")
     runtime = _make_runtime(state={"session_id": "sid"}, working_dir=working_repo)
@@ -183,13 +207,11 @@ async def test_write_file_handles_5xx_with_rollback(fake_client, working_repo):
     import httpx
     from deepagents.backends.filesystem import FilesystemBackend
 
-    from automation.agent.middlewares.file_system import FilesystemMiddleware
-
     fake_client.apply_file_mutations.side_effect = httpx.HTTPStatusError(
         "500", request=httpx.Request("POST", "x"), response=httpx.Response(500)
     )
     backend = FilesystemBackend(root_dir=working_repo.parent, virtual_mode=True)
-    mw = FilesystemMiddleware(backend=backend, sandbox_sync=True, working_dir=working_repo)
+    mw = _build_synced_filesystem(backend=backend, sandbox_sync=True, working_dir=working_repo)
 
     write = next(t for t in mw.tools if t.name == "write_file")
     runtime = _make_runtime(state={"session_id": "sid"}, working_dir=working_repo)
@@ -204,8 +226,6 @@ async def test_edit_file_handles_network_error(fake_client, working_repo):
     import httpx
     from deepagents.backends.filesystem import FilesystemBackend
 
-    from automation.agent.middlewares.file_system import FilesystemMiddleware
-
     target = working_repo / "foo.py"
     target.write_text("a\nb\n")
     fake_client.apply_file_mutations.side_effect = httpx.RequestError(
@@ -213,7 +233,7 @@ async def test_edit_file_handles_network_error(fake_client, working_repo):
     )
 
     backend = FilesystemBackend(root_dir=working_repo.parent, virtual_mode=True)
-    mw = FilesystemMiddleware(backend=backend, sandbox_sync=True, working_dir=working_repo)
+    mw = _build_synced_filesystem(backend=backend, sandbox_sync=True, working_dir=working_repo)
     edit = next(t for t in mw.tools if t.name == "edit_file")
     runtime = _make_runtime(state={"session_id": "sid"}, working_dir=working_repo)
 
@@ -228,10 +248,8 @@ async def test_sandbox_sync_disabled_uses_unmodified_tools(working_repo):
     """When sandbox_sync=False, deepagents' tools run without sync."""
     from deepagents.backends.filesystem import FilesystemBackend
 
-    from automation.agent.middlewares.file_system import FilesystemMiddleware
-
     backend = FilesystemBackend(root_dir=working_repo.parent, virtual_mode=True)
-    mw = FilesystemMiddleware(backend=backend, sandbox_sync=False)
+    mw = _build_synced_filesystem(backend=backend, sandbox_sync=False)
 
     write = next(t for t in mw.tools if t.name == "write_file")
     runtime = _make_runtime(state={}, working_dir=working_repo)
@@ -246,12 +264,10 @@ async def test_sync_write_file_rejects_path_outside_working_dir(fake_client, wor
     """A write to a path outside working_dir is rolled back; sandbox is never called."""
     from deepagents.backends.filesystem import FilesystemBackend
 
-    from automation.agent.middlewares.file_system import FilesystemMiddleware
-
     outside = tmp_path / "elsewhere"
     outside.mkdir()
     backend = FilesystemBackend(root_dir=tmp_path, virtual_mode=True)
-    mw = FilesystemMiddleware(backend=backend, sandbox_sync=True, working_dir=working_repo)
+    mw = _build_synced_filesystem(backend=backend, sandbox_sync=True, working_dir=working_repo)
 
     write = next(t for t in mw.tools if t.name == "write_file")
     runtime = _make_runtime(state={"session_id": "sid"}, working_dir=working_repo)
@@ -267,10 +283,8 @@ async def test_sync_edit_file_pre_read_failure(fake_client, working_repo):
     """edit_file on a missing path returns a read error, never calls the sandbox, never creates the file."""
     from deepagents.backends.filesystem import FilesystemBackend
 
-    from automation.agent.middlewares.file_system import FilesystemMiddleware
-
     backend = FilesystemBackend(root_dir=working_repo.parent, virtual_mode=True)
-    mw = FilesystemMiddleware(backend=backend, sandbox_sync=True, working_dir=working_repo)
+    mw = _build_synced_filesystem(backend=backend, sandbox_sync=True, working_dir=working_repo)
 
     edit = next(t for t in mw.tools if t.name == "edit_file")
     runtime = _make_runtime(state={"session_id": "sid"}, working_dir=working_repo)
@@ -289,11 +303,9 @@ async def test_sync_write_surfaces_critical_when_rollback_fails(fake_client, wor
     """If the sandbox sync fails AND rollback also fails, the agent gets a CRITICAL marker."""
     from deepagents.backends.filesystem import FilesystemBackend
 
-    from automation.agent.middlewares.file_system import FilesystemMiddleware
-
     fake_client.apply_file_mutations.side_effect = RuntimeError("sandbox down")
     backend = FilesystemBackend(root_dir=working_repo.parent, virtual_mode=True)
-    mw = FilesystemMiddleware(backend=backend, sandbox_sync=True, working_dir=working_repo)
+    mw = _build_synced_filesystem(backend=backend, sandbox_sync=True, working_dir=working_repo)
 
     write = next(t for t in mw.tools if t.name == "write_file")
     runtime = _make_runtime(state={"session_id": "sid"}, working_dir=working_repo)
@@ -320,15 +332,12 @@ async def test_read_only_with_sandbox_sync_strips_write_and_edit(working_repo):
     """
     from deepagents.backends.filesystem import FilesystemBackend
 
-    from automation.agent.middlewares.file_system import FilesystemMiddleware
-
     backend = FilesystemBackend(root_dir=working_repo.parent, virtual_mode=True)
-    mw = FilesystemMiddleware(backend=backend, read_only=True, sandbox_sync=True)
+    mw = _build_synced_filesystem(backend=backend, read_only=True, sandbox_sync=True)
 
     tool_names = {t.name for t in mw.tools}
     assert "write_file" not in tool_names
     assert "edit_file" not in tool_names
-    assert mw._syncer is None
 
 
 async def test_wrapped_tools_inject_runtime(working_repo):
@@ -340,10 +349,8 @@ async def test_wrapped_tools_inject_runtime(working_repo):
     """
     from deepagents.backends.filesystem import FilesystemBackend
 
-    from automation.agent.middlewares.file_system import FilesystemMiddleware
-
     backend = FilesystemBackend(root_dir=working_repo.parent, virtual_mode=True)
-    mw = FilesystemMiddleware(backend=backend, sandbox_sync=True, working_dir=working_repo)
+    mw = _build_synced_filesystem(backend=backend, sandbox_sync=True, working_dir=working_repo)
 
     write = next(t for t in mw.tools if t.name == "write_file")
     edit = next(t for t in mw.tools if t.name == "edit_file")
@@ -423,3 +430,90 @@ class TestSandboxSyncerLifecycle:
         # Second aclose must not re-close.
         await syncer.aclose()
         fake_client.close.assert_awaited_once()
+
+
+class TestFilesystemSandboxSyncMiddlewareWrap:
+    """Cover the production wrap path: ``awrap_model_call`` + ``_wrap_if_needed`` + ``_wrap_cache``.
+
+    The per-tool tests above hand-compose syncer wrappers via the test helper; these tests go
+    through the actual middleware so a regression in the dispatch logic surfaces here.
+    """
+
+    @staticmethod
+    def _make_request(tools):
+        captured = {}
+
+        async def handler(req):
+            captured["tools"] = list(req.tools)
+            return object()
+
+        request = SimpleNamespace(tools=tools, override=lambda **kw: SimpleNamespace(tools=kw["tools"]))
+        return request, handler, captured
+
+    async def test_wraps_write_and_edit_passes_through_others(self, fake_client, working_repo):
+        from deepagents.backends.filesystem import FilesystemBackend
+        from deepagents.middleware.filesystem import FilesystemMiddleware as UpstreamFilesystemMiddleware
+
+        from automation.agent.middlewares.file_system import FilesystemSandboxSyncMiddleware
+
+        backend = FilesystemBackend(root_dir=working_repo.parent, virtual_mode=True)
+        upstream = UpstreamFilesystemMiddleware(backend=backend)
+        write = next(t for t in upstream.tools if t.name == "write_file")
+        edit = next(t for t in upstream.tools if t.name == "edit_file")
+        read = next(t for t in upstream.tools if t.name == "read_file")
+        unrelated_dict = {"name": "ls"}
+
+        mw = FilesystemSandboxSyncMiddleware(backend=backend, working_dir=working_repo)
+        request, handler, captured = self._make_request([write, edit, read, unrelated_dict])
+
+        await mw.awrap_model_call(request, handler)
+
+        out_by_name = {t.name if hasattr(t, "name") else t["name"]: t for t in captured["tools"]}
+        # write_file and edit_file are replaced (different object identity).
+        assert out_by_name["write_file"] is not write
+        assert out_by_name["edit_file"] is not edit
+        # Non-write tools pass through unchanged.
+        assert out_by_name["read_file"] is read
+        assert out_by_name["ls"] is unrelated_dict
+
+    async def test_cache_reuses_wrapped_tool_across_calls(self, fake_client, working_repo):
+        from deepagents.backends.filesystem import FilesystemBackend
+        from deepagents.middleware.filesystem import FilesystemMiddleware as UpstreamFilesystemMiddleware
+
+        from automation.agent.middlewares.file_system import FilesystemSandboxSyncMiddleware
+
+        backend = FilesystemBackend(root_dir=working_repo.parent, virtual_mode=True)
+        upstream = UpstreamFilesystemMiddleware(backend=backend)
+        write = next(t for t in upstream.tools if t.name == "write_file")
+
+        mw = FilesystemSandboxSyncMiddleware(backend=backend, working_dir=working_repo)
+        request1, handler1, captured1 = self._make_request([write])
+        request2, handler2, captured2 = self._make_request([write])
+
+        await mw.awrap_model_call(request1, handler1)
+        await mw.awrap_model_call(request2, handler2)
+
+        wrapped1 = next(t for t in captured1["tools"] if t.name == "write_file")
+        wrapped2 = next(t for t in captured2["tools"] if t.name == "write_file")
+        assert wrapped1 is wrapped2, "cache must return the same wrapped tool instance"
+
+    async def test_aafter_agent_closes_opened_syncer(self, fake_client, working_repo):
+        """Regression: ``aafter_agent`` must close an opened syncer.
+
+        The syncer's own ``aclose`` no-ops when never opened, so the test must mark the
+        syncer as opened before calling ``aafter_agent`` — otherwise the assertion would
+        pass even if ``aafter_agent`` did nothing.
+        """
+        from deepagents.backends.filesystem import FilesystemBackend
+
+        from automation.agent.middlewares.file_system import FilesystemSandboxSyncMiddleware
+
+        backend = FilesystemBackend(root_dir=working_repo.parent, virtual_mode=True)
+        mw = FilesystemSandboxSyncMiddleware(backend=backend, working_dir=working_repo)
+        # Force the open-once flag without opening a real connection.
+        mw._syncer._opened = True
+
+        result = await mw.aafter_agent(state={}, runtime=_make_runtime(state={}, working_dir=working_repo))
+
+        fake_client.close.assert_awaited_once()
+        assert result is None

--- a/tests/unit_tests/automation/agent/middlewares/test_file_system.py
+++ b/tests/unit_tests/automation/agent/middlewares/test_file_system.py
@@ -17,9 +17,9 @@ def _make_runtime(state, working_dir, gitrepo=None):
 def _build_synced_filesystem(*, backend, working_dir=None, read_only=False, sandbox_sync=False):
     """Test helper: build upstream ``FilesystemMiddleware`` and apply DAIV's syncer wrappers.
 
-    Mirrors the old DAIV ``FilesystemMiddleware`` subclass shape so the per-tool tests
-    can keep iterating ``mw.tools``. Production code uses upstream's middleware plus
-    ``FilesystemSandboxSyncMiddleware`` directly.
+    Per-tool tests iterate ``mw.tools`` to invoke the wrapped ``write_file``/``edit_file``
+    coroutine directly. Production code wires the syncer through ``SandboxMiddleware``;
+    this helper exists so tests can exercise the wrapping in isolation.
     """
     from deepagents.middleware.filesystem import FilesystemMiddleware as UpstreamFilesystemMiddleware
 
@@ -33,7 +33,7 @@ def _build_synced_filesystem(*, backend, working_dir=None, read_only=False, sand
 
     if sandbox_sync:
         client = fs_module.DAIVSandboxClient()
-        syncer = fs_module._SandboxSyncer(backend=backend, working_dir=working_dir, client=client)
+        syncer = fs_module.SandboxSyncer(backend=backend, working_dir=working_dir, client=client)
         new_tools = []
         for tool in fs.tools:
             if tool.name == fs_module.WRITE_FILE_TOOL:
@@ -389,131 +389,3 @@ async def test_upstream_success_prefixes_remain_stable(working_repo):
     assert edit_result.startswith("Successfully replaced"), (
         f"upstream changed edit success format; update wrap_edit_tool prefix check: {edit_result!r}"
     )
-
-
-class TestSandboxSyncerLifecycle:
-    """Cover the open-once-on-first-mirror / close-once invariant of `_SandboxSyncer`."""
-
-    @staticmethod
-    def _make_syncer(working_repo, fake_client):
-        from automation.agent.middlewares.file_system import _SandboxSyncer
-
-        return _SandboxSyncer(backend=object(), working_dir=working_repo, client=fake_client)
-
-    async def test_aclose_is_noop_when_never_opened(self, fake_client, working_repo):
-        syncer = self._make_syncer(working_repo, fake_client)
-        await syncer.aclose()
-        fake_client.close.assert_not_awaited()
-
-    async def test_first_mirror_opens_client_then_aclose_closes_once(
-        self, fake_client, working_repo, tmp_path, monkeypatch
-    ):
-        from core.sandbox.schemas import ApplyMutationsResponse, MutationResult
-
-        fake_client.apply_file_mutations.return_value = ApplyMutationsResponse(
-            results=[MutationResult(path="/repo/foo.py", ok=True, error=None)]
-        )
-        target = working_repo / "foo.py"
-        target.write_text("hello")
-        syncer = self._make_syncer(working_repo, fake_client)
-        runtime = _make_runtime(state={"session_id": "sid"}, working_dir=working_repo)
-
-        async with syncer.lock:
-            await syncer.mirror(
-                runtime=runtime, resolved_path=target, content_bytes=b"hello", mode=0o644, rollback=lambda: True
-            )
-        fake_client.open.assert_awaited_once()
-
-        await syncer.aclose()
-        fake_client.close.assert_awaited_once()
-
-        # Second aclose must not re-close.
-        await syncer.aclose()
-        fake_client.close.assert_awaited_once()
-
-
-class TestFilesystemSandboxSyncMiddlewareWrap:
-    """Cover the production wrap path: ``awrap_model_call`` + ``_wrap_if_needed`` + ``_wrap_cache``.
-
-    The per-tool tests above hand-compose syncer wrappers via the test helper; these tests go
-    through the actual middleware so a regression in the dispatch logic surfaces here.
-    """
-
-    @staticmethod
-    def _make_request(tools):
-        captured = {}
-
-        async def handler(req):
-            captured["tools"] = list(req.tools)
-            return object()
-
-        request = SimpleNamespace(tools=tools, override=lambda **kw: SimpleNamespace(tools=kw["tools"]))
-        return request, handler, captured
-
-    async def test_wraps_write_and_edit_passes_through_others(self, fake_client, working_repo):
-        from deepagents.backends.filesystem import FilesystemBackend
-        from deepagents.middleware.filesystem import FilesystemMiddleware as UpstreamFilesystemMiddleware
-
-        from automation.agent.middlewares.file_system import FilesystemSandboxSyncMiddleware
-
-        backend = FilesystemBackend(root_dir=working_repo.parent, virtual_mode=True)
-        upstream = UpstreamFilesystemMiddleware(backend=backend)
-        write = next(t for t in upstream.tools if t.name == "write_file")
-        edit = next(t for t in upstream.tools if t.name == "edit_file")
-        read = next(t for t in upstream.tools if t.name == "read_file")
-        unrelated_dict = {"name": "ls"}
-
-        mw = FilesystemSandboxSyncMiddleware(backend=backend, working_dir=working_repo)
-        request, handler, captured = self._make_request([write, edit, read, unrelated_dict])
-
-        await mw.awrap_model_call(request, handler)
-
-        out_by_name = {t.name if hasattr(t, "name") else t["name"]: t for t in captured["tools"]}
-        # write_file and edit_file are replaced (different object identity).
-        assert out_by_name["write_file"] is not write
-        assert out_by_name["edit_file"] is not edit
-        # Non-write tools pass through unchanged.
-        assert out_by_name["read_file"] is read
-        assert out_by_name["ls"] is unrelated_dict
-
-    async def test_cache_reuses_wrapped_tool_across_calls(self, fake_client, working_repo):
-        from deepagents.backends.filesystem import FilesystemBackend
-        from deepagents.middleware.filesystem import FilesystemMiddleware as UpstreamFilesystemMiddleware
-
-        from automation.agent.middlewares.file_system import FilesystemSandboxSyncMiddleware
-
-        backend = FilesystemBackend(root_dir=working_repo.parent, virtual_mode=True)
-        upstream = UpstreamFilesystemMiddleware(backend=backend)
-        write = next(t for t in upstream.tools if t.name == "write_file")
-
-        mw = FilesystemSandboxSyncMiddleware(backend=backend, working_dir=working_repo)
-        request1, handler1, captured1 = self._make_request([write])
-        request2, handler2, captured2 = self._make_request([write])
-
-        await mw.awrap_model_call(request1, handler1)
-        await mw.awrap_model_call(request2, handler2)
-
-        wrapped1 = next(t for t in captured1["tools"] if t.name == "write_file")
-        wrapped2 = next(t for t in captured2["tools"] if t.name == "write_file")
-        assert wrapped1 is wrapped2, "cache must return the same wrapped tool instance"
-
-    async def test_aafter_agent_closes_opened_syncer(self, fake_client, working_repo):
-        """Regression: ``aafter_agent`` must close an opened syncer.
-
-        The syncer's own ``aclose`` no-ops when never opened, so the test must mark the
-        syncer as opened before calling ``aafter_agent`` — otherwise the assertion would
-        pass even if ``aafter_agent`` did nothing.
-        """
-        from deepagents.backends.filesystem import FilesystemBackend
-
-        from automation.agent.middlewares.file_system import FilesystemSandboxSyncMiddleware
-
-        backend = FilesystemBackend(root_dir=working_repo.parent, virtual_mode=True)
-        mw = FilesystemSandboxSyncMiddleware(backend=backend, working_dir=working_repo)
-        # Force the open-once flag without opening a real connection.
-        mw._syncer._opened = True
-
-        result = await mw.aafter_agent(state={}, runtime=_make_runtime(state={}, working_dir=working_repo))
-
-        fake_client.close.assert_awaited_once()
-        assert result is None

--- a/tests/unit_tests/automation/agent/middlewares/test_file_system.py
+++ b/tests/unit_tests/automation/agent/middlewares/test_file_system.py
@@ -3,312 +3,213 @@ from __future__ import annotations
 import os
 import stat
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from typing import TYPE_CHECKING, Any
+from unittest.mock import AsyncMock, Mock
 
+import httpx
 import pytest
+from deepagents.backends.filesystem import FilesystemBackend
+from deepagents.middleware.filesystem import FilesystemMiddleware as UpstreamFilesystemMiddleware
+from langchain_core.messages import ToolMessage
+from langgraph.prebuilt.tool_node import ToolCallRequest
 
+from automation.agent.middlewares import file_system as fs_module
+from automation.agent.middlewares.file_system import EDIT_SUCCESS_PREFIX, WRITE_SUCCESS_PREFIX
+from automation.agent.middlewares.sandbox import SandboxMiddleware
+from core.sandbox.schemas import ApplyMutationsResponse, MutationResult
 
-def _make_runtime(state, working_dir, gitrepo=None):
-    return SimpleNamespace(
-        state=state, context=SimpleNamespace(gitrepo=gitrepo or SimpleNamespace(working_dir=str(working_dir)))
-    )
+if TYPE_CHECKING:
+    from pathlib import Path
 
-
-def _build_synced_filesystem(*, backend, working_dir=None, read_only=False, sandbox_sync=False):
-    """Test helper: build upstream ``FilesystemMiddleware`` and apply DAIV's syncer wrappers.
-
-    Per-tool tests iterate ``mw.tools`` to invoke the wrapped ``write_file``/``edit_file``
-    coroutine directly. Production code wires the syncer through ``SandboxMiddleware``;
-    this helper exists so tests can exercise the wrapping in isolation.
-    """
-    from deepagents.middleware.filesystem import FilesystemMiddleware as UpstreamFilesystemMiddleware
-
-    from automation.agent.middlewares import file_system as fs_module
-
-    fs = UpstreamFilesystemMiddleware(backend=backend, custom_tool_descriptions=fs_module.CUSTOM_TOOL_DESCRIPTIONS)
-
-    if read_only:
-        fs.tools = [t for t in fs.tools if t.name not in fs_module.WRITE_TOOL_NAMES]
-        return fs
-
-    if sandbox_sync:
-        client = fs_module.DAIVSandboxClient()
-        syncer = fs_module.SandboxSyncer(backend=backend, working_dir=working_dir, client=client)
-        new_tools = []
-        for tool in fs.tools:
-            if tool.name == fs_module.WRITE_FILE_TOOL:
-                new_tools.append(syncer.wrap_write_tool(tool))
-            elif tool.name == fs_module.EDIT_FILE_TOOL:
-                new_tools.append(syncer.wrap_edit_tool(tool))
-            else:
-                new_tools.append(tool)
-        fs.tools = new_tools
-
-    return fs
+    from langchain_core.tools import BaseTool
 
 
 @pytest.fixture
-def fake_client(monkeypatch):
-    """Patch DAIVSandboxClient with an AsyncMock and yield the mock."""
-    from automation.agent.middlewares import file_system as fs_module
-
-    mock = AsyncMock()
-    monkeypatch.setattr(fs_module, "DAIVSandboxClient", lambda: mock)
-    return mock
-
-
-@pytest.fixture
-def working_repo(tmp_path):
-    """A working_dir layout: tmp_path/repo/."""
+def working_repo(tmp_path) -> Path:
+    """Test layout: tmp_path/myrepo/."""
     repo = tmp_path / "myrepo"
     repo.mkdir()
     return repo
 
 
-async def test_sync_write_file_writes_locally_and_syncs(fake_client, working_repo):
-    from deepagents.backends.filesystem import FilesystemBackend
+@pytest.fixture
+def fake_client() -> AsyncMock:
+    return AsyncMock()
 
-    from core.sandbox.schemas import ApplyMutationsResponse, MutationResult
 
-    fake_client.apply_file_mutations.return_value = ApplyMutationsResponse(
-        results=[MutationResult(path="/repo/foo.py", ok=True, error=None)]
-    )
+@pytest.fixture(autouse=True)
+def _sandbox_api_key(monkeypatch):
+    """``SandboxMiddleware.__init__`` refuses to instantiate without an API key."""
+    from core.site_settings import site_settings
+
+    monkeypatch.setattr(site_settings, "sandbox_api_key", Mock(get_secret_value=lambda: "test-key"))
+
+
+@pytest.fixture
+def setup(working_repo, fake_client):
+    """Backend + upstream tool map + sandbox middleware with pre-installed client/syncer."""
     backend = FilesystemBackend(root_dir=working_repo.parent, virtual_mode=True)
-    mw = _build_synced_filesystem(backend=backend, sandbox_sync=True, working_dir=working_repo)
+    fs = UpstreamFilesystemMiddleware(backend=backend, custom_tool_descriptions=fs_module.CUSTOM_TOOL_DESCRIPTIONS)
+    tools = {tool.name: tool for tool in fs.tools}
+    middleware = SandboxMiddleware(backend=backend, working_dir=working_repo)
+    middleware._client = fake_client
+    middleware._syncer = fs_module.SandboxSyncer(backend=backend, working_dir=working_repo, client=fake_client)
+    return SimpleNamespace(backend=backend, tools=tools, middleware=middleware, repo=working_repo)
 
-    write = next(t for t in mw.tools if t.name == "write_file")
-    runtime = _make_runtime(state={"session_id": "sid"}, working_dir=working_repo)
 
-    result = await write.coroutine(file_path=f"/{working_repo.name}/foo.py", content="print('hi')\n", runtime=runtime)
+def _runtime(*, state: dict[str, Any], working_dir: Path) -> SimpleNamespace:
+    """A minimal ``ToolRuntime`` shim sufficient for the syncer + upstream tools."""
+    return SimpleNamespace(
+        state=state,
+        context=SimpleNamespace(gitrepo=SimpleNamespace(working_dir=str(working_dir))),
+        tool_call_id="call_test",
+    )
 
-    # Local write happened.
-    assert (working_repo / "foo.py").read_text() == "print('hi')\n"
-    # Sync called with the right path + content + mode.
+
+async def _invoke(middleware: SandboxMiddleware, tool: BaseTool, args: dict, runtime: SimpleNamespace):
+    """Run ``args`` through ``middleware.awrap_tool_call``, dispatching to ``tool``."""
+    request = ToolCallRequest(
+        tool_call={"name": tool.name, "args": args, "id": runtime.tool_call_id, "type": "tool_call"},
+        tool=tool,
+        state=runtime.state,
+        runtime=runtime,
+    )
+
+    async def handler(req: ToolCallRequest) -> ToolMessage:
+        # Mimic ToolNode._execute_tool_async: invoke the coroutine with runtime injected,
+        # and normalize a string return into a ToolMessage. ToolMessage returns (e.g. permission
+        # denied) pass through unchanged.
+        result = await req.tool.coroutine(**req.tool_call["args"], runtime=req.runtime)
+        if isinstance(result, ToolMessage):
+            return result
+        return ToolMessage(content=result, tool_call_id=req.tool_call["id"], name=req.tool.name)
+
+    return await middleware.awrap_tool_call(request, handler)
+
+
+def _content(result) -> str:
+    assert isinstance(result, ToolMessage), f"expected ToolMessage, got {type(result)}"
+    assert isinstance(result.content, str)
+    return result.content
+
+
+def _mirror_ok(path: str = "/repo/foo.py") -> ApplyMutationsResponse:
+    return ApplyMutationsResponse(results=[MutationResult(path=path, ok=True, error=None)])
+
+
+# ---------------------------------------------------------------------------
+# write_file
+# ---------------------------------------------------------------------------
+
+
+async def test_write_file_writes_locally_and_mirrors(setup, fake_client):
+    fake_client.apply_file_mutations.return_value = _mirror_ok()
+    runtime = _runtime(state={"session_id": "sid"}, working_dir=setup.repo)
+
+    result = await _invoke(
+        setup.middleware,
+        setup.tools["write_file"],
+        {"file_path": f"/{setup.repo.name}/foo.py", "content": "print('hi')\n"},
+        runtime,
+    )
+
+    assert (setup.repo / "foo.py").read_text() == "print('hi')\n"
     fake_client.apply_file_mutations.assert_awaited_once()
-    args = fake_client.apply_file_mutations.call_args
-    request = args.args[1]
-    mutation = request.mutations[0]
+    mutation = fake_client.apply_file_mutations.call_args.args[1].mutations[0]
     assert mutation.path == "/repo/foo.py"
     assert mutation.content == b"print('hi')\n"
     assert mutation.mode == 0o644
-    assert "Updated file" in result
+    assert WRITE_SUCCESS_PREFIX in _content(result)
 
 
-async def test_sync_write_file_rolls_back_on_sync_failure(fake_client, working_repo):
-    from deepagents.backends.filesystem import FilesystemBackend
+@pytest.mark.parametrize(
+    ("apply_kwargs", "expected_substring"),
+    [
+        ({"side_effect": RuntimeError("network down")}, "network down"),
+        (
+            {
+                "return_value": ApplyMutationsResponse(
+                    results=[MutationResult(path="/repo/foo.py", ok=False, error="server-side validation failed")]
+                )
+            },
+            "server-side validation failed",
+        ),
+        (
+            {
+                "side_effect": httpx.HTTPStatusError(
+                    "500", request=httpx.Request("POST", "x"), response=httpx.Response(500)
+                )
+            },
+            "sandbox sync raised",
+        ),
+    ],
+    ids=["mirror_exception", "per_item_failure", "http_5xx"],
+)
+async def test_write_file_rolls_back_on_mirror_failure(setup, fake_client, apply_kwargs, expected_substring):
+    for attr, value in apply_kwargs.items():
+        setattr(fake_client.apply_file_mutations, attr, value)
+    runtime = _runtime(state={"session_id": "sid"}, working_dir=setup.repo)
 
-    fake_client.apply_file_mutations.side_effect = RuntimeError("network down")
-    backend = FilesystemBackend(root_dir=working_repo.parent, virtual_mode=True)
-    mw = _build_synced_filesystem(backend=backend, sandbox_sync=True, working_dir=working_repo)
-
-    write = next(t for t in mw.tools if t.name == "write_file")
-    runtime = _make_runtime(state={"session_id": "sid"}, working_dir=working_repo)
-
-    result = await write.coroutine(file_path=f"/{working_repo.name}/foo.py", content="print('hi')\n", runtime=runtime)
-
-    # File deleted (rollback).
-    assert not (working_repo / "foo.py").exists()
-    assert "Error" in result or "failed" in result.lower()
-
-
-async def test_sync_write_file_rolls_back_on_per_item_failure(fake_client, working_repo):
-    from deepagents.backends.filesystem import FilesystemBackend
-
-    from core.sandbox.schemas import ApplyMutationsResponse, MutationResult
-
-    fake_client.apply_file_mutations.return_value = ApplyMutationsResponse(
-        results=[MutationResult(path="/repo/foo.py", ok=False, error="server-side validation failed")]
+    result = await _invoke(
+        setup.middleware,
+        setup.tools["write_file"],
+        {"file_path": f"/{setup.repo.name}/foo.py", "content": "x"},
+        runtime,
     )
-    backend = FilesystemBackend(root_dir=working_repo.parent, virtual_mode=True)
-    mw = _build_synced_filesystem(backend=backend, sandbox_sync=True, working_dir=working_repo)
 
-    write = next(t for t in mw.tools if t.name == "write_file")
-    runtime = _make_runtime(state={"session_id": "sid"}, working_dir=working_repo)
-
-    result = await write.coroutine(file_path=f"/{working_repo.name}/foo.py", content="x", runtime=runtime)
-
-    assert not (working_repo / "foo.py").exists()
-    assert "server-side validation failed" in result
+    assert not (setup.repo / "foo.py").exists()
+    text = _content(result)
+    assert text.startswith("Error:"), f"rollback succeeded → expected Error: prefix, got {text!r}"
+    assert expected_substring in text
 
 
-async def test_sync_write_file_missing_session_id(fake_client, working_repo):
-    from deepagents.backends.filesystem import FilesystemBackend
+async def test_write_file_missing_session_id_rolls_back(setup, fake_client):
+    runtime = _runtime(state={}, working_dir=setup.repo)
 
-    backend = FilesystemBackend(root_dir=working_repo.parent, virtual_mode=True)
-    mw = _build_synced_filesystem(backend=backend, sandbox_sync=True, working_dir=working_repo)
+    result = await _invoke(
+        setup.middleware,
+        setup.tools["write_file"],
+        {"file_path": f"/{setup.repo.name}/foo.py", "content": "x"},
+        runtime,
+    )
 
-    write = next(t for t in mw.tools if t.name == "write_file")
-    runtime = _make_runtime(state={}, working_dir=working_repo)  # no session_id
-
-    result = await write.coroutine(file_path=f"/{working_repo.name}/foo.py", content="x", runtime=runtime)
-    assert not (working_repo / "foo.py").exists()
-    assert "session" in result.lower()
+    assert not (setup.repo / "foo.py").exists()
+    assert "session" in _content(result).lower()
     fake_client.apply_file_mutations.assert_not_awaited()
 
 
-async def test_sync_edit_file_writes_locally_and_syncs(fake_client, working_repo):
-    from deepagents.backends.filesystem import FilesystemBackend
-
-    from core.sandbox.schemas import ApplyMutationsResponse, MutationResult
-
-    target = working_repo / "foo.py"
-    target.write_text("hello world\n")
-    os.chmod(target, 0o755)  # noqa: PTH101, S103
-
-    fake_client.apply_file_mutations.return_value = ApplyMutationsResponse(
-        results=[MutationResult(path="/repo/foo.py", ok=True, error=None)]
-    )
-    backend = FilesystemBackend(root_dir=working_repo.parent, virtual_mode=True)
-    mw = _build_synced_filesystem(backend=backend, sandbox_sync=True, working_dir=working_repo)
-
-    edit = next(t for t in mw.tools if t.name == "edit_file")
-    runtime = _make_runtime(state={"session_id": "sid"}, working_dir=working_repo)
-
-    result = await edit.coroutine(
-        file_path=f"/{working_repo.name}/foo.py", old_string="hello", new_string="goodbye", runtime=runtime
-    )
-
-    assert (working_repo / "foo.py").read_text() == "goodbye world\n"
-    # Mode preserved.
-    assert stat.S_IMODE(target.stat().st_mode) == 0o755
-    args = fake_client.apply_file_mutations.call_args
-    mutation = args.args[1].mutations[0]
-    assert mutation.mode == 0o755
-    assert mutation.content == b"goodbye world\n"
-    assert "Successfully replaced" in result
-
-
-async def test_sync_edit_file_rolls_back_on_sync_failure(fake_client, working_repo):
-    from deepagents.backends.filesystem import FilesystemBackend
-
-    target = working_repo / "foo.py"
-    target.write_text("original\n")
-    os.chmod(target, 0o644)  # noqa: PTH101
-
-    fake_client.apply_file_mutations.side_effect = RuntimeError("network down")
-    backend = FilesystemBackend(root_dir=working_repo.parent, virtual_mode=True)
-    mw = _build_synced_filesystem(backend=backend, sandbox_sync=True, working_dir=working_repo)
-
-    edit = next(t for t in mw.tools if t.name == "edit_file")
-    runtime = _make_runtime(state={"session_id": "sid"}, working_dir=working_repo)
-
-    result = await edit.coroutine(
-        file_path=f"/{working_repo.name}/foo.py", old_string="original", new_string="modified", runtime=runtime
-    )
-
-    # Pre-edit content and mode restored.
-    assert (working_repo / "foo.py").read_text() == "original\n"
-    assert stat.S_IMODE(target.stat().st_mode) == 0o644
-    assert "Error" in result or "failed" in result.lower()
-
-
-async def test_write_file_handles_5xx_with_rollback(fake_client, working_repo):
-    """A 500 from the sandbox propagates as a tool error and triggers rollback."""
-    import httpx
-    from deepagents.backends.filesystem import FilesystemBackend
-
-    fake_client.apply_file_mutations.side_effect = httpx.HTTPStatusError(
-        "500", request=httpx.Request("POST", "x"), response=httpx.Response(500)
-    )
-    backend = FilesystemBackend(root_dir=working_repo.parent, virtual_mode=True)
-    mw = _build_synced_filesystem(backend=backend, sandbox_sync=True, working_dir=working_repo)
-
-    write = next(t for t in mw.tools if t.name == "write_file")
-    runtime = _make_runtime(state={"session_id": "sid"}, working_dir=working_repo)
-
-    result = await write.coroutine(file_path=f"/{working_repo.name}/foo.py", content="x", runtime=runtime)
-    assert not (working_repo / "foo.py").exists()
-    assert "Error" in result
-
-
-async def test_edit_file_handles_network_error(fake_client, working_repo):
-    """A network error during edit_file rolls back to the pre-edit content."""
-    import httpx
-    from deepagents.backends.filesystem import FilesystemBackend
-
-    target = working_repo / "foo.py"
-    target.write_text("a\nb\n")
-    fake_client.apply_file_mutations.side_effect = httpx.RequestError(
-        "conn refused", request=httpx.Request("POST", "x")
-    )
-
-    backend = FilesystemBackend(root_dir=working_repo.parent, virtual_mode=True)
-    mw = _build_synced_filesystem(backend=backend, sandbox_sync=True, working_dir=working_repo)
-    edit = next(t for t in mw.tools if t.name == "edit_file")
-    runtime = _make_runtime(state={"session_id": "sid"}, working_dir=working_repo)
-
-    result = await edit.coroutine(
-        file_path=f"/{working_repo.name}/foo.py", old_string="a", new_string="z", runtime=runtime
-    )
-    assert (working_repo / "foo.py").read_text() == "a\nb\n"
-    assert "Error" in result
-
-
-async def test_sandbox_sync_disabled_uses_unmodified_tools(working_repo):
-    """When sandbox_sync=False, deepagents' tools run without sync."""
-    from deepagents.backends.filesystem import FilesystemBackend
-
-    backend = FilesystemBackend(root_dir=working_repo.parent, virtual_mode=True)
-    mw = _build_synced_filesystem(backend=backend, sandbox_sync=False)
-
-    write = next(t for t in mw.tools if t.name == "write_file")
-    runtime = _make_runtime(state={}, working_dir=working_repo)
-
-    result = await write.coroutine(file_path=f"/{working_repo.name}/foo.py", content="x", runtime=runtime)
-
-    assert (working_repo / "foo.py").exists()
-    assert "Updated file" in result
-
-
-async def test_sync_write_file_rejects_path_outside_working_dir(fake_client, working_repo, tmp_path):
+async def test_write_file_rejects_path_outside_working_dir(working_repo, fake_client, tmp_path):
     """A write to a path outside working_dir is rolled back; sandbox is never called."""
-    from deepagents.backends.filesystem import FilesystemBackend
-
     outside = tmp_path / "elsewhere"
     outside.mkdir()
     backend = FilesystemBackend(root_dir=tmp_path, virtual_mode=True)
-    mw = _build_synced_filesystem(backend=backend, sandbox_sync=True, working_dir=working_repo)
+    write = next(
+        t
+        for t in UpstreamFilesystemMiddleware(
+            backend=backend, custom_tool_descriptions=fs_module.CUSTOM_TOOL_DESCRIPTIONS
+        ).tools
+        if t.name == "write_file"
+    )
+    middleware = SandboxMiddleware(backend=backend, working_dir=working_repo)
+    middleware._client = fake_client
+    middleware._syncer = fs_module.SandboxSyncer(backend=backend, working_dir=working_repo, client=fake_client)
 
-    write = next(t for t in mw.tools if t.name == "write_file")
-    runtime = _make_runtime(state={"session_id": "sid"}, working_dir=working_repo)
-
-    result = await write.coroutine(file_path=f"/{outside.name}/leak.py", content="oops", runtime=runtime)
+    result = await _invoke(
+        middleware,
+        write,
+        {"file_path": f"/{outside.name}/leak.py", "content": "oops"},
+        _runtime(state={"session_id": "sid"}, working_dir=working_repo),
+    )
 
     assert not (outside / "leak.py").exists()
     fake_client.apply_file_mutations.assert_not_awaited()
-    assert "Error" in result
+    assert "Error" in _content(result)
 
 
-async def test_sync_edit_file_pre_read_failure(fake_client, working_repo):
-    """edit_file on a missing path returns a read error, never calls the sandbox, never creates the file."""
-    from deepagents.backends.filesystem import FilesystemBackend
-
-    backend = FilesystemBackend(root_dir=working_repo.parent, virtual_mode=True)
-    mw = _build_synced_filesystem(backend=backend, sandbox_sync=True, working_dir=working_repo)
-
-    edit = next(t for t in mw.tools if t.name == "edit_file")
-    runtime = _make_runtime(state={"session_id": "sid"}, working_dir=working_repo)
-
-    result = await edit.coroutine(
-        file_path=f"/{working_repo.name}/missing.py", old_string="a", new_string="b", runtime=runtime
-    )
-
-    # Upstream returns the canonical "not found" error; we defer to it instead of inventing our own.
-    assert "not found" in result.lower()
-    assert not (working_repo / "missing.py").exists()
-    fake_client.apply_file_mutations.assert_not_awaited()
-
-
-async def test_sync_write_surfaces_critical_when_rollback_fails(fake_client, working_repo, monkeypatch):
-    """If the sandbox sync fails AND rollback also fails, the agent gets a CRITICAL marker."""
-    from deepagents.backends.filesystem import FilesystemBackend
-
+async def test_write_file_surfaces_critical_when_rollback_fails(setup, fake_client, monkeypatch):
+    """Sandbox sync fails AND rollback also fails → CRITICAL marker so the agent sees the desync."""
     fake_client.apply_file_mutations.side_effect = RuntimeError("sandbox down")
-    backend = FilesystemBackend(root_dir=working_repo.parent, virtual_mode=True)
-    mw = _build_synced_filesystem(backend=backend, sandbox_sync=True, working_dir=working_repo)
-
-    write = next(t for t in mw.tools if t.name == "write_file")
-    runtime = _make_runtime(state={"session_id": "sid"}, working_dir=working_repo)
+    runtime = _runtime(state={"session_id": "sid"}, working_dir=setup.repo)
 
     real_unlink = os.unlink
 
@@ -319,73 +220,188 @@ async def test_sync_write_surfaces_critical_when_rollback_fails(fake_client, wor
 
     monkeypatch.setattr(os, "unlink", fail_unlink)
 
-    result = await write.coroutine(file_path=f"/{working_repo.name}/foo.py", content="x", runtime=runtime)
-
-    assert "CRITICAL" in result
-    assert "rollback also failed" in result
-
-
-async def test_read_only_with_sandbox_sync_strips_write_and_edit(working_repo):
-    """`read_only=True` takes precedence over `sandbox_sync=True`.
-
-    Constructs without `working_dir`, sets no syncer, and strips write/edit from the tool list.
-    """
-    from deepagents.backends.filesystem import FilesystemBackend
-
-    backend = FilesystemBackend(root_dir=working_repo.parent, virtual_mode=True)
-    mw = _build_synced_filesystem(backend=backend, read_only=True, sandbox_sync=True)
-
-    tool_names = {t.name for t in mw.tools}
-    assert "write_file" not in tool_names
-    assert "edit_file" not in tool_names
-
-
-async def test_wrapped_tools_inject_runtime(working_repo):
-    """Regression: `runtime` must be annotated so LangChain treats it as an injected arg.
-
-    Without the `ToolRuntime` annotation, langchain leaves `runtime` in the LLM-facing schema
-    and never injects it, so the agent's first edit_file/write_file call crashes with
-    `missing 1 required positional argument: 'runtime'`.
-    """
-    from deepagents.backends.filesystem import FilesystemBackend
-
-    backend = FilesystemBackend(root_dir=working_repo.parent, virtual_mode=True)
-    mw = _build_synced_filesystem(backend=backend, sandbox_sync=True, working_dir=working_repo)
-
-    write = next(t for t in mw.tools if t.name == "write_file")
-    edit = next(t for t in mw.tools if t.name == "edit_file")
-
-    assert "runtime" not in write.args, f"runtime leaked into LLM args: {list(write.args)}"
-    assert "runtime" not in edit.args, f"runtime leaked into LLM args: {list(edit.args)}"
-
-
-async def test_upstream_success_prefixes_remain_stable(working_repo):
-    """Guard against deepagents bumps that change the success-message wording.
-
-    The wrapper detects success via `startswith("Updated file")` / `startswith("Successfully replaced")`.
-    If upstream rewords either, sandbox sync would silently stop firing — pin the contract here so a
-    deepagents bump fails this test instead of failing in production.
-    """
-    from deepagents.backends.filesystem import FilesystemBackend
-    from deepagents.middleware.filesystem import FilesystemMiddleware as BaseFilesystemMiddleware
-
-    backend = FilesystemBackend(root_dir=working_repo.parent, virtual_mode=True)
-    base = BaseFilesystemMiddleware(backend=backend)
-
-    write_tool = next(t for t in base.tools if t.name == "write_file")
-    edit_tool = next(t for t in base.tools if t.name == "edit_file")
-    runtime = _make_runtime(state={}, working_dir=working_repo)
-
-    write_result = await write_tool.coroutine(
-        file_path=f"/{working_repo.name}/contract.py", content="x", runtime=runtime
-    )
-    assert write_result.startswith("Updated file"), (
-        f"upstream changed write success format; update wrap_write_tool prefix check: {write_result!r}"
+    result = await _invoke(
+        setup.middleware,
+        setup.tools["write_file"],
+        {"file_path": f"/{setup.repo.name}/foo.py", "content": "x"},
+        runtime,
     )
 
-    edit_result = await edit_tool.coroutine(
-        file_path=f"/{working_repo.name}/contract.py", old_string="x", new_string="y", runtime=runtime
+    text = _content(result)
+    assert "CRITICAL" in text
+    assert "rollback also failed" in text
+
+
+async def test_write_file_skips_mirror_on_upstream_error(setup, fake_client):
+    """Upstream rejects writes to existing files; sandbox is never called."""
+    (setup.repo / "foo.py").write_text("already-here\n")
+    runtime = _runtime(state={"session_id": "sid"}, working_dir=setup.repo)
+
+    result = await _invoke(
+        setup.middleware,
+        setup.tools["write_file"],
+        {"file_path": f"/{setup.repo.name}/foo.py", "content": "new"},
+        runtime,
     )
-    assert edit_result.startswith("Successfully replaced"), (
-        f"upstream changed edit success format; update wrap_edit_tool prefix check: {edit_result!r}"
+
+    fake_client.apply_file_mutations.assert_not_awaited()
+    assert "already exists" in _content(result)
+    assert (setup.repo / "foo.py").read_text() == "already-here\n"
+
+
+# ---------------------------------------------------------------------------
+# edit_file
+# ---------------------------------------------------------------------------
+
+
+async def test_edit_file_writes_locally_and_mirrors(setup, fake_client):
+    target = setup.repo / "foo.py"
+    target.write_text("hello world\n")
+    os.chmod(target, 0o755)  # noqa: PTH101, S103
+    fake_client.apply_file_mutations.return_value = _mirror_ok()
+    runtime = _runtime(state={"session_id": "sid"}, working_dir=setup.repo)
+
+    result = await _invoke(
+        setup.middleware,
+        setup.tools["edit_file"],
+        {"file_path": f"/{setup.repo.name}/foo.py", "old_string": "hello", "new_string": "goodbye"},
+        runtime,
+    )
+
+    assert target.read_text() == "goodbye world\n"
+    assert stat.S_IMODE(target.stat().st_mode) == 0o755
+    mutation = fake_client.apply_file_mutations.call_args.args[1].mutations[0]
+    assert mutation.mode == 0o755
+    assert mutation.content == b"goodbye world\n"
+    assert EDIT_SUCCESS_PREFIX in _content(result)
+
+
+@pytest.mark.parametrize(
+    "side_effect",
+    [RuntimeError("network down"), httpx.RequestError("conn refused", request=httpx.Request("POST", "x"))],
+    ids=["mirror_exception", "network_error"],
+)
+async def test_edit_file_rolls_back_on_mirror_failure(setup, fake_client, side_effect):
+    target = setup.repo / "foo.py"
+    target.write_text("original\n")
+    os.chmod(target, 0o644)  # noqa: PTH101
+    fake_client.apply_file_mutations.side_effect = side_effect
+    runtime = _runtime(state={"session_id": "sid"}, working_dir=setup.repo)
+
+    result = await _invoke(
+        setup.middleware,
+        setup.tools["edit_file"],
+        {"file_path": f"/{setup.repo.name}/foo.py", "old_string": "original", "new_string": "modified"},
+        runtime,
+    )
+
+    assert target.read_text() == "original\n"
+    assert stat.S_IMODE(target.stat().st_mode) == 0o644
+    text = _content(result)
+    assert "Error" in text or "failed" in text.lower()
+
+
+async def test_edit_file_surfaces_critical_when_rollback_fails(setup, fake_client, monkeypatch):
+    """Sync fails AND restoring pre-edit bytes also fails → CRITICAL marker so the agent sees the desync."""
+    target = setup.repo / "foo.py"
+    target.write_text("original\n")
+    fake_client.apply_file_mutations.side_effect = RuntimeError("sandbox down")
+    runtime = _runtime(state={"session_id": "sid"}, working_dir=setup.repo)
+
+    real_write_bytes = type(target).write_bytes
+
+    def fail_write_bytes(self, data, *a, **kw):
+        if str(self).endswith("foo.py"):
+            raise OSError("disk gone")
+        return real_write_bytes(self, data, *a, **kw)
+
+    monkeypatch.setattr(type(target), "write_bytes", fail_write_bytes)
+
+    result = await _invoke(
+        setup.middleware,
+        setup.tools["edit_file"],
+        {"file_path": f"/{setup.repo.name}/foo.py", "old_string": "original", "new_string": "modified"},
+        runtime,
+    )
+
+    text = _content(result)
+    assert "CRITICAL" in text
+    assert "rollback also failed" in text
+
+
+async def test_edit_file_pre_read_failure_defers_to_upstream(setup, fake_client):
+    """``edit_file`` on a missing path defers to upstream's "not found" error; sandbox is never called."""
+    runtime = _runtime(state={"session_id": "sid"}, working_dir=setup.repo)
+
+    result = await _invoke(
+        setup.middleware,
+        setup.tools["edit_file"],
+        {"file_path": f"/{setup.repo.name}/missing.py", "old_string": "a", "new_string": "b"},
+        runtime,
+    )
+
+    assert "not found" in _content(result).lower()
+    assert not (setup.repo / "missing.py").exists()
+    fake_client.apply_file_mutations.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Bypass conditions
+# ---------------------------------------------------------------------------
+
+
+async def test_non_write_tool_passes_through(setup, fake_client):
+    (setup.repo / "foo.py").write_text("hi\n")
+    runtime = _runtime(state={"session_id": "sid"}, working_dir=setup.repo)
+
+    result = await _invoke(
+        setup.middleware, setup.tools["read_file"], {"file_path": f"/{setup.repo.name}/foo.py"}, runtime
+    )
+
+    assert "hi" in _content(result)
+    fake_client.apply_file_mutations.assert_not_awaited()
+
+
+async def test_no_syncer_falls_back_to_handler(setup, fake_client):
+    """Pre-``abefore_agent`` dispatch (no syncer) is not intercepted; the handler runs as-is."""
+    setup.middleware._client = None
+    setup.middleware._syncer = None
+    runtime = _runtime(state={"session_id": "sid"}, working_dir=setup.repo)
+
+    result = await _invoke(
+        setup.middleware,
+        setup.tools["write_file"],
+        {"file_path": f"/{setup.repo.name}/foo.py", "content": "x"},
+        runtime,
+    )
+
+    assert (setup.repo / "foo.py").exists()
+    fake_client.apply_file_mutations.assert_not_awaited()
+    assert WRITE_SUCCESS_PREFIX in _content(result)
+
+
+# ---------------------------------------------------------------------------
+# Upstream contract pinning
+# ---------------------------------------------------------------------------
+
+
+async def test_upstream_success_prefixes_remain_stable(setup):
+    """A deepagents bump that rewords either prefix would silently disable sandbox sync.
+
+    Pinning the constants here makes the bump fail this test instead of failing in production.
+    """
+    runtime = _runtime(state={}, working_dir=setup.repo)
+
+    write_result = await setup.tools["write_file"].coroutine(
+        file_path=f"/{setup.repo.name}/contract.py", content="x", runtime=runtime
+    )
+    assert write_result.startswith(WRITE_SUCCESS_PREFIX), (
+        f"upstream changed write success format; update WRITE_SUCCESS_PREFIX: {write_result!r}"
+    )
+
+    edit_result = await setup.tools["edit_file"].coroutine(
+        file_path=f"/{setup.repo.name}/contract.py", old_string="x", new_string="y", runtime=runtime
+    )
+    assert edit_result.startswith(EDIT_SUCCESS_PREFIX), (
+        f"upstream changed edit success format; update EDIT_SUCCESS_PREFIX: {edit_result!r}"
     )

--- a/tests/unit_tests/automation/agent/middlewares/test_sandbox.py
+++ b/tests/unit_tests/automation/agent/middlewares/test_sandbox.py
@@ -52,9 +52,17 @@ def _make_bash_runtime(repo: Repo, disallow=(), allow=()) -> Mock:
     return runtime
 
 
+def _make_middleware(*, close_session: bool = True) -> SandboxMiddleware:
+    """Build a SandboxMiddleware with dummy backend/working_dir; tests that don't exercise
+    write-sync never read these values."""
+    from pathlib import Path
+
+    return SandboxMiddleware(backend=Mock(), working_dir=Path("/dummy"), close_session=close_session)
+
+
 def _bash_tool_with_fake_client(client: Mock):
     """Build a fresh SandboxMiddleware with ``client`` pre-installed and return its bash tool."""
-    middleware = SandboxMiddleware(close_session=True)
+    middleware = _make_middleware()
     middleware._client = client
     return middleware.tools[0]
 
@@ -128,7 +136,7 @@ class TestBashTool:
         repo = Repo.init(repo_dir)
 
         runtime = _make_bash_runtime(repo)
-        middleware = SandboxMiddleware(close_session=True)
+        middleware = _make_middleware(close_session=True)
         bash_tool = middleware.tools[0]
 
         with pytest.raises(RuntimeError, match="bash tool invoked before abefore_agent"):
@@ -328,7 +336,7 @@ class TestSandboxMiddleware:
                 "automation.agent.middlewares.sandbox.DAIVSandboxClient.seed_session", new=AsyncMock(return_value=None)
             ) as seed_session_mock,
         ):
-            middleware = SandboxMiddleware(close_session=True)
+            middleware = _make_middleware(close_session=True)
             update = await middleware.abefore_agent({}, runtime)
 
         assert update == {"session_id": "sess_1"}
@@ -364,7 +372,7 @@ class TestSandboxMiddleware:
             ),
             patch("automation.agent.middlewares.sandbox.DAIVSandboxClient.close_session", new=close_session_mock),
         ):
-            middleware = SandboxMiddleware(close_session=True)
+            middleware = _make_middleware(close_session=True)
             with pytest.raises(RuntimeError, match="simulated seed failure"):
                 await middleware.abefore_agent({}, runtime)
 
@@ -392,7 +400,7 @@ class TestSandboxMiddleware:
             ),
             patch("automation.agent.middlewares.sandbox.DAIVSandboxClient.close_session", new=close_session_mock),
         ):
-            middleware = SandboxMiddleware(close_session=True)
+            middleware = _make_middleware(close_session=True)
             with pytest.raises(RuntimeError, match="sandbox unreachable"):
                 await middleware.abefore_agent({}, runtime)
 
@@ -418,7 +426,7 @@ class TestSandboxMiddleware:
                 new=AsyncMock(side_effect=RuntimeError("unexpected")),
             ),
         ):
-            middleware = SandboxMiddleware(close_session=True)
+            middleware = _make_middleware(close_session=True)
             middleware._client = DAIVSandboxClient()
             with pytest.raises(RuntimeError, match="unexpected"):
                 await middleware.aafter_agent(state, runtime)
@@ -439,7 +447,7 @@ class TestSandboxMiddleware:
                 new=AsyncMock(return_value="sess_1"),
             ) as start_session_mock,
         ):
-            middleware = SandboxMiddleware(close_session=False)
+            middleware = _make_middleware(close_session=False)
             update = await middleware.abefore_agent(state, runtime)
 
         assert update is None
@@ -458,7 +466,7 @@ class TestSandboxMiddleware:
                 "automation.agent.middlewares.sandbox.DAIVSandboxClient.close_session", new=AsyncMock(return_value=None)
             ) as close_session_mock,
         ):
-            middleware = SandboxMiddleware(close_session=True)
+            middleware = _make_middleware(close_session=True)
             middleware._client = DAIVSandboxClient()
             update = await middleware.aafter_agent(state, runtime)
 
@@ -479,7 +487,7 @@ class TestSandboxMiddleware:
                 "automation.agent.middlewares.sandbox.DAIVSandboxClient.close_session", new=AsyncMock(return_value=None)
             ) as close_session_mock,
         ):
-            middleware = SandboxMiddleware(close_session=False)
+            middleware = _make_middleware(close_session=False)
             middleware._client = DAIVSandboxClient()
             update = await middleware.aafter_agent(state, runtime)
 
@@ -512,7 +520,7 @@ class TestSandboxMiddleware:
                 "automation.agent.middlewares.sandbox.DAIVSandboxClient.seed_session", new=AsyncMock(return_value=None)
             ) as seed_session_mock,
         ):
-            middleware = SandboxMiddleware(close_session=True)
+            middleware = _make_middleware(close_session=True)
             update = await middleware.abefore_agent({}, runtime)
 
         assert update == {"session_id": "sess_skills"}
@@ -580,7 +588,7 @@ class TestSandboxMiddleware:
 
         runtime = _make_agent_runtime(repo_working_dir=str(tmp_path / "repoX"))
 
-        middleware = SandboxMiddleware()
+        middleware = _make_middleware()
 
         seen_prompt: str | None = None
 

--- a/tests/unit_tests/automation/agent/middlewares/test_sandbox.py
+++ b/tests/unit_tests/automation/agent/middlewares/test_sandbox.py
@@ -603,3 +603,74 @@ class TestSandboxMiddleware:
         assert seen_prompt is not None
         assert seen_prompt.startswith("base prompt")
         assert SANDBOX_SYSTEM_PROMPT in seen_prompt
+
+
+class TestAwrapToolCall:
+    """Tool dispatch is intercepted at ToolNode level, not via ``awrap_model_call``.
+
+    These tests pin the entry point: ``awrap_tool_call`` must intercept dispatched
+    write_file/edit_file calls so that the mirror runs against ``ToolNode.tools_by_name``,
+    which is built once at agent-creation time and not updated by ``awrap_model_call``.
+    """
+
+    @staticmethod
+    def _request(tool_name: str, args: dict, *, runtime=None):
+        from langgraph.prebuilt.tool_node import ToolCallRequest
+
+        tool = Mock(spec_set=["name"])
+        tool.name = tool_name
+        return ToolCallRequest(
+            tool_call={"name": tool_name, "args": args, "id": "call_1", "type": "tool_call"},
+            tool=tool,
+            state={},
+            runtime=runtime or Mock(),
+        )
+
+    async def test_passes_through_when_tool_is_not_write_or_edit(self, tmp_path: Path):
+        request = self._request("read_file", {"file_path": "/repo/foo.py"})
+        middleware = _make_middleware()
+        middleware._syncer = Mock()  # set so we don't bypass on syncer-missing path
+
+        sentinel = object()
+
+        async def handler(req):
+            assert req is request
+            return sentinel
+
+        result = await middleware.awrap_tool_call(request, handler)
+        assert result is sentinel
+
+    async def test_passes_through_when_syncer_not_initialized(self, tmp_path: Path):
+        """Pre-``abefore_agent`` dispatch is rare but must not raise."""
+        request = self._request("write_file", {"file_path": "/repo/foo.py", "content": "x"})
+        middleware = _make_middleware()
+        # _syncer is None — abefore_agent never ran.
+
+        sentinel = object()
+
+        async def handler(req):
+            return sentinel
+
+        result = await middleware.awrap_tool_call(request, handler)
+        assert result is sentinel
+
+    async def test_passes_through_when_tool_is_none(self, tmp_path: Path):
+        """Unregistered tool calls reach awrap_tool_call with ``request.tool=None``."""
+        from langgraph.prebuilt.tool_node import ToolCallRequest
+
+        request = ToolCallRequest(
+            tool_call={"name": "unknown", "args": {}, "id": "call_1", "type": "tool_call"},
+            tool=None,
+            state={},
+            runtime=Mock(),
+        )
+        middleware = _make_middleware()
+        middleware._syncer = Mock()
+
+        sentinel = object()
+
+        async def handler(req):
+            return sentinel
+
+        result = await middleware.awrap_tool_call(request, handler)
+        assert result is sentinel

--- a/tests/unit_tests/automation/agent/test_graph_construction.py
+++ b/tests/unit_tests/automation/agent/test_graph_construction.py
@@ -1,9 +1,11 @@
 """Static-source regression guards.
 
 These tests use ``inspect.getsource`` to assert that ``graph.py`` and
-``subagents.py`` always wire up the sandbox-sync middleware when sandbox is
-enabled. They are cheap and catch the kind of merge-conflict or refactor
-that silently disables sandbox sync.
+``subagents.py`` always pass ``backend`` and ``working_dir`` to
+``SandboxMiddleware`` when sandbox is enabled — the merged middleware needs
+both to mirror successful ``write_file``/``edit_file`` calls to the sandbox.
+They are cheap and catch the kind of merge-conflict or refactor that silently
+disables sandbox sync.
 """
 
 import inspect
@@ -12,17 +14,19 @@ from automation.agent import graph as graph_module
 from automation.agent import subagents as subagents_module
 
 
-def test_graph_wires_sandbox_sync_middleware():
+def test_graph_passes_backend_and_working_dir_to_sandbox_middleware():
     src = inspect.getsource(graph_module)
-    assert "FilesystemSandboxSyncMiddleware(backend=backend, working_dir=" in src, (
-        "graph.py must construct FilesystemSandboxSyncMiddleware with backend and working_dir"
+    assert "SandboxMiddleware(backend=backend, working_dir=agent_path)" in src, (
+        "graph.py must construct SandboxMiddleware with backend and working_dir"
     )
-    assert "_sandbox_enabled" in src, "graph.py must gate the sandbox-sync middleware on _sandbox_enabled"
+    assert "_sandbox_enabled" in src, "graph.py must gate SandboxMiddleware on _sandbox_enabled"
 
 
-def test_general_purpose_subagent_wires_sandbox_sync_middleware():
+def test_general_purpose_subagent_passes_backend_and_working_dir_to_sandbox_middleware():
     src = inspect.getsource(subagents_module)
-    assert "FilesystemSandboxSyncMiddleware(backend=backend, working_dir=" in src, (
-        "subagents.py must construct FilesystemSandboxSyncMiddleware with backend and working_dir"
-    )
-    assert "if sandbox_enabled:" in src, "subagents.py must gate the sandbox-sync middleware on sandbox_enabled"
+    assert (
+        "SandboxMiddleware(" in src
+        and "backend=backend" in src
+        and "working_dir=Path(runtime.gitrepo.working_dir)" in src
+    ), "subagents.py must construct SandboxMiddleware with backend and working_dir"
+    assert "if sandbox_enabled:" in src, "subagents.py must gate SandboxMiddleware on sandbox_enabled"

--- a/tests/unit_tests/automation/agent/test_graph_construction.py
+++ b/tests/unit_tests/automation/agent/test_graph_construction.py
@@ -1,9 +1,9 @@
 """Static-source regression guards.
 
 These tests use ``inspect.getsource`` to assert that ``graph.py`` and
-``subagents.py`` always pass the eager-sync flag through to
-``FilesystemMiddleware``. They are cheap and catch the kind of merge-conflict
-or refactor that silently disables sandbox sync.
+``subagents.py`` always wire up the sandbox-sync middleware when sandbox is
+enabled. They are cheap and catch the kind of merge-conflict or refactor
+that silently disables sandbox sync.
 """
 
 import inspect
@@ -12,16 +12,17 @@ from automation.agent import graph as graph_module
 from automation.agent import subagents as subagents_module
 
 
-def test_graph_passes_sandbox_sync_to_filesystem_middleware():
+def test_graph_wires_sandbox_sync_middleware():
     src = inspect.getsource(graph_module)
-    assert "sandbox_sync=_sandbox_enabled" in src, (
-        "graph.py must pass sandbox_sync=_sandbox_enabled to FilesystemMiddleware"
+    assert "FilesystemSandboxSyncMiddleware(backend=backend, working_dir=" in src, (
+        "graph.py must construct FilesystemSandboxSyncMiddleware with backend and working_dir"
     )
-    assert "working_dir=" in src, "graph.py must pass working_dir to FilesystemMiddleware"
+    assert "_sandbox_enabled" in src, "graph.py must gate the sandbox-sync middleware on _sandbox_enabled"
 
 
-def test_general_purpose_subagent_passes_sandbox_sync():
+def test_general_purpose_subagent_wires_sandbox_sync_middleware():
     src = inspect.getsource(subagents_module)
-    assert "sandbox_sync=sandbox_enabled" in src, (
-        "subagents.py must pass sandbox_sync=sandbox_enabled to FilesystemMiddleware"
+    assert "FilesystemSandboxSyncMiddleware(backend=backend, working_dir=" in src, (
+        "subagents.py must construct FilesystemSandboxSyncMiddleware with backend and working_dir"
     )
+    assert "if sandbox_enabled:" in src, "subagents.py must gate the sandbox-sync middleware on sandbox_enabled"

--- a/tests/unit_tests/automation/agent/test_graph_deferred.py
+++ b/tests/unit_tests/automation/agent/test_graph_deferred.py
@@ -4,25 +4,18 @@ from unittest.mock import AsyncMock, MagicMock, patch
 def _common_patches():
     """Patches that disable side effects unrelated to the deferred-tools wiring."""
     return [
-        patch("automation.agent.graph.compute_summarization_defaults"),
         patch("automation.agent.graph.FilesystemBackend"),
         patch("automation.agent.graph.create_general_purpose_subagent"),
         patch("automation.agent.graph.create_explore_subagent"),
         patch("automation.agent.graph.load_custom_subagents", AsyncMock(return_value=[])),
-        patch("automation.agent.graph.create_agent"),
+        patch("automation.agent.graph.create_deep_agent"),
         patch("automation.agent.graph.MCPToolkit"),
         patch("automation.agent.graph.deferred_settings"),
         patch("automation.agent.graph.BaseAgent"),
         patch("automation.agent.graph.site_settings"),
         # Middleware constructors that validate input — replaced with no-op mocks
-        patch("automation.agent.graph.SubAgentMiddleware"),
-        patch("automation.agent.graph.MemoryMiddleware"),
         patch("automation.agent.graph.SkillsMiddleware"),
-        patch("automation.agent.graph.TodoListMiddleware"),
-        patch("automation.agent.graph.SummarizationMiddleware"),
         patch("automation.agent.graph.AnthropicPromptCachingMiddleware"),
-        patch("automation.agent.graph.PatchToolCallsMiddleware"),
-        patch("automation.agent.graph.FilesystemMiddleware"),
         patch("automation.agent.graph.GitMiddleware"),
         patch("automation.agent.graph.GitPlatformMiddleware"),
         patch("automation.agent.graph.ToolCallLoggingMiddleware"),
@@ -39,12 +32,11 @@ class TestCreateDaivAgentDeferredFlag:
         managers = [p.start() for p in patches]
         try:
             (
-                mock_summ,
                 mock_fs_backend,
                 mock_create_gp,
                 mock_create_explore,
                 mock_load_custom,
-                mock_create_agent,
+                mock_create_deep_agent,
                 mock_toolkit,
                 mock_deferred_settings,
                 mock_base_agent,
@@ -60,11 +52,6 @@ class TestCreateDaivAgentDeferredFlag:
             mock_toolkit.get_tools = AsyncMock(return_value=[mcp_tool])
 
             mock_base_agent.get_model.return_value = MagicMock()
-            mock_summ.return_value = {
-                "trigger": MagicMock(),
-                "keep": MagicMock(),
-                "truncate_args_settings": MagicMock(),
-            }
 
             mock_site_settings.agent_recursion_limit = 50
             mock_site_settings.agent_model_name = "claude"
@@ -73,7 +60,7 @@ class TestCreateDaivAgentDeferredFlag:
             mock_site_settings.web_fetch_enabled = False
             mock_site_settings.web_search_enabled = False
 
-            mock_create_agent.return_value.with_config.return_value = MagicMock()
+            mock_create_deep_agent.return_value.with_config.return_value = MagicMock()
 
             ctx = MagicMock()
             ctx.gitrepo.working_dir = "/repo"
@@ -82,25 +69,25 @@ class TestCreateDaivAgentDeferredFlag:
             ctx.git_platform = MagicMock()
 
             await create_daiv_agent(ctx=ctx, auto_commit_changes=False)
-            return mock_create_agent, mock_toolkit, mcp_tool
+            return mock_create_deep_agent, mock_toolkit, mcp_tool
         finally:
             for p in patches:
                 p.stop()
 
     async def test_flag_off_passes_eager_tools(self):
-        mock_create_agent, mock_toolkit, mcp_tool = await self._run(flag_on=False)
+        mock_create_deep_agent, mock_toolkit, mcp_tool = await self._run(flag_on=False)
 
         mock_toolkit.get_tools.assert_awaited()
-        kwargs = mock_create_agent.call_args.kwargs
+        kwargs = mock_create_deep_agent.call_args.kwargs
         assert kwargs["tools"] == [mcp_tool]
         middleware_types = [type(m).__name__ for m in kwargs["middleware"]]
         assert "DeferredToolsMiddleware" not in middleware_types
 
     async def test_flag_on_passes_empty_tools_and_adds_middleware(self):
-        mock_create_agent, mock_toolkit, _ = await self._run(flag_on=True)
+        mock_create_deep_agent, mock_toolkit, _ = await self._run(flag_on=True)
 
         mock_toolkit.get_tools.assert_awaited()
-        kwargs = mock_create_agent.call_args.kwargs
+        kwargs = mock_create_deep_agent.call_args.kwargs
         assert kwargs["tools"] == []
         middleware_types = [type(m).__name__ for m in kwargs["middleware"]]
         assert "DeferredToolsMiddleware" in middleware_types

--- a/tests/unit_tests/automation/agent/test_subagents.py
+++ b/tests/unit_tests/automation/agent/test_subagents.py
@@ -15,7 +15,6 @@ import pytest
 from deepagents.middleware.filesystem import FilesystemMiddleware
 from langchain.agents.middleware import ModelFallbackMiddleware
 
-from automation.agent.middlewares.file_system import FilesystemSandboxSyncMiddleware
 from automation.agent.middlewares.git_platform import GitPlatformMiddleware
 from automation.agent.middlewares.sandbox import SandboxMiddleware
 from automation.agent.middlewares.web_fetch import WebFetchMiddleware
@@ -60,7 +59,6 @@ class TestGeneralPurposeMiddleware:
             web_fetch_enabled=True,
         )
         assert any(isinstance(m, FilesystemMiddleware) for m in middleware)
-        assert any(isinstance(m, FilesystemSandboxSyncMiddleware) for m in middleware)
         assert any(isinstance(m, GitPlatformMiddleware) for m in middleware)
         assert any(isinstance(m, WebFetchMiddleware) for m in middleware)
         assert any(isinstance(m, WebSearchMiddleware) for m in middleware)
@@ -78,7 +76,6 @@ class TestGeneralPurposeMiddleware:
             web_fetch_enabled=True,
         )
         assert not any(isinstance(m, SandboxMiddleware) for m in middleware)
-        assert not any(isinstance(m, FilesystemSandboxSyncMiddleware) for m in middleware)
 
     def test_excludes_web_search_middleware(self, mock_model, mock_backend, mock_runtime_ctx):
         middleware = _build_general_purpose_middleware(
@@ -132,14 +129,14 @@ class TestGeneralPurposeMiddleware:
 
         DAIV-custom contract: a subagent inheriting the parent runtime's ``session_id`` calls the
         sandbox under that same session, never opening a fresh one. Exercises the production wrap
-        path: ``_build_general_purpose_middleware`` → ``FilesystemSandboxSyncMiddleware.awrap_model_call``
-        → wrapped ``write_file``.
+        path: ``_build_general_purpose_middleware`` → ``SandboxMiddleware.awrap_model_call`` →
+        wrapped ``write_file``.
         """
         from types import SimpleNamespace
 
         from deepagents.backends.filesystem import FilesystemBackend
 
-        from automation.agent.middlewares import file_system as fs_module
+        from automation.agent.middlewares.file_system import SandboxSyncer
         from core.sandbox.schemas import ApplyMutationsResponse, MutationResult
 
         repo_dir = tmp_path / "repo"
@@ -153,25 +150,28 @@ class TestGeneralPurposeMiddleware:
         )
 
         backend = FilesystemBackend(root_dir=tmp_path, virtual_mode=True)
-        with pytest.MonkeyPatch.context() as mp:
-            mp.setattr(fs_module, "DAIVSandboxClient", lambda: fake_client)
-            middleware = _build_general_purpose_middleware(
-                mock_model, backend, ctx, sandbox_enabled=True, web_search_enabled=False, web_fetch_enabled=False
-            )
+        middleware = _build_general_purpose_middleware(
+            mock_model, backend, ctx, sandbox_enabled=True, web_search_enabled=False, web_fetch_enabled=False
+        )
 
         fs_mw = next(m for m in middleware if isinstance(m, FilesystemMiddleware))
-        sync_mw = next(m for m in middleware if isinstance(m, FilesystemSandboxSyncMiddleware))
+        sandbox_mw = next(m for m in middleware if isinstance(m, SandboxMiddleware))
+        # Inject fake client + syncer to skip network setup that abefore_agent would otherwise drive.
+        sandbox_mw._client = fake_client
+        sandbox_mw._syncer = SandboxSyncer(backend=backend, working_dir=repo_dir, client=fake_client)
 
-        # Drive the production wrap path: the sync middleware re-wraps tools at
-        # ``awrap_model_call`` time, so go through it rather than reaching into private state.
         captured = {}
 
         async def handler(req):
             captured["tools"] = list(req.tools)
             return object()
 
-        request = SimpleNamespace(tools=list(fs_mw.tools), override=lambda **kw: SimpleNamespace(tools=kw["tools"]))
-        await sync_mw.awrap_model_call(request, handler)
+        request = SimpleNamespace(
+            tools=list(fs_mw.tools),
+            system_prompt="base prompt",
+            override=lambda **kw: SimpleNamespace(tools=kw["tools"], system_prompt=kw["system_prompt"]),
+        )
+        await sandbox_mw.awrap_model_call(request, handler)
         write = next(t for t in captured["tools"] if t.name == "write_file")
 
         runtime = SimpleNamespace(

--- a/tests/unit_tests/automation/agent/test_subagents.py
+++ b/tests/unit_tests/automation/agent/test_subagents.py
@@ -225,21 +225,14 @@ class TestExploreSubagent:
         assert result["description"]
         assert "runnable" in result
 
-    def test_read_only_guard_raises_when_write_tools_missing(self, tmp_path, monkeypatch):
-        """Regression: if upstream renames ``write_file``/``edit_file``, the read-only filter
-        would silently match nothing and the explore subagent would regain write capability —
-        a security contract. ``_build_read_only_filesystem_middleware`` must fail loud instead.
-        """
-        from deepagents.backends.filesystem import FilesystemBackend
+    def test_read_only_permissions_deny_all_writes(self):
+        """Locks the explore subagent's read-only contract: relaxing this constant would
+        silently grant write capability the explore subagent must never have."""
+        from deepagents.middleware.filesystem import FilesystemPermission
 
-        from automation.agent.subagents import _build_read_only_filesystem_middleware
+        from automation.agent.subagents import READ_ONLY_PERMISSIONS
 
-        # Pretend upstream renamed ``write_file`` so it is no longer in the produced tool list.
-        monkeypatch.setattr("automation.agent.subagents.WRITE_TOOL_NAMES", frozenset({"unmapped_write_tool"}))
-
-        backend = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=True)
-        with pytest.raises(RuntimeError, match=r"no longer exposes expected write tools"):
-            _build_read_only_filesystem_middleware(backend)
+        assert [FilesystemPermission(operations=["write"], paths=["/**"], mode="deny")] == READ_ONLY_PERMISSIONS
 
 
 def _make_subagent_md(*, name: str, description: str, model: str | None = None, body: str = "You are a custom agent."):

--- a/tests/unit_tests/automation/agent/test_subagents.py
+++ b/tests/unit_tests/automation/agent/test_subagents.py
@@ -1,126 +1,245 @@
-"""Tests for deepagent subagents."""
+"""Tests for deepagent subagents.
+
+After migrating to ``create_deep_agent``, the public factories return
+``CompiledSubAgent`` dicts (``{name, description, runnable}``) — the middleware
+stack is baked into the runnable. Middleware-composition tests therefore
+exercise ``_build_general_purpose_middleware`` directly rather than introspect
+the compiled runnable, which keeps coverage focused on DAIV's choices about
+which middlewares to compose.
+"""
 
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, Mock
 
 import pytest
+from deepagents.middleware.filesystem import FilesystemMiddleware
 from langchain.agents.middleware import ModelFallbackMiddleware
 
-from automation.agent.middlewares.file_system import FilesystemMiddleware
+from automation.agent.middlewares.file_system import FilesystemSandboxSyncMiddleware
 from automation.agent.middlewares.git_platform import GitPlatformMiddleware
 from automation.agent.middlewares.sandbox import SandboxMiddleware
 from automation.agent.middlewares.web_fetch import WebFetchMiddleware
 from automation.agent.middlewares.web_search import WebSearchMiddleware
-from automation.agent.subagents import create_explore_subagent, create_general_purpose_subagent, load_custom_subagents
+from automation.agent.subagents import (
+    _build_general_purpose_middleware,
+    create_explore_subagent,
+    create_general_purpose_subagent,
+    load_custom_subagents,
+)
 
 if TYPE_CHECKING:
     from pathlib import Path
 
 
-class TestGeneralPurposeSubagent:
-    """Tests for create_general_purpose_subagent."""
+class TestGeneralPurposeMiddleware:
+    """Tests for ``_build_general_purpose_middleware`` — the middleware composer."""
 
     @pytest.fixture
     def mock_backend(self):
-        """Create a mock backend."""
         return Mock()
 
     @pytest.fixture
     def mock_model(self):
-        """Create a mock model."""
         return Mock()
 
     @pytest.fixture
     def mock_runtime_ctx(self, tmp_path):
-        """Create a mock runtime context with a real working_dir on disk.
-
-        ``working_dir`` must be a real path because ``FilesystemMiddleware``
-        wraps it in :class:`pathlib.Path` when ``sandbox_sync`` is on.
-        """
         repo_dir = tmp_path / "repo"
         repo_dir.mkdir()
         ctx = Mock()
         ctx.gitrepo.working_dir = str(repo_dir)
         return ctx
 
-    def test_returns_subagent(self, mock_model, mock_backend, mock_runtime_ctx):
-        """Test that create_general_purpose_subagent returns a SubAgent."""
+    def test_includes_full_stack_by_default(self, mock_model, mock_backend, mock_runtime_ctx):
+        middleware = _build_general_purpose_middleware(
+            mock_model,
+            mock_backend,
+            mock_runtime_ctx,
+            sandbox_enabled=True,
+            web_search_enabled=True,
+            web_fetch_enabled=True,
+        )
+        assert any(isinstance(m, FilesystemMiddleware) for m in middleware)
+        assert any(isinstance(m, FilesystemSandboxSyncMiddleware) for m in middleware)
+        assert any(isinstance(m, GitPlatformMiddleware) for m in middleware)
+        assert any(isinstance(m, WebFetchMiddleware) for m in middleware)
+        assert any(isinstance(m, WebSearchMiddleware) for m in middleware)
+        sandbox_middlewares = [m for m in middleware if isinstance(m, SandboxMiddleware)]
+        assert len(sandbox_middlewares) == 1
+        assert sandbox_middlewares[0].close_session is False
+
+    def test_excludes_sandbox_when_disabled(self, mock_model, mock_backend, mock_runtime_ctx):
+        middleware = _build_general_purpose_middleware(
+            mock_model,
+            mock_backend,
+            mock_runtime_ctx,
+            sandbox_enabled=False,
+            web_search_enabled=True,
+            web_fetch_enabled=True,
+        )
+        assert not any(isinstance(m, SandboxMiddleware) for m in middleware)
+        assert not any(isinstance(m, FilesystemSandboxSyncMiddleware) for m in middleware)
+
+    def test_excludes_web_search_middleware(self, mock_model, mock_backend, mock_runtime_ctx):
+        middleware = _build_general_purpose_middleware(
+            mock_model,
+            mock_backend,
+            mock_runtime_ctx,
+            sandbox_enabled=True,
+            web_search_enabled=False,
+            web_fetch_enabled=True,
+        )
+        assert not any(isinstance(m, WebSearchMiddleware) for m in middleware)
+
+    def test_excludes_web_fetch_middleware(self, mock_model, mock_backend, mock_runtime_ctx):
+        middleware = _build_general_purpose_middleware(
+            mock_model,
+            mock_backend,
+            mock_runtime_ctx,
+            sandbox_enabled=True,
+            web_search_enabled=True,
+            web_fetch_enabled=False,
+        )
+        assert not any(isinstance(m, WebFetchMiddleware) for m in middleware)
+
+    def test_includes_fallback_middleware_when_fallback_models_provided(
+        self, mock_model, mock_backend, mock_runtime_ctx
+    ):
+        middleware = _build_general_purpose_middleware(
+            mock_model,
+            mock_backend,
+            mock_runtime_ctx,
+            sandbox_enabled=True,
+            web_search_enabled=True,
+            web_fetch_enabled=True,
+            fallback_models=[Mock(), Mock()],
+        )
+        assert any(isinstance(m, ModelFallbackMiddleware) for m in middleware)
+
+    def test_excludes_fallback_middleware_when_no_fallback_models(self, mock_model, mock_backend, mock_runtime_ctx):
+        middleware = _build_general_purpose_middleware(
+            mock_model,
+            mock_backend,
+            mock_runtime_ctx,
+            sandbox_enabled=True,
+            web_search_enabled=True,
+            web_fetch_enabled=True,
+        )
+        assert not any(isinstance(m, ModelFallbackMiddleware) for m in middleware)
+
+    async def test_subagent_write_file_uses_parent_session_id(self, tmp_path, mock_model):
+        """The subagent's sync-aware write_file must thread the parent's session_id into the sandbox call.
+
+        DAIV-custom contract: a subagent inheriting the parent runtime's ``session_id`` calls the
+        sandbox under that same session, never opening a fresh one. Exercises the production wrap
+        path: ``_build_general_purpose_middleware`` → ``FilesystemSandboxSyncMiddleware.awrap_model_call``
+        → wrapped ``write_file``.
+        """
+        from types import SimpleNamespace
+
+        from deepagents.backends.filesystem import FilesystemBackend
+
+        from automation.agent.middlewares import file_system as fs_module
+        from core.sandbox.schemas import ApplyMutationsResponse, MutationResult
+
+        repo_dir = tmp_path / "repo"
+        repo_dir.mkdir()
+        ctx = Mock()
+        ctx.gitrepo.working_dir = str(repo_dir)
+
+        fake_client = AsyncMock()
+        fake_client.apply_file_mutations.return_value = ApplyMutationsResponse(
+            results=[MutationResult(path="/repo/sub.py", ok=True, error=None)]
+        )
+
+        backend = FilesystemBackend(root_dir=tmp_path, virtual_mode=True)
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(fs_module, "DAIVSandboxClient", lambda: fake_client)
+            middleware = _build_general_purpose_middleware(
+                mock_model, backend, ctx, sandbox_enabled=True, web_search_enabled=False, web_fetch_enabled=False
+            )
+
+        fs_mw = next(m for m in middleware if isinstance(m, FilesystemMiddleware))
+        sync_mw = next(m for m in middleware if isinstance(m, FilesystemSandboxSyncMiddleware))
+
+        # Drive the production wrap path: the sync middleware re-wraps tools at
+        # ``awrap_model_call`` time, so go through it rather than reaching into private state.
+        captured = {}
+
+        async def handler(req):
+            captured["tools"] = list(req.tools)
+            return object()
+
+        request = SimpleNamespace(tools=list(fs_mw.tools), override=lambda **kw: SimpleNamespace(tools=kw["tools"]))
+        await sync_mw.awrap_model_call(request, handler)
+        write = next(t for t in captured["tools"] if t.name == "write_file")
+
+        runtime = SimpleNamespace(
+            state={"session_id": "parent-sid"},
+            context=SimpleNamespace(gitrepo=SimpleNamespace(working_dir=str(repo_dir))),
+        )
+        result = await write.coroutine(file_path=f"/{repo_dir.name}/sub.py", content="x", runtime=runtime)
+
+        assert "Updated file" in result
+        fake_client.apply_file_mutations.assert_awaited_once()
+        call_session_id = fake_client.apply_file_mutations.call_args.args[0]
+        assert call_session_id == "parent-sid"
+
+
+class TestGeneralPurposeSubagent:
+    """Tests for the public ``create_general_purpose_subagent`` factory."""
+
+    @pytest.fixture
+    def mock_backend(self):
+        return Mock()
+
+    @pytest.fixture
+    def mock_model(self):
+        return Mock()
+
+    @pytest.fixture
+    def mock_runtime_ctx(self, tmp_path):
+        repo_dir = tmp_path / "repo"
+        repo_dir.mkdir()
+        ctx = Mock()
+        ctx.gitrepo.working_dir = str(repo_dir)
+        return ctx
+
+    def test_returns_compiled_subagent(self, mock_model, mock_backend, mock_runtime_ctx):
         result = create_general_purpose_subagent(mock_model, mock_backend, mock_runtime_ctx)
 
         assert isinstance(result, dict)
         assert result["name"] == "general-purpose"
         assert result["description"]
-        assert result["system_prompt"]
-        assert any(isinstance(m, WebFetchMiddleware) for m in result["middleware"])
-        assert any(isinstance(m, WebSearchMiddleware) for m in result["middleware"])
-        sandbox_middlewares = [m for m in result["middleware"] if isinstance(m, SandboxMiddleware)]
-        assert len(sandbox_middlewares) == 1
-        assert sandbox_middlewares[0].close_session is False
-
-    def test_excludes_sandbox_when_disabled(self, mock_model, mock_backend, mock_runtime_ctx):
-        result = create_general_purpose_subagent(mock_model, mock_backend, mock_runtime_ctx, sandbox_enabled=False)
-        assert not any(isinstance(m, SandboxMiddleware) for m in result["middleware"])
-
-    def test_excludes_web_search_middleware(self, mock_model, mock_backend, mock_runtime_ctx):
-        result = create_general_purpose_subagent(mock_model, mock_backend, mock_runtime_ctx, web_search_enabled=False)
-        assert not any(isinstance(m, WebSearchMiddleware) for m in result["middleware"])
-
-    def test_excludes_web_fetch_middleware(self, mock_model, mock_backend, mock_runtime_ctx):
-        result = create_general_purpose_subagent(mock_model, mock_backend, mock_runtime_ctx, web_fetch_enabled=False)
-        assert not any(isinstance(m, WebFetchMiddleware) for m in result["middleware"])
-
-    def test_includes_fallback_middleware_when_fallback_models_provided(
-        self, mock_model, mock_backend, mock_runtime_ctx
-    ):
-        fallback = [Mock(), Mock()]
-        result = create_general_purpose_subagent(mock_model, mock_backend, mock_runtime_ctx, fallback_models=fallback)
-        assert any(isinstance(m, ModelFallbackMiddleware) for m in result["middleware"])
-
-    def test_excludes_fallback_middleware_when_no_fallback_models(self, mock_model, mock_backend, mock_runtime_ctx):
-        result = create_general_purpose_subagent(mock_model, mock_backend, mock_runtime_ctx)
-        assert not any(isinstance(m, ModelFallbackMiddleware) for m in result["middleware"])
+        assert "runnable" in result
 
 
 class TestExploreSubagent:
-    """Tests for create_explore_subagent."""
+    """Tests for the public ``create_explore_subagent`` factory."""
 
-    def test_returns_subagent(self):
-        """Test that create_explore_subagent returns a SubAgent."""
+    def test_returns_compiled_subagent(self):
         result = create_explore_subagent(Mock())
 
         assert isinstance(result, dict)
         assert result["name"] == "explore"
         assert result["description"]
-        assert result["system_prompt"]
-        assert "READ-ONLY" in result["system_prompt"]
-        assert "PROHIBITED" in result["system_prompt"]
+        assert "runnable" in result
 
-    def test_includes_fallback_middleware_when_setting_configured(self, mocker):
-        mocker.patch(
-            "automation.agent.subagents.site_settings",
-            agent_explore_model_name="openrouter:anthropic/claude-haiku-4.5",
-            agent_explore_fallback_model_name="openrouter:openai/gpt-5.4-mini",
-        )
-        result = create_explore_subagent(Mock())
-        assert any(isinstance(m, ModelFallbackMiddleware) for m in result["middleware"])
+    def test_read_only_guard_raises_when_write_tools_missing(self, tmp_path, monkeypatch):
+        """Regression: if upstream renames ``write_file``/``edit_file``, the read-only filter
+        would silently match nothing and the explore subagent would regain write capability —
+        a security contract. ``_build_read_only_filesystem_middleware`` must fail loud instead.
+        """
+        from deepagents.backends.filesystem import FilesystemBackend
 
-    def test_excludes_fallback_middleware_when_setting_is_none(self, mocker):
-        mocker.patch(
-            "automation.agent.subagents.site_settings",
-            agent_explore_model_name="openrouter:anthropic/claude-haiku-4.5",
-            agent_explore_fallback_model_name=None,
-        )
-        result = create_explore_subagent(Mock())
-        assert not any(isinstance(m, ModelFallbackMiddleware) for m in result["middleware"])
+        from automation.agent.subagents import _build_read_only_filesystem_middleware
 
-    def test_proceeds_without_fallback_on_invalid_model(self, mocker):
-        mocker.patch(
-            "automation.agent.subagents.site_settings",
-            agent_explore_model_name="openrouter:anthropic/claude-haiku-4.5",
-            agent_explore_fallback_model_name="totally-invalid-model",
-        )
-        result = create_explore_subagent(Mock())
-        assert not any(isinstance(m, ModelFallbackMiddleware) for m in result["middleware"])
+        # Pretend upstream renamed ``write_file`` so it is no longer in the produced tool list.
+        monkeypatch.setattr("automation.agent.subagents.WRITE_TOOL_NAMES", frozenset({"unmapped_write_tool"}))
+
+        backend = FilesystemBackend(root_dir=str(tmp_path), virtual_mode=True)
+        with pytest.raises(RuntimeError, match=r"no longer exposes expected write tools"):
+            _build_read_only_filesystem_middleware(backend)
 
 
 def _make_subagent_md(*, name: str, description: str, model: str | None = None, body: str = "You are a custom agent."):
@@ -163,8 +282,7 @@ class TestCustomSubagents:
         assert len(result) == 1
         assert result[0]["name"] == "my-agent"
         assert result[0]["description"] == "Does custom things"
-        assert result[0]["system_prompt"] == "You do custom things."
-        assert result[0]["model"] is mock_model
+        assert "runnable" in result[0]
 
     async def test_loads_multiple_subagents(self, tmp_path: Path, mock_model, mock_runtime_ctx):
         from deepagents.backends.filesystem import FilesystemBackend
@@ -270,39 +388,6 @@ class TestCustomSubagents:
 
         assert len(result) == 0
 
-    async def test_uses_frontmatter_model(self, tmp_path: Path, mock_model, mock_runtime_ctx):
-        from deepagents.backends.filesystem import FilesystemBackend
-
-        subagents_dir = tmp_path / "repo" / ".agents" / "subagents"
-        subagents_dir.mkdir(parents=True)
-        (subagents_dir / "custom.md").write_text(
-            _make_subagent_md(name="custom", description="Custom agent", model="openrouter:anthropic/claude-haiku-4.5")
-        )
-
-        backend = FilesystemBackend(root_dir=tmp_path, virtual_mode=True)
-        result = await load_custom_subagents(
-            model=mock_model, backend=backend, runtime=mock_runtime_ctx, sources=["/repo/.agents/subagents"]
-        )
-
-        assert len(result) == 1
-        # Model should not be the default mock_model since frontmatter specifies one
-        assert result[0]["model"] is not mock_model
-
-    async def test_falls_back_to_default_model(self, tmp_path: Path, mock_model, mock_runtime_ctx):
-        from deepagents.backends.filesystem import FilesystemBackend
-
-        subagents_dir = tmp_path / "repo" / ".agents" / "subagents"
-        subagents_dir.mkdir(parents=True)
-        (subagents_dir / "custom.md").write_text(_make_subagent_md(name="custom", description="Custom agent"))
-
-        backend = FilesystemBackend(root_dir=tmp_path, virtual_mode=True)
-        result = await load_custom_subagents(
-            model=mock_model, backend=backend, runtime=mock_runtime_ctx, sources=["/repo/.agents/subagents"]
-        )
-
-        assert len(result) == 1
-        assert result[0]["model"] is mock_model
-
     async def test_returns_empty_when_no_source_exists(self, mock_model, mock_runtime_ctx):
         backend = Mock()
         backend.als = AsyncMock(side_effect=FileNotFoundError("not found"))
@@ -312,52 +397,6 @@ class TestCustomSubagents:
         )
 
         assert result == []
-
-    async def test_has_general_purpose_middleware(self, tmp_path: Path, mock_model, mock_runtime_ctx):
-        from deepagents.backends.filesystem import FilesystemBackend
-
-        subagents_dir = tmp_path / "repo" / ".agents" / "subagents"
-        subagents_dir.mkdir(parents=True)
-        (subagents_dir / "custom.md").write_text(_make_subagent_md(name="custom", description="Custom agent"))
-
-        backend = FilesystemBackend(root_dir=tmp_path, virtual_mode=True)
-        result = await load_custom_subagents(
-            model=mock_model, backend=backend, runtime=mock_runtime_ctx, sources=["/repo/.agents/subagents"]
-        )
-
-        assert len(result) == 1
-        middleware = result[0]["middleware"]
-        assert any(isinstance(m, FilesystemMiddleware) for m in middleware)
-        assert any(isinstance(m, GitPlatformMiddleware) for m in middleware)
-        assert any(isinstance(m, WebSearchMiddleware) for m in middleware)
-        assert any(isinstance(m, WebFetchMiddleware) for m in middleware)
-        sandbox_middlewares = [m for m in middleware if isinstance(m, SandboxMiddleware)]
-        assert len(sandbox_middlewares) == 1
-        assert sandbox_middlewares[0].close_session is False
-
-    async def test_excludes_optional_middleware_when_disabled(self, tmp_path: Path, mock_model, mock_runtime_ctx):
-        from deepagents.backends.filesystem import FilesystemBackend
-
-        subagents_dir = tmp_path / "repo" / ".agents" / "subagents"
-        subagents_dir.mkdir(parents=True)
-        (subagents_dir / "custom.md").write_text(_make_subagent_md(name="custom", description="Custom agent"))
-
-        backend = FilesystemBackend(root_dir=tmp_path, virtual_mode=True)
-        result = await load_custom_subagents(
-            model=mock_model,
-            backend=backend,
-            runtime=mock_runtime_ctx,
-            sources=["/repo/.agents/subagents"],
-            sandbox_enabled=False,
-            web_search_enabled=False,
-            web_fetch_enabled=False,
-        )
-
-        assert len(result) == 1
-        middleware = result[0]["middleware"]
-        assert not any(isinstance(m, SandboxMiddleware) for m in middleware)
-        assert not any(isinstance(m, WebSearchMiddleware) for m in middleware)
-        assert not any(isinstance(m, WebFetchMiddleware) for m in middleware)
 
     @pytest.mark.parametrize("reserved_name", ["general-purpose", "explore"])
     async def test_skips_builtin_name_collision(self, tmp_path: Path, mock_model, mock_runtime_ctx, reserved_name):
@@ -378,68 +417,6 @@ class TestCustomSubagents:
         names = {s["name"] for s in result}
         assert reserved_name not in names
         assert "custom" in names
-
-    async def test_includes_fallback_middleware_when_fallback_models_provided(
-        self, tmp_path: Path, mock_model, mock_runtime_ctx
-    ):
-        from deepagents.backends.filesystem import FilesystemBackend
-
-        subagents_dir = tmp_path / "repo" / ".agents" / "subagents"
-        subagents_dir.mkdir(parents=True)
-        (subagents_dir / "custom.md").write_text(_make_subagent_md(name="custom", description="Custom agent"))
-
-        backend = FilesystemBackend(root_dir=tmp_path, virtual_mode=True)
-        result = await load_custom_subagents(
-            model=mock_model,
-            backend=backend,
-            runtime=mock_runtime_ctx,
-            sources=["/repo/.agents/subagents"],
-            fallback_models=[Mock()],
-        )
-
-        assert len(result) == 1
-        assert any(isinstance(m, ModelFallbackMiddleware) for m in result[0]["middleware"])
-
-    async def test_subagent_write_file_uses_parent_session_id(self, tmp_path, mock_model):
-        """The subagent's sync-aware write_file must thread the parent's session_id into the sandbox call."""
-        from types import SimpleNamespace
-        from unittest.mock import AsyncMock
-
-        from deepagents.backends.filesystem import FilesystemBackend
-
-        from automation.agent.middlewares import file_system as fs_module
-        from automation.agent.subagents import create_general_purpose_subagent
-        from core.sandbox.schemas import ApplyMutationsResponse, MutationResult
-
-        repo_dir = tmp_path / "repo"
-        repo_dir.mkdir()
-        ctx = Mock()
-        ctx.gitrepo.working_dir = str(repo_dir)
-
-        fake_client = AsyncMock()
-        fake_client.apply_file_mutations.return_value = ApplyMutationsResponse(
-            results=[MutationResult(path="/repo/sub.py", ok=True, error=None)]
-        )
-
-        backend = FilesystemBackend(root_dir=tmp_path, virtual_mode=True)
-        with pytest.MonkeyPatch.context() as mp:
-            mp.setattr(fs_module, "DAIVSandboxClient", lambda: fake_client)
-            sub = create_general_purpose_subagent(mock_model, backend, ctx)
-
-        fs_mw = next(m for m in sub["middleware"] if isinstance(m, FilesystemMiddleware))
-        write = next(t for t in fs_mw.tools if t.name == "write_file")
-
-        # Subagent inherits the parent's session_id via runtime.state.
-        runtime = SimpleNamespace(
-            state={"session_id": "parent-sid"},
-            context=SimpleNamespace(gitrepo=SimpleNamespace(working_dir=str(repo_dir))),
-        )
-        result = await write.coroutine(file_path=f"/{repo_dir.name}/sub.py", content="x", runtime=runtime)
-
-        assert "Updated file" in result
-        fake_client.apply_file_mutations.assert_awaited_once()
-        call_session_id = fake_client.apply_file_mutations.call_args.args[0]
-        assert call_session_id == "parent-sid"
 
     async def test_skips_invalid_model(self, tmp_path: Path, mock_model, mock_runtime_ctx):
         from deepagents.backends.filesystem import FilesystemBackend

--- a/tests/unit_tests/automation/agent/test_subagents.py
+++ b/tests/unit_tests/automation/agent/test_subagents.py
@@ -125,16 +125,18 @@ class TestGeneralPurposeMiddleware:
         assert not any(isinstance(m, ModelFallbackMiddleware) for m in middleware)
 
     async def test_subagent_write_file_uses_parent_session_id(self, tmp_path, mock_model):
-        """The subagent's sync-aware write_file must thread the parent's session_id into the sandbox call.
+        """The subagent's sandbox-mirroring write_file must thread the parent's session_id into the sandbox call.
 
         DAIV-custom contract: a subagent inheriting the parent runtime's ``session_id`` calls the
-        sandbox under that same session, never opening a fresh one. Exercises the production wrap
-        path: ``_build_general_purpose_middleware`` → ``SandboxMiddleware.awrap_model_call`` →
-        wrapped ``write_file``.
+        sandbox under that same session, never opening a fresh one. Exercises the production
+        intercept path: ``_build_general_purpose_middleware`` → ``SandboxMiddleware.awrap_tool_call``
+        → ``SandboxSyncer.mirror``.
         """
         from types import SimpleNamespace
 
         from deepagents.backends.filesystem import FilesystemBackend
+        from langchain_core.messages import ToolMessage
+        from langgraph.prebuilt.tool_node import ToolCallRequest
 
         from automation.agent.middlewares.file_system import SandboxSyncer
         from core.sandbox.schemas import ApplyMutationsResponse, MutationResult
@@ -160,27 +162,34 @@ class TestGeneralPurposeMiddleware:
         sandbox_mw._client = fake_client
         sandbox_mw._syncer = SandboxSyncer(backend=backend, working_dir=repo_dir, client=fake_client)
 
-        captured = {}
-
-        async def handler(req):
-            captured["tools"] = list(req.tools)
-            return object()
-
-        request = SimpleNamespace(
-            tools=list(fs_mw.tools),
-            system_prompt="base prompt",
-            override=lambda **kw: SimpleNamespace(tools=kw["tools"], system_prompt=kw["system_prompt"]),
-        )
-        await sandbox_mw.awrap_model_call(request, handler)
-        write = next(t for t in captured["tools"] if t.name == "write_file")
-
+        write = next(t for t in fs_mw.tools if t.name == "write_file")
         runtime = SimpleNamespace(
             state={"session_id": "parent-sid"},
             context=SimpleNamespace(gitrepo=SimpleNamespace(working_dir=str(repo_dir))),
+            tool_call_id="call_subagent",
         )
-        result = await write.coroutine(file_path=f"/{repo_dir.name}/sub.py", content="x", runtime=runtime)
 
-        assert "Updated file" in result
+        request = ToolCallRequest(
+            tool_call={
+                "name": "write_file",
+                "args": {"file_path": f"/{repo_dir.name}/sub.py", "content": "x"},
+                "id": "call_subagent",
+                "type": "tool_call",
+            },
+            tool=write,
+            state=runtime.state,
+            runtime=runtime,
+        )
+
+        async def handler(req: ToolCallRequest) -> ToolMessage:
+            text = await req.tool.coroutine(**req.tool_call["args"], runtime=req.runtime)
+            return ToolMessage(content=text, tool_call_id=req.tool_call["id"], name=req.tool.name)
+
+        result = await sandbox_mw.awrap_tool_call(request, handler)
+
+        assert isinstance(result, ToolMessage)
+        assert isinstance(result.content, str)
+        assert "Updated file" in result.content
         fake_client.apply_file_mutations.assert_awaited_once()
         call_session_id = fake_client.apply_file_mutations.call_args.args[0]
         assert call_session_id == "parent-sid"


### PR DESCRIPTION
## Summary

- Replace the hand-rolled middleware stack and `langchain.agents.create_agent` call with `deepagents.create_deep_agent` plus a registered `HarnessProfile` (custom filesystem tool descriptions, exclusion of upstream's prompt-caching middleware, opt-out of upstream's auto-added general-purpose subagent).
- Split the old `FilesystemMiddleware` subclass into upstream's middleware (used directly with `custom_tool_descriptions`) and a focused `FilesystemSandboxSyncMiddleware` that re-wraps `write_file`/`edit_file` via `awrap_model_call`.
- Migrate built-in and custom subagents from `SubAgent` dicts to pre-`CompiledSubAgent` runnables.
- Read-only filesystem helper now fails loud (`RuntimeError`) if upstream renames the write tools — a security contract for the explore subagent.
- Promote the absolute-path filesystem directive to a shared constant so it reaches both the main agent and every subagent at the system-prompt level.

## Test plan

- [x] `uv run pytest tests/unit_tests/automation/agent/middlewares/test_file_system.py tests/unit_tests/automation/agent/test_subagents.py tests/unit_tests/automation/agent/test_graph_construction.py tests/unit_tests/automation/agent/test_graph_deferred.py` — 45 passed
- [x] `make lint-fix` — clean
- [x] New coverage: `awrap_model_call` wrap-and-cache path, parent `session_id` propagation through subagent stack, `RuntimeError` guard on missing write tools, `aafter_agent` syncer close
- [ ] Verify prompt-cache hit rate on a real agent run (middleware ordering shifted under `create_deep_agent`'s composition)