### PR TITLE
fix(agent): Open new MR when source branch is protected

### DIFF
--- a/daiv/automation/agent/publishers.py
+++ b/daiv/automation/agent/publishers.py
@@ -8,6 +8,8 @@ from urllib.parse import quote, urlencode
 
 from django.template.loader import render_to_string
 
+from asgiref.sync import sync_to_async
+
 from automation.agent.utils import build_langsmith_config
 from codebase.base import GitPlatform, MergeRequest, Scope
 from codebase.clients import RepoClient
@@ -69,6 +71,18 @@ class GitChangePublisher(ChangePublisher):
             logger.info("No changes to publish.")
             return None
 
+        fallback_from_mr: MergeRequest | None = None
+        if merge_request is not None and await sync_to_async(self.client.is_branch_protected)(
+            self.ctx.repository.slug, merge_request.source_branch
+        ):
+            logger.warning(
+                "Source branch '%s' of MR !%s is protected; opening a new MR with a fresh branch instead.",
+                merge_request.source_branch,
+                merge_request.merge_request_id,
+            )
+            fallback_from_mr = merge_request
+            merge_request = None
+
         # Compute full diff metadata when creating a new merge request or updating a draft merge request
         # to ensure we have the most up-to-date information.
         pr_metadata_diff = (
@@ -105,6 +119,8 @@ class GitChangePublisher(ChangePublisher):
                 merge_request.merge_request_id,
                 merge_request.draft,
             )
+            if fallback_from_mr is not None:
+                self._notify_protected_branch_fallback(fallback_from_mr, merge_request)
             self._suggest_context_file(merge_request)
         elif merge_request.draft and as_draft is False:
             merge_request = self.client.update_merge_request(
@@ -205,6 +221,35 @@ class GitChangePublisher(ChangePublisher):
                 },
             ),
         )
+
+    def _notify_protected_branch_fallback(
+        self, original_merge_request: MergeRequest, new_merge_request: MergeRequest
+    ) -> None:
+        """
+        Leave a comment on the original MR explaining that the changes were published
+        to a new MR because the original's source branch is protected on the remote.
+        """
+        try:
+            self.client.create_merge_request_comment(
+                self.ctx.repository.slug,
+                original_merge_request.merge_request_id,
+                render_to_string(
+                    "automation/protected_branch_fallback.txt",
+                    {
+                        "bot_name": BOT_NAME,
+                        "new_merge_request_url": new_merge_request.web_url,
+                        "new_merge_request_id": new_merge_request.merge_request_id,
+                        "source_branch": original_merge_request.source_branch,
+                        "is_gitlab": self.ctx.git_platform == GitPlatform.GITLAB,
+                    },
+                ),
+            )
+        except Exception:
+            logger.warning(
+                "Failed to post protected-branch fallback notice on MR !%s",
+                original_merge_request.merge_request_id,
+                exc_info=True,
+            )
 
     def _suggest_context_file(self, merge_request: MergeRequest) -> None:
         if not site_settings.suggest_context_file_enabled or not self.ctx.config.suggest_context_file:

--- a/daiv/automation/templates/automation/protected_branch_fallback.txt
+++ b/daiv/automation/templates/automation/protected_branch_fallback.txt
@@ -1,0 +1,5 @@
+#### :lock: Source branch `{{ source_branch }}` is protected
+
+I couldn't push the requested changes to this merge request because its source branch (`{{ source_branch }}`) is protected on the remote.
+
+I've opened a new {% if is_gitlab %}merge request{% else %}pull request{% endif %} with the changes instead: {{ new_merge_request_url }}{% if is_gitlab %} (!{{ new_merge_request_id }}){% else %} (#{{ new_merge_request_id }}){% endif %}.

--- a/daiv/codebase/clients/base.py
+++ b/daiv/codebase/clients/base.py
@@ -61,6 +61,21 @@ class RepoClient(abc.ABC):
         pass
 
     @abc.abstractmethod
+    def is_branch_protected(self, repo_id: str, branch: str) -> bool:
+        """
+        Return whether ``branch`` is protected on the remote (covers both exact-name
+        and wildcard protection rules — the platform branch resource resolves them).
+
+        Args:
+            repo_id: The repository ID.
+            branch: The branch name to check.
+
+        Returns:
+            ``True`` if the branch exists and is protected, ``False`` otherwise.
+        """
+        pass
+
+    @abc.abstractmethod
     def list_branches(self, repo_id: str, search: str | None = None, limit: int = 20) -> list[str]:
         """
         Return up to ``limit`` branch names for ``repo_id``.

--- a/daiv/codebase/clients/github/client.py
+++ b/daiv/codebase/clients/github/client.py
@@ -134,6 +134,21 @@ class GitHubClient(RepoClient):
                 repos = repos[:limit]
         return repos
 
+    def is_branch_protected(self, repo_id: str, branch: str) -> bool:
+        """
+        Resolve protection via ``GET /repos/{owner}/{repo}/branches/{branch}``; the
+        ``protected`` flag reflects both classic branch protection and ruleset-based
+        rules. Fails open on any API error (404, auth, rate limit, transport): the caller
+        treats this as a best-effort pre-check, and the subsequent ``git push`` remains
+        the source of truth.
+        """
+        repo = self.client.get_repo(repo_id, lazy=True)
+        try:
+            return bool(repo.get_branch(branch).protected)
+        except GithubException:
+            logger.warning("Failed to check protection for %s@%s; assuming unprotected", repo_id, branch, exc_info=True)
+            return False
+
     def list_branches(self, repo_id: str, search: str | None = None, limit: int = 20) -> list[str]:
         """
         Return up to ``limit`` branch names. GitHub's branches endpoint has no server-side

--- a/daiv/codebase/clients/gitlab/client.py
+++ b/daiv/codebase/clients/gitlab/client.py
@@ -157,6 +157,20 @@ class GitLabClient(RepoClient):
                 break
         return repos
 
+    def is_branch_protected(self, repo_id: str, branch: str) -> bool:
+        """
+        Resolve protection via ``GET /projects/:id/repository/branches/:branch``; the
+        ``protected`` flag covers both exact-name and wildcard rules. Fails open on any
+        API error (404, auth, rate limit, transport): the caller treats this as a best-effort
+        pre-check, and the subsequent ``git push`` remains the source of truth.
+        """
+        project = self.client.projects.get(repo_id, lazy=True)
+        try:
+            return bool(project.branches.get(branch).protected)
+        except GitlabError:
+            logger.warning("Failed to check protection for %s@%s; assuming unprotected", repo_id, branch, exc_info=True)
+            return False
+
     def list_branches(self, repo_id: str, search: str | None = None, limit: int = 20) -> list[str]:
         """
         Return up to ``limit`` branch names, optionally filtered by server-side substring ``search``.

--- a/daiv/codebase/clients/swe.py
+++ b/daiv/codebase/clients/swe.py
@@ -91,6 +91,10 @@ class SWERepoClient(RepoClient):
         """
         raise NotImplementedError("SWERepoClient does not support listing repositories")
 
+    def is_branch_protected(self, repo_id: str, branch: str) -> bool:
+        """SWE sandbox repos have no remote branch protection."""
+        return False
+
     def list_branches(self, repo_id: str, search: str | None = None, limit: int = 20) -> list[str]:
         """List branches is not supported for SWE client."""
         raise NotImplementedError("SWERepoClient does not support listing branches")

--- a/tests/unit_tests/automation/agent/test_publishers.py
+++ b/tests/unit_tests/automation/agent/test_publishers.py
@@ -38,6 +38,7 @@ def _make_publisher(*, git_platform: GitPlatform = GitPlatform.GITLAB, context_f
 
     publisher = GitChangePublisher(ctx)
     publisher.client = Mock()
+    publisher.client.is_branch_protected.return_value = False
     return publisher
 
 
@@ -125,6 +126,49 @@ class TestSuggestContextFile:
         assert "CLAUDE.md" in comment_body
 
 
+class TestNotifyProtectedBranchFallback:
+    def test_posts_comment_linking_to_new_mr(self):
+        publisher = _make_publisher()
+        original = _make_merge_request(source_branch="dev", merge_request_id=42)
+        new_mr = _make_merge_request(
+            source_branch="feature-fix",
+            merge_request_id=43,
+            web_url="https://gitlab.com/owner/repo/-/merge_requests/43",
+        )
+
+        publisher._notify_protected_branch_fallback(original, new_mr)
+
+        publisher.client.create_merge_request_comment.assert_called_once()
+        repo_id, mr_id, body = publisher.client.create_merge_request_comment.call_args[0]
+        assert repo_id == "owner/repo"
+        assert mr_id == 42
+        assert "dev" in body
+        assert "https://gitlab.com/owner/repo/-/merge_requests/43" in body
+        assert "!43" in body
+
+    def test_does_not_raise_when_comment_post_fails(self):
+        publisher = _make_publisher()
+        publisher.client.create_merge_request_comment.side_effect = Exception("boom")
+        original = _make_merge_request(merge_request_id=42)
+        new_mr = _make_merge_request(merge_request_id=43)
+
+        # Best-effort: a failed courtesy comment must not tear down a successful publish.
+        publisher._notify_protected_branch_fallback(original, new_mr)
+
+    def test_renders_github_terminology_for_github_platform(self):
+        publisher = _make_publisher(git_platform=GitPlatform.GITHUB)
+        original = _make_merge_request(source_branch="main", merge_request_id=10)
+        new_mr = _make_merge_request(
+            source_branch="feature-fix", merge_request_id=11, web_url="https://github.com/owner/repo/pull/11"
+        )
+
+        publisher._notify_protected_branch_fallback(original, new_mr)
+
+        body = publisher.client.create_merge_request_comment.call_args[0][2]
+        assert "pull request" in body
+        assert "#11" in body
+
+
 class TestBuildIssueCreationUrl:
     def test_gitlab_url_format(self):
         publisher = _make_publisher(git_platform=GitPlatform.GITLAB)
@@ -186,6 +230,43 @@ class TestPublishSuggestsContextFile:
 
             mock_suggest.assert_called_once_with(mr)
             assert result == mr
+
+    async def test_falls_back_to_new_mr_when_source_branch_protected(self, publisher):
+        existing_mr = _make_merge_request(source_branch="dev", merge_request_id=42)
+        new_mr = _make_merge_request(source_branch="feature-fix", merge_request_id=43)
+        publisher.client.is_branch_protected.return_value = True
+
+        with (
+            patch.object(
+                publisher,
+                "_diff_to_metadata",
+                return_value={
+                    "pr_metadata": Mock(branch="feature-fix", title="Title", description="Desc"),
+                    "commit_message": Mock(commit_message="commit msg"),
+                },
+            ) as mock_diff_to_metadata,
+            patch("automation.agent.publishers.GitManager") as mock_git_mgr_cls,
+            patch.object(publisher, "_create_merge_request", return_value=new_mr) as mock_create_mr,
+            patch.object(publisher, "_suggest_context_file"),
+            patch.object(publisher, "_notify_protected_branch_fallback") as mock_notify,
+        ):
+            mock_git_mgr = mock_git_mgr_cls.return_value
+            mock_git_mgr.is_dirty.return_value = True
+            mock_git_mgr.get_diff.return_value = "diff"
+            mock_git_mgr.commit_and_push_changes.return_value = "feature-fix"
+
+            result = await publisher.publish(merge_request=existing_mr)
+
+            publisher.client.is_branch_protected.assert_called_once_with("owner/repo", "dev")
+            # Pre-check must run before _diff_to_metadata so the fallback path receives a
+            # populated pr_metadata_diff (the new MR needs title/branch/description).
+            assert mock_diff_to_metadata.call_args.kwargs["pr_metadata_diff"] is not None
+            mock_git_mgr.commit_and_push_changes.assert_called_once_with(
+                "commit msg", branch_name="feature-fix", use_branch_if_exists=False, skip_ci=False
+            )
+            mock_create_mr.assert_called_once()
+            mock_notify.assert_called_once_with(existing_mr, new_mr)
+            assert result == new_mr
 
     async def test_does_not_suggest_on_existing_mr(self, publisher):
         mr = _make_merge_request()

--- a/tests/unit_tests/codebase/clients/github/test_client.py
+++ b/tests/unit_tests/codebase/clients/github/test_client.py
@@ -393,6 +393,30 @@ class TestGitHubClient:
         assert result.labels == ["enhancement"]
         mock_repo.get_pulls.assert_called_once_with(state="open", base="main", head="feat-x")
 
+    def test_is_branch_protected_returns_true_when_branch_protected(self, github_client):
+        mock_repo = Mock()
+        mock_repo.get_branch.return_value = Mock(protected=True)
+        github_client.client.get_repo.return_value = mock_repo
+
+        assert github_client.is_branch_protected("owner/repo", "main") is True
+        mock_repo.get_branch.assert_called_once_with("main")
+
+    def test_is_branch_protected_returns_false_when_branch_unprotected(self, github_client):
+        mock_repo = Mock()
+        mock_repo.get_branch.return_value = Mock(protected=False)
+        github_client.client.get_repo.return_value = mock_repo
+
+        assert github_client.is_branch_protected("owner/repo", "feature") is False
+
+    def test_is_branch_protected_returns_false_on_api_error(self, github_client):
+        """Fails open: treats any GitHub error (404, auth, rate limit, transport) as unprotected."""
+        mock_repo = Mock()
+        github_client.client.get_repo.return_value = mock_repo
+
+        for status in (404, 401, 500):
+            mock_repo.get_branch.side_effect = GithubException(status, "error", None)
+            assert github_client.is_branch_protected("owner/repo", "missing") is False
+
     def test_get_merge_request_by_branches_returns_none_when_empty(self, github_client):
         """No open PR matching the branch pair → ``None``."""
         mock_repo = Mock()

--- a/tests/unit_tests/codebase/clients/gitlab/test_client.py
+++ b/tests/unit_tests/codebase/clients/gitlab/test_client.py
@@ -394,6 +394,33 @@ class TestGitLabClient:
         )
         serialize.assert_called_once_with("group/repo", mock_mr)
 
+    def test_is_branch_protected_returns_true_when_branch_protected(self, gitlab_client):
+        mock_project = Mock()
+        mock_branch = Mock(protected=True)
+        mock_project.branches.get.return_value = mock_branch
+        gitlab_client.client.projects.get.return_value = mock_project
+
+        assert gitlab_client.is_branch_protected("group/repo", "dev") is True
+        mock_project.branches.get.assert_called_once_with("dev")
+
+    def test_is_branch_protected_returns_false_when_branch_unprotected(self, gitlab_client):
+        mock_project = Mock()
+        mock_project.branches.get.return_value = Mock(protected=False)
+        gitlab_client.client.projects.get.return_value = mock_project
+
+        assert gitlab_client.is_branch_protected("group/repo", "feature") is False
+
+    def test_is_branch_protected_returns_false_on_api_error(self, gitlab_client):
+        """Fails open: treats any GitLab error (404, auth, rate limit, transport) as unprotected."""
+        from gitlab.exceptions import GitlabAuthenticationError
+
+        mock_project = Mock()
+        gitlab_client.client.projects.get.return_value = mock_project
+
+        for error in (GitlabGetError("404", response_code=404), GitlabAuthenticationError("401")):
+            mock_project.branches.get.side_effect = error
+            assert gitlab_client.is_branch_protected("group/repo", "missing") is False
+
     def test_get_merge_request_by_branches_returns_none_when_empty(self, gitlab_client):
         """Empty list → ``None`` (not an exception)."""
         mock_project = Mock()


### PR DESCRIPTION
## Summary

- When DAIV processes a comment on an MR whose source branch is protected on the remote, the publisher used to crash on `git push` (Sentry [DAIV-84](https://sentry.eurotux.pt/organizations/dipcode/issues/8514/)).
- Adds `RepoClient.is_branch_protected(repo_id, branch)` — implemented for GitLab via `GET /projects/:id/repository/branches/:branch` and GitHub via `GET /repos/{owner}/{repo}/branches/{branch}`. Both endpoints' `protected` flag already accounts for wildcard / ruleset-based rules, so a single API call covers all cases.
- Publisher pre-checks before pushing. When protected, it drops the MR reference so the standard "no MR" path generates a fresh branch + new MR, and posts a notice on the original MR linking to the new one (best-effort, mirrors `_suggest_context_file`'s pattern).
- Pre-check fails open: any API error (404, auth, rate limit, transport) is logged and treated as unprotected. The actual `git push` remains the source of truth, so a transient API hiccup never aborts publish.

## Test plan

- [ ] `make test` (770 unit tests pass; new tests cover `is_branch_protected` happy/404/fail-open paths for both clients, plus the publisher fallback ordering and `_notify_protected_branch_fallback` rendering for GitLab + GitHub).
- [ ] Manually trigger DAIV via comment on a protected-branch MR; verify a new MR is opened with the changes and the original MR receives the linking notice.
- [ ] Manually trigger DAIV on a non-protected-branch MR; verify normal flow is unchanged (one extra API call per publish, no fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)