### PR TITLE
perf(agent): Stabilize deferred-tools system prompt and default cache TTL to 5m

### DIFF
--- a/daiv/automation/agent/deferred/prompt.py
+++ b/daiv/automation/agent/deferred/prompt.py
@@ -9,13 +9,17 @@ _INSTRUCTIONS = """\
 You have access to additional tools that are deferred — their names and
 summaries are listed below but their full schemas are not loaded by default.
 To use one, call `tool_search` first to load it. Once loaded, the tool stays
-available for the rest of this session.
+available for the rest of this session and its full schema appears in your
+loaded tools.
 
 Prefer `select=[<name>]` with the exact tool name from the list — that is
 faster and more precise than a query. Use `query=` only when you can't
 identify the right tool from the list and want to search by capability.
 
 Do not call a deferred tool by name without loading it first; the call will fail.
+The list below is exhaustive and stable across the conversation — entries do
+not disappear once loaded, so use your loaded-tools view (not this list) to
+tell what is currently available.
 
 When the user asks what tools or capabilities you have, include the deferred
 tools listed below alongside your loaded tools — note they are deferred and
@@ -26,8 +30,15 @@ Examples:
   - tool_search(query="open pull request")      # only when browsing for capability"""
 
 
-def build_deferred_tools_block(index: DeferredToolsIndex, loaded: set[str]) -> str:
-    lines = [f"{entry.name}: {entry.summary}" for entry in index.deferred_entries() if entry.name not in loaded]
+def build_deferred_tools_block(index: DeferredToolsIndex) -> str:
+    """Render the deferred-tools advertisement appended to the system prompt.
+
+    The output is intentionally independent of which tools have already been loaded:
+    any per-call variation in the system prompt invalidates Anthropic's prompt cache
+    from byte 0 (system message is hashed before tools/messages), which in observed
+    traces cost ~22k tokens of fresh cache creation per deferred-tool load.
+    """
+    lines = [f"{entry.name}: {entry.summary}" for entry in index.deferred_entries()]
     if not lines:
         return ""
 

--- a/daiv/automation/agent/middlewares/deferred_tools.py
+++ b/daiv/automation/agent/middlewares/deferred_tools.py
@@ -79,18 +79,18 @@ class DeferredToolsMiddleware(AgentMiddleware):
             self._index = self._build_index(request.tools)
 
         loaded_names: set[str] = request.state.get("loaded_tool_names") or set()
-        loaded_tools: list[BaseTool] = []
-        stale: list[str] = []
-        for name in loaded_names:
-            entry = self._index.get(name)
-            if entry is None:
-                stale.append(name)
-            else:
-                loaded_tools.append(entry.tool)
-        if stale:
-            logger.warning("Dropping stale loaded_tool_names not present in deferred index: %s", sorted(stale))
+        # Iterate the index in its (insertion-ordered) registration order, not the `loaded_names`
+        # set. Set iteration is not contractually stable across CPython versions, and any
+        # reordering of the tools array invalidates Anthropic's cached prefix.
+        loaded_tools: list[BaseTool] = [
+            entry.tool for entry in self._index.deferred_entries() if entry.name in loaded_names
+        ]
+        if loaded_names:
+            stale = sorted(loaded_names - set(self._index.names()))
+            if stale:
+                logger.warning("Dropping stale loaded_tool_names not present in deferred index: %s", stale)
 
-        suffix = build_deferred_tools_block(self._index, loaded_names)
+        suffix = build_deferred_tools_block(self._index)
         new_system_prompt = request.system_prompt or ""
         if suffix:
             new_system_prompt = f"{new_system_prompt}\n\n{suffix}" if new_system_prompt else suffix

--- a/daiv/automation/agent/middlewares/prompt_cache.py
+++ b/daiv/automation/agent/middlewares/prompt_cache.py
@@ -34,7 +34,7 @@ class AnthropicPromptCachingMiddleware(AnthropicPromptCachingMiddlewareV0):
         ```
     """
 
-    def __init__(self, *args, ttl: Literal["5m", "1h"] = "1h", **kwargs):
+    def __init__(self, *args, ttl: Literal["5m", "1h"] = "5m", **kwargs):
         """
         Initialize the middleware.
         """

--- a/tests/unit_tests/automation/agent/deferred/test_prompt.py
+++ b/tests/unit_tests/automation/agent/deferred/test_prompt.py
@@ -11,15 +11,15 @@ def _make_tool(name: str, description: str) -> StructuredTool:
 class TestBuildDeferredToolsBlock:
     def test_empty_when_no_deferred_entries(self):
         index = DeferredToolsIndex([])
-        assert build_deferred_tools_block(index, set()) == ""
+        assert build_deferred_tools_block(index) == ""
 
-    def test_lists_unloaded_tools_with_first_description_line(self):
+    def test_lists_deferred_tools_with_first_description_line(self):
         tools = [
             _make_tool("github_create_issue", "Create a GitHub issue.\nMore detail follows."),
             _make_tool("sentry_find_orgs", "List Sentry organizations."),
         ]
         index = DeferredToolsIndex(tools)
-        block = build_deferred_tools_block(index, set())
+        block = build_deferred_tools_block(index)
 
         assert "<available-deferred-tools>" in block
         assert "</available-deferred-tools>" in block
@@ -27,24 +27,19 @@ class TestBuildDeferredToolsBlock:
         assert "sentry_find_orgs: List Sentry organizations." in block
         assert "More detail follows." not in block
 
-    def test_hides_already_loaded_tools(self):
+    def test_block_is_stable_regardless_of_loaded_state(self):
+        # Cache stability invariant: the block must be byte-identical across calls
+        # within a session, otherwise the system message hash changes and Anthropic's
+        # prompt cache invalidates from byte 0.
         tools = [_make_tool("github_create_issue", "Create issue"), _make_tool("sentry_find_orgs", "List orgs")]
         index = DeferredToolsIndex(tools)
-        block = build_deferred_tools_block(index, {"github_create_issue"})
-
-        assert "github_create_issue" not in block
-        assert "sentry_find_orgs" in block
-
-    def test_empty_when_every_tool_loaded(self):
-        tools = [_make_tool("github_create_issue", "Create issue")]
-        index = DeferredToolsIndex(tools)
-        assert build_deferred_tools_block(index, {"github_create_issue"}) == ""
+        assert build_deferred_tools_block(index) == build_deferred_tools_block(index)
 
     def test_truncates_long_first_lines(self):
         long_desc = "Create something. " + ("verylong " * 100)
         tools = [_make_tool("noisy", long_desc)]
         index = DeferredToolsIndex(tools)
-        block = build_deferred_tools_block(index, set())
+        block = build_deferred_tools_block(index)
         assert "noisy: " in block
         body_line = next(line for line in block.splitlines() if line.startswith("noisy:"))
         assert len(body_line) <= len("noisy: ") + 200
@@ -52,5 +47,5 @@ class TestBuildDeferredToolsBlock:
     def test_includes_tool_search_usage_instructions(self):
         tools = [_make_tool("github_create_issue", "Create issue")]
         index = DeferredToolsIndex(tools)
-        block = build_deferred_tools_block(index, set())
+        block = build_deferred_tools_block(index)
         assert "tool_search" in block

--- a/tests/unit_tests/automation/agent/middlewares/test_deferred_tools.py
+++ b/tests/unit_tests/automation/agent/middlewares/test_deferred_tools.py
@@ -138,20 +138,35 @@ class TestDeferredToolsMiddleware:
         assert "<available-deferred-tools>" in captured["system_prompt"]
         assert "github_create_issue" in captured["system_prompt"]
 
-    async def test_no_block_when_all_tools_loaded(self):
+    async def test_system_prompt_is_byte_identical_regardless_of_loaded_state(self):
+        # Cache-stability invariant: any per-call mutation of the system prompt invalidates
+        # Anthropic's prompt cache from byte 0. The deferred-tools block must therefore be
+        # the same in calls before and after a deferred tool is loaded.
         github = _make_tool("github_create_issue", "Create issue")
-        middleware = DeferredToolsMiddleware(always_loaded=set(), extra_tools=[github])
+        sentry = _make_tool("sentry_find_orgs", "List orgs")
+        middleware = DeferredToolsMiddleware(always_loaded=set(), extra_tools=[github, sentry])
 
-        request = _request(system_prompt="EXISTING PROMPT", state={"loaded_tool_names": {"github_create_issue"}})
-        captured: dict = {}
+        captured: list[str] = []
 
         async def handler(req):
-            captured["system_prompt"] = req.system_prompt
+            captured.append(req.system_prompt)
             return MagicMock()
 
-        await middleware.awrap_model_call(request, handler)
+        # Before any deferred tool is loaded.
+        await middleware.awrap_model_call(_request(system_prompt="P", state={}), handler)
+        # After one is loaded.
+        await middleware.awrap_model_call(
+            _request(system_prompt="P", state={"loaded_tool_names": {"github_create_issue"}}), handler
+        )
+        # After both are loaded.
+        await middleware.awrap_model_call(
+            _request(system_prompt="P", state={"loaded_tool_names": {"github_create_issue", "sentry_find_orgs"}}),
+            handler,
+        )
 
-        assert "<available-deferred-tools>" not in captured["system_prompt"]
+        assert captured[0] == captured[1] == captured[2]
+        assert "github_create_issue" in captured[0]
+        assert "sentry_find_orgs" in captured[0]
 
     async def test_system_prompt_none_does_not_pollute(self):
         github = _make_tool("github_create_issue", "Create issue")
@@ -168,6 +183,33 @@ class TestDeferredToolsMiddleware:
 
         assert not captured["system_prompt"].startswith("\n")
         assert "<available-deferred-tools>" in captured["system_prompt"]
+
+    async def test_loaded_tools_appended_in_stable_index_order(self):
+        # Cache-stability invariant: the tools array must grow monotonically by appending
+        # in a deterministic order. Anthropic's prefix-match cache loses the previously
+        # cached prefix if any earlier tool is reordered or replaced.
+        a = _make_tool("a_tool", "A")
+        b = _make_tool("b_tool", "B")
+        c = _make_tool("c_tool", "C")
+        middleware = DeferredToolsMiddleware(always_loaded=set(), extra_tools=[a, b, c])
+
+        captured: list[list[str]] = []
+
+        async def handler(req):
+            captured.append([t.name for t in req.tools])
+            return MagicMock()
+
+        # Load b first, then a — order of `loaded_tool_names` set is irrelevant; output
+        # must follow index order (a, b, c) regardless.
+        await middleware.awrap_model_call(_request(state={"loaded_tool_names": {"b_tool"}}), handler)
+        await middleware.awrap_model_call(_request(state={"loaded_tool_names": {"a_tool", "b_tool"}}), handler)
+        await middleware.awrap_model_call(
+            _request(state={"loaded_tool_names": {"a_tool", "b_tool", "c_tool"}}), handler
+        )
+
+        # tool_search is the only always-loaded tool here; deferred order is index order.
+        deferred_only = [[n for n in step if n != "tool_search"] for step in captured]
+        assert deferred_only == [["b_tool"], ["a_tool", "b_tool"], ["a_tool", "b_tool", "c_tool"]]
 
     async def test_init_rejects_invalid_top_k(self):
         import pytest


### PR DESCRIPTION
## Summary

Two independent changes that both target Anthropic prompt-cache hit rate (companion to #1170, which fixed the same class of issue in `SkillsMiddleware`).

1. **Byte-stabilize the deferred-tools block in the system prompt.** `build_deferred_tools_block` previously filtered out already-loaded tools, so loading a deferred tool via `tool_search` mutated the system message and invalidated the cached prefix from byte 0. Observed cost in trace analysis: **~22k tokens of fresh cache creation per `tool_search` call**. The block is now stable across the conversation; the agent uses its loaded-tools view (not the system-prompt list) to know what's currently available — this is documented in the prompt itself.
2. **Iterate the registration-ordered index, not `loaded_names`.** Set iteration is not contractually stable across CPython versions; any reordering would also shuffle the tools array and invalidate the cached prefix. We now iterate `index.deferred_entries()` and filter by membership in `loaded_names`.
3. **Default `AnthropicPromptCachingMiddleware` TTL from `1h` to `5m`.** 1h ephemeral cache writes are billed at ~2× base input rate vs ~1.25× for 5m. Most chat/mention conversations finish well inside 5 minutes, so 1h was paying the higher surcharge without amortising it. Long-lived agents that need 1h can still opt in explicitly.

## Test plan

- [x] `uv run pytest tests/unit_tests/automation/agent/deferred/ tests/unit_tests/automation/agent/middlewares/test_deferred_tools.py` — 50 passed
- [x] `uv run ruff check` clean
- [x] New invariant test `test_system_prompt_is_byte_identical_regardless_of_loaded_state` (test_deferred_tools.py) verifies the system prompt is byte-stable across before/after loading deferred tools
- [ ] Real-run verification: on next ~30 traces with at least one `tool_search` call, the AI message immediately following the load should hit ≥80% prompt cache (baseline 0%, observed in 3+ traces).

## Background

Cache hit rate analysis across 6 LangSmith traces (52 AI calls) identified `tool_search`-driven invalidations and over-aggressive 1h TTL as the two largest non-cold-start sources of cache cost. See companion PR #1170 for the skills-mode fix.