### PR TITLE
feat(notifications): Mark unread as read when bell tray opens

### DIFF
--- a/daiv/notifications/models.py
+++ b/daiv/notifications/models.py
@@ -61,6 +61,11 @@ class Notification(TimeStampedModel):
             self.read_at = timezone.now()
             self.save(update_fields=["read_at", "modified"])
 
+    @classmethod
+    def mark_all_read_for(cls, user) -> int:
+        now = timezone.now()
+        return cls.objects.filter(recipient=user, read_at__isnull=True).update(read_at=now, modified=now)
+
 
 class NotificationDelivery(TimeStampedModel):
     """Tracks the delivery of a notification through a specific channel.

--- a/daiv/notifications/views.py
+++ b/daiv/notifications/views.py
@@ -70,7 +70,9 @@ class BellDropdownView(LoginRequiredMixin, TemplateView):
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data(**kwargs)
         qs = Notification.objects.filter(recipient=self.request.user).prefetch_related("deliveries")
+        # Fetch before the bulk-update below so unread cues still render on first open.
         ctx["notifications"] = list(qs[:10])
+        Notification.mark_all_read_for(self.request.user)
         return ctx
 
 
@@ -91,7 +93,7 @@ class MarkNotificationReadView(LoginRequiredMixin, TemplateView):
 @method_decorator(require_POST, name="dispatch")
 class MarkAllReadView(LoginRequiredMixin, View):
     def post(self, request):
-        Notification.objects.filter(recipient=request.user, read_at__isnull=True).update(read_at=timezone.now())
+        Notification.mark_all_read_for(request.user)
         return HttpResponseRedirect(reverse("notifications:list"))
 
 

--- a/tests/unit_tests/notifications/test_models.py
+++ b/tests/unit_tests/notifications/test_models.py
@@ -35,6 +35,31 @@ class TestNotification:
         n.refresh_from_db()
         assert n.read_at == original
 
+    def test_mark_all_read_for_returns_count_and_preserves_already_read(self, member_user):
+        unread = [
+            Notification.objects.create(recipient=member_user, event_type="e", subject=f"u{i}", body="b", link_url="/")
+            for i in range(3)
+        ]
+        already_read = Notification.objects.create(
+            recipient=member_user, event_type="e", subject="r", body="b", link_url="/"
+        )
+        already_read.mark_as_read()
+        original_read_at = Notification.objects.get(pk=already_read.pk).read_at
+
+        updated = Notification.mark_all_read_for(member_user)
+
+        assert updated == len(unread)
+        assert Notification.objects.filter(recipient=member_user, read_at__isnull=True).count() == 0
+        # Already-read rows must keep their original read_at — the helper must scope to unread only.
+        assert Notification.objects.get(pk=already_read.pk).read_at == original_read_at
+
+    def test_mark_all_read_for_bumps_modified(self, member_user):
+        n = Notification.objects.create(recipient=member_user, event_type="e", subject="s", body="b", link_url="/")
+        original_modified = n.modified
+        Notification.mark_all_read_for(member_user)
+        n.refresh_from_db()
+        assert n.modified > original_modified
+
 
 @pytest.mark.django_db
 class TestNotificationDelivery:

--- a/tests/unit_tests/notifications/test_views_bell.py
+++ b/tests/unit_tests/notifications/test_views_bell.py
@@ -24,3 +24,29 @@ class TestBellDropdown:
         content = response.content.decode()
         assert "msg14" in content
         assert "msg4" not in content  # 11th-newest excluded
+
+    def test_marks_all_unread_as_read_on_open(self, member_client, member_user):
+        for i in range(15):
+            Notification.objects.create(
+                recipient=member_user, event_type="schedule.finished", subject=f"n{i}", body="b", link_url="/"
+            )
+        response = member_client.get("/dashboard/notifications/bell/")
+        assert response.status_code == 200
+        assert Notification.objects.filter(recipient=member_user, read_at__isnull=True).count() == 0
+
+    def test_visible_rows_keep_unread_cue_on_first_open(self, member_client, member_user):
+        Notification.objects.create(
+            recipient=member_user, event_type="schedule.finished", subject="n", body="b", link_url="/"
+        )
+        response = member_client.get("/dashboard/notifications/bell/")
+        # Pins the fetch-before-update ordering — if the bulk update ran first, the green
+        # dot (bg-emerald-400) would be absent here.
+        assert "bg-emerald-400" in response.content.decode()
+
+    def test_does_not_touch_other_users_notifications(self, member_client, admin_user):
+        other = Notification.objects.create(
+            recipient=admin_user, event_type="schedule.finished", subject="other", body="b", link_url="/"
+        )
+        member_client.get("/dashboard/notifications/bell/")
+        other.refresh_from_db()
+        assert other.read_at is None


### PR DESCRIPTION
## Summary
- Opening the notification bell tray now bulk-marks every unread notification for the current user as read, so users don't have to click each item one by one.
- The visible list is materialised before the update so unread visual cues still render on first open; the badge clears on its next 10s poll.
- Extract `Notification.mark_all_read_for(user)` and reuse from both `BellDropdownView` and `MarkAllReadView`; the helper now also bumps `modified` (the prior in-place update silently skipped it).

## Test plan
- [x] `uv run pytest tests/unit_tests/notifications/` — 144 passed
- [x] `uv run ruff check daiv/notifications/ tests/unit_tests/notifications/` — clean
- [ ] Open the notification tray in a browser with unread notifications and verify (a) the green dots render on first open, (b) the badge clears within ~10s, (c) reopening shows no unread cues.

## Notes
- A reviewer raised that `BellDropdownView.get_context_data` performs an `UPDATE` on a `GET` (HTTP semantics). The endpoint is only triggered by the bell button's HTMX click handler — not a navigable href — so prefetch/preview exposure is minimal in practice. Happy to convert to POST in a follow-up if preferred.