### PR TITLE
perf(skills): Enforce read-only mode at tool layer to preserve prompt cache

### DIFF
--- a/daiv/automation/agent/middlewares/skills.py
+++ b/daiv/automation/agent/middlewares/skills.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Annotated, NotRequired, override
 from deepagents.middleware.skills import SkillMetadata, SkillsState, SkillsStateUpdate
 from deepagents.middleware.skills import SkillsMiddleware as DeepAgentsSkillsMiddleware
 from langchain.agents.middleware import hook_config
-from langchain.agents.middleware.types import ModelRequest, ModelResponse, PrivateStateAttr
+from langchain.agents.middleware.types import PrivateStateAttr
 from langchain.tools import ToolRuntime, tool  # noqa: TC002
 from langchain_core.messages import AIMessage, AnyMessage, HumanMessage, ToolMessage
 from langchain_core.prompts import PromptTemplate
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
 
     from deepagents.graph import SubAgent
+    from langchain.agents.middleware.types import ToolCallRequest
     from langchain_core.runnables import RunnableConfig
     from langchain_core.tools import BaseTool
 
@@ -256,16 +257,29 @@ class SkillsMiddleware(DeepAgentsSkillsMiddleware):
         return AVAILABLE_SKILLS_TEMPLATE.format(skills_list=skills)
 
     @override
-    async def awrap_model_call(
-        self, request: ModelRequest[RuntimeCtx], handler: Callable[[ModelRequest[RuntimeCtx]], Awaitable[ModelResponse]]
-    ) -> ModelResponse:
-        """Filter write tools when the active skill declares read-only mode."""
-        active_mode = request.state.get("active_skill_mode")
-        if active_mode == SKILL_MODE_READ_ONLY:
-            filtered_tools = [t for t in request.tools if t.name not in WRITE_TOOL_NAMES]
-            modified = self.modify_request(request.override(tools=filtered_tools))
-            return await handler(modified)
-        return await super().awrap_model_call(request, handler)
+    async def awrap_tool_call(
+        self, request: ToolCallRequest, handler: Callable[[ToolCallRequest], Awaitable[ToolMessage | Command]]
+    ) -> ToolMessage | Command:
+        """Refuse write-tool execution when the active skill declares read-only mode.
+
+        Enforced at the tool layer rather than by stripping tools from the model request,
+        so the cached prompt prefix (which includes the tool list) stays stable across
+        skill activation and skill exit. Filtering at request-time invalidates the
+        Anthropic prompt cache and forces a full prefix re-create on the next call.
+        """
+        if (
+            request.tool_call["name"] in WRITE_TOOL_NAMES
+            and request.state.get("active_skill_mode") == SKILL_MODE_READ_ONLY
+        ):
+            return ToolMessage(
+                content=(
+                    f"Refused: tool '{request.tool_call['name']}' is unavailable while a read-only skill is active. "
+                    "Read-only skills must not modify files. Wait for the user's follow-up before writing."
+                ),
+                tool_call_id=request.tool_call["id"],
+                status="error",
+            )
+        return await handler(request)
 
     @staticmethod
     def _has_user_followup(messages: list[AnyMessage]) -> bool:

--- a/tests/unit_tests/automation/agent/middlewares/test_skills.py
+++ b/tests/unit_tests/automation/agent/middlewares/test_skills.py
@@ -4,11 +4,12 @@ from pathlib import Path
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
+from langchain.agents.middleware.types import ToolCallRequest
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 from langgraph.types import Command
 
 from automation.agent.constants import AGENTS_SKILLS_PATH, CLAUDE_CODE_SKILLS_PATH, CURSOR_SKILLS_PATH, SKILLS_SOURCES
-from automation.agent.middlewares.skills import SkillsMiddleware
+from automation.agent.middlewares.skills import SKILL_MODE_READ_ONLY, SkillsMiddleware
 from codebase.base import Scope
 from codebase.repo_config import RepositoryConfig, SlashCommands
 from slash_commands.base import SlashCommand
@@ -483,6 +484,65 @@ class TestSkillsMiddleware:
         assert "is_builtin" not in skills["agents-skill"]["metadata"]
         assert skills["cursor-skill"]["description"] == "from cursor"
         assert "is_builtin" not in skills["cursor-skill"]["metadata"]
+
+
+class TestReadOnlyMode:
+    """Tests for read-only skill mode enforcement at the tool-call layer.
+
+    Gating at execution rather than by stripping tools from the model request keeps
+    the cached prompt prefix (tool list) stable across skill activation and exit.
+    """
+
+    @staticmethod
+    def _make_middleware(tmp_path: Path) -> SkillsMiddleware:
+        from deepagents.backends.filesystem import FilesystemBackend
+
+        return SkillsMiddleware(backend=FilesystemBackend(root_dir=tmp_path, virtual_mode=True), sources=["/skills"])
+
+    @staticmethod
+    def _make_request(*, name: str, mode: str | None, call_id: str) -> ToolCallRequest:
+        return ToolCallRequest(
+            tool_call={"name": name, "args": {}, "id": call_id},
+            tool=None,
+            state={"active_skill_mode": mode},
+            runtime=Mock(),
+        )
+
+    async def test_blocks_writes_in_read_only_mode(self, tmp_path: Path):
+        middleware = self._make_middleware(tmp_path)
+        request = self._make_request(name="edit_file", mode=SKILL_MODE_READ_ONLY, call_id="call-1")
+        handler = AsyncMock()
+
+        result = await middleware.awrap_tool_call(request, handler)
+
+        handler.assert_not_awaited()
+        assert isinstance(result, ToolMessage)
+        assert result.tool_call_id == "call-1"
+        assert result.status == "error"
+        assert "edit_file" in result.content
+        assert "read-only" in result.content
+
+    async def test_allows_reads_in_read_only_mode(self, tmp_path: Path):
+        middleware = self._make_middleware(tmp_path)
+        request = self._make_request(name="read_file", mode=SKILL_MODE_READ_ONLY, call_id="call-2")
+        expected = ToolMessage(content="ok", tool_call_id="call-2")
+        handler = AsyncMock(return_value=expected)
+
+        result = await middleware.awrap_tool_call(request, handler)
+
+        handler.assert_awaited_once_with(request)
+        assert result is expected
+
+    async def test_allows_writes_when_mode_inactive(self, tmp_path: Path):
+        middleware = self._make_middleware(tmp_path)
+        request = self._make_request(name="edit_file", mode=None, call_id="call-3")
+        expected = ToolMessage(content="ok", tool_call_id="call-3")
+        handler = AsyncMock(return_value=expected)
+
+        result = await middleware.awrap_tool_call(request, handler)
+
+        handler.assert_awaited_once_with(request)
+        assert result is expected
 
 
 class TestCustomGlobalSkills:


### PR DESCRIPTION
## Summary

- Replace `awrap_model_call` (which stripped `edit_file`/`write_file` from `request.tools`) with `awrap_tool_call` for read-only skill mode enforcement.
- Filtering tools at request-time mutated the tool list in the cached prompt prefix, invalidating the Anthropic prompt cache on **both** skill activation *and* skill exit — observed in trace analysis as two consecutive full prefix re-creates (~40k token-equivalents at premium rate) per `plan`-then-`fix` flow.
- New approach gates writes at execution time, so the visible tool list stays constant and the cached prefix survives across skill activation/exit. Write-tool calls during read-only mode now short-circuit with an error `ToolMessage`.

## Test plan

- [x] `uv run pytest tests/unit_tests/automation/agent/middlewares/test_skills.py` — 28 passed (3 new tests in `TestReadOnlyMode` cover: write blocked in read-only, read passes through, write passes when mode inactive)
- [x] `uv run ruff check` clean
- [ ] Real-run verification: on next ~30 traces that invoke a `mode: read-only` skill, the AI message immediately following the skill tool result should hit ≥80% prompt cache (baseline 0%); the AI message after a user follow-up that clears the skill mode should hit ≥80% (baseline 23%).

## Background

Cache hit rate analysis across 6 LangSmith traces (52 AI calls) showed an aggregate 76.7% hit rate, with 5/40 non-first calls suffering full cache invalidation. The two largest invalidation causes were skill activation and skill mode exit — both rooted in the same `request.override(tools=...)` mechanism this PR removes.