### PR TITLE
fix(chat): Stop echoing assistant turns back on follow-up

### DIFF
--- a/daiv/chat/static/chat/js/chat-stream.js
+++ b/daiv/chat/static/chat/js/chat-stream.js
@@ -455,8 +455,15 @@
       this._autoFollow = true;
       this.$nextTick(() => this.scrollToBottom({ force: true }));
 
+      // Send only user turns. Streamed assistant turns carry a client-minted
+      // UUID (set when we pushed the placeholder), but the server stored the
+      // AIMessage under its own LangChain-generated id — echoing the assistant
+      // turn back would slip past ag_ui_langgraph's id-based dedupe and append
+      // a duplicate AIMessage to the checkpoint. The agent reads prior history
+      // from the checkpointer; it doesn't need the client to replay it.
       const priorMessages = this.turns
         .slice(0, -1)
+        .filter((t) => t.role === "user")
         .map((t) => ({
           id: t.id,
           role: t.role,


### PR DESCRIPTION
## Summary

- Filter `priorMessages` in `chat-stream.js` to user-role turns only, so streamed assistant turns are never replayed back to the server.
- Prior assistant turns carried a client-minted UUID (set when the placeholder was pushed) while the server stored the AIMessage under its own LangChain-generated id. Echoing the turn back slipped past `ag_ui_langgraph.langgraph_default_merge_state`'s id-based dedupe and appended a duplicate `AIMessage` to the checkpoint.
- Symptom: on reload of a thread where the user had sent a follow-up without reloading, the previous assistant message rendered twice (a "real" lc_run-- copy followed by a UUID-id copy).
- The checkpointer already holds the full assistant history the agent needs; the client doesn't need to replay it.

## Test plan

- [ ] Open a chat, send a prompt, wait for the assistant to finish.
- [ ] Send a follow-up *without* reloading the page.
- [ ] Reload the page; the first assistant message should appear exactly once.
- [ ] (Regression) Verify the agent still produces sensible follow-up answers (i.e. the checkpointer-driven history works without the client replay).