### PR TITLE
chore(lint): Add djade template formatter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,3 +19,9 @@ repos:
     rev: v2.20.0
     hooks:
       - id: pyproject-fmt
+
+  - repo: https://github.com/adamchainz/djade-pre-commit
+    rev: "1.9.0"
+    hooks:
+      - id: djade
+        args: [--target-version, "6.0"]

--- a/Makefile
+++ b/Makefile
@@ -49,11 +49,13 @@ lint-check:
 lint-format:
 	uv run --only-group=dev ruff format . --check
 	uv run --only-group=dev pyproject-fmt pyproject.toml --check
+	git ls-files -z -- '*templates/*.html' | xargs -0r uv run --only-group=dev djade --target-version 6.0 --check
 
 lint-fix:
 	uv run --only-group=dev ruff check . --fix
 	uv run --only-group=dev ruff format .
 	uv run --only-group=dev pyproject-fmt pyproject.toml
+	git ls-files -z -- '*templates/*.html' | xargs -0r uv run --only-group=dev djade --target-version 6.0
 
 lint-typing:
 	uv run --only-group=dev ty check daiv

--- a/daiv/accounts/templates/account/confirm_login_code.html
+++ b/daiv/accounts/templates/account/confirm_login_code.html
@@ -1,9 +1,12 @@
 {% extends "base.html" %}
-{% load static icon_tags %}
+{% load icon_tags static %}
 
 {% block title %}Enter code — DAIV{% endblock %}
+
 {% block meta_description %}{% endblock %}
+
 {% block meta_robots %}<meta name="robots" content="noindex">{% endblock %}
+
 {% block open_graph %}{% endblock %}
 
 {% block content %}
@@ -60,4 +63,4 @@
         </p>
     </div>
 </div>
-{% endblock %}
+{% endblock content %}

--- a/daiv/accounts/templates/account/email/login_code_message.html
+++ b/daiv/accounts/templates/account/email/login_code_message.html
@@ -3,10 +3,10 @@
 
 {% block content %}
 <h1 style="margin: 0 0 8px; font-size: 20px; font-weight: 600; color: #111827;">
-    {% trans "Sign-In Code" %}
+    {% translate "Sign-In Code" %}
 </h1>
 <p style="margin: 0 0 20px; font-size: 14px; line-height: 1.6; color: #6b7280;">
-    {% trans "Enter the code below in your open browser window to complete sign-in." %}
+    {% translate "Enter the code below in your open browser window to complete sign-in." %}
 </p>
 <table role="presentation" cellpadding="0" cellspacing="0" width="100%">
     <tr>
@@ -18,6 +18,6 @@
     </tr>
 </table>
 <p style="margin: 20px 0 0; font-size: 13px; line-height: 1.6; color: #9ca3af;">
-    {% trans "This code expires in 5 minutes. If you did not request this, you can safely ignore this email." %}
+    {% translate "This code expires in 5 minutes. If you did not request this, you can safely ignore this email." %}
 </p>
-{% endblock %}
+{% endblock content %}

--- a/daiv/accounts/templates/account/login.html
+++ b/daiv/accounts/templates/account/login.html
@@ -1,9 +1,12 @@
 {% extends "base.html" %}
-{% load static socialaccount icon_tags %}
+{% load icon_tags socialaccount static %}
 
 {% block title %}Sign in — DAIV{% endblock %}
+
 {% block meta_description %}{% endblock %}
+
 {% block meta_robots %}<meta name="robots" content="noindex">{% endblock %}
+
 {% block open_graph %}{% endblock %}
 
 {% block content %}
@@ -88,4 +91,4 @@
         </form>
     </div>
 </div>
-{% endblock %}
+{% endblock content %}

--- a/daiv/accounts/templates/account/logout.html
+++ b/daiv/accounts/templates/account/logout.html
@@ -1,8 +1,11 @@
 {% extends "base.html" %}
 
 {% block title %}Sign out — DAIV{% endblock %}
+
 {% block meta_description %}{% endblock %}
+
 {% block meta_robots %}<meta name="robots" content="noindex">{% endblock %}
+
 {% block open_graph %}{% endblock %}
 
 {% block content %}
@@ -23,4 +26,4 @@
         </form>
     </div>
 </div>
-{% endblock %}
+{% endblock content %}

--- a/daiv/accounts/templates/account/request_login_code.html
+++ b/daiv/accounts/templates/account/request_login_code.html
@@ -2,8 +2,11 @@
 {% load static %}
 
 {% block title %}Sign in with email — DAIV{% endblock %}
+
 {% block meta_description %}{% endblock %}
+
 {% block meta_robots %}<meta name="robots" content="noindex">{% endblock %}
+
 {% block open_graph %}{% endblock %}
 
 {% block content %}
@@ -47,4 +50,4 @@
         </p>
     </div>
 </div>
-{% endblock %}
+{% endblock content %}

--- a/daiv/accounts/templates/account/signup_closed.html
+++ b/daiv/accounts/templates/account/signup_closed.html
@@ -1,9 +1,12 @@
 {% extends "base.html" %}
-{% load static icon_tags %}
+{% load icon_tags static %}
 
 {% block title %}Sign up closed — DAIV{% endblock %}
+
 {% block meta_description %}{% endblock %}
+
 {% block meta_robots %}<meta name="robots" content="noindex">{% endblock %}
+
 {% block open_graph %}{% endblock %}
 
 {% block content %}
@@ -33,4 +36,4 @@
         </a>
     </div>
 </div>
-{% endblock %}
+{% endblock content %}

--- a/daiv/accounts/templates/accounts/api_keys.html
+++ b/daiv/accounts/templates/accounts/api_keys.html
@@ -1,7 +1,8 @@
 {% extends "base_app.html" %}
-{% load static icon_tags %}
+{% load icon_tags static %}
 
 {% block title %}API Keys — DAIV{% endblock %}
+
 {% block container_width %}max-w-screen-2xl{% endblock %}
 
 {% block app_content %}
@@ -91,4 +92,4 @@
             </div>
             {% endif %}
         </div>
-{% endblock %}
+{% endblock app_content %}

--- a/daiv/accounts/templates/accounts/dashboard.html
+++ b/daiv/accounts/templates/accounts/dashboard.html
@@ -1,7 +1,8 @@
 {% extends "base_app.html" %}
-{% load static dashboard_tags i18n icon_tags %}
+{% load dashboard_tags i18n icon_tags static %}
 
 {% block title %}Dashboard — DAIV{% endblock %}
+
 {% block container_width %}max-w-screen-2xl{% endblock %}
 
 {% block app_content %}
@@ -171,4 +172,4 @@
     </div>
 </section>
 {% endif %}
-{% endblock %}
+{% endblock app_content %}

--- a/daiv/accounts/templates/accounts/emails/welcome.html
+++ b/daiv/accounts/templates/accounts/emails/welcome.html
@@ -3,31 +3,31 @@
 
 {% block content %}
 <h1 style="margin: 0 0 8px; font-size: 20px; font-weight: 600; color: #111827;">
-    {% trans "Welcome to DAIV" %}
+    {% translate "Welcome to DAIV" %}
 </h1>
 <p style="margin: 0 0 20px; font-size: 14px; line-height: 1.6; color: #6b7280;">
-    {% if user.name %}{% blocktrans with name=user.name %}Hi {{ name }}, you've been invited by an administrator.{% endblocktrans %}{% else %}{% trans "Hi, you've been invited by an administrator." %}{% endif %}
+    {% if user.name %}{% blocktranslate with name=user.name %}Hi {{ name }}, you've been invited by an administrator.{% endblocktranslate %}{% else %}{% translate "Hi, you've been invited by an administrator." %}{% endif %}
 </p>
 <p style="margin: 0 0 24px; font-size: 14px; line-height: 1.6; color: #6b7280;">
-    {% blocktrans with email=user.email %}<strong style="color: #111827;">{{ email }}</strong>{% endblocktrans %}
+    {% blocktranslate with email=user.email %}<strong style="color: #111827;">{{ email }}</strong>{% endblocktranslate %}
 </p>
 <p style="margin: 0 0 24px; font-size: 14px; line-height: 1.6; color: #6b7280;">
-    {% trans "Sign in with a one-time code sent to your email, or use your GitHub or GitLab account if it's linked to the same email." %}
+    {% translate "Sign in with a one-time code sent to your email, or use your GitHub or GitLab account if it's linked to the same email." %}
 </p>
 <table role="presentation" cellpadding="0" cellspacing="0">
     <tr>
         <td style="border-radius: 8px; background-color: #111827;">
             <a href="{{ login_url }}"
                style="display: inline-block; padding: 12px 24px; font-size: 14px; font-weight: 600; color: #ffffff; text-decoration: none;">
-                {% trans "Sign in to DAIV" %}
+                {% translate "Sign in to DAIV" %}
             </a>
         </td>
     </tr>
 </table>
-{% endblock %}
+{% endblock content %}
 
 {% block footer %}
 <p style="margin: 0; font-size: 12px; color: #9ca3af;">
-    {% blocktrans with url=login_url %}If the button doesn't work, copy and paste this link: {{ url }}{% endblocktrans %}
+    {% blocktranslate with url=login_url %}If the button doesn't work, copy and paste this link: {{ url }}{% endblocktranslate %}
 </p>
-{% endblock %}
+{% endblock footer %}

--- a/daiv/accounts/templates/accounts/homepage.html
+++ b/daiv/accounts/templates/accounts/homepage.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load static icon_tags %}
+{% load icon_tags static %}
 
 {% block title %}DAIV — Open-source async SWE agent for your Git platform{% endblock %}
 
@@ -22,7 +22,7 @@
   }
 }
 </script>
-{% endblock %}
+{% endblock head_extra %}
 
 {% block content %}
 <!-- Navigation -->
@@ -360,4 +360,4 @@
         </div>
     </div>
 </footer>
-{% endblock %}
+{% endblock content %}

--- a/daiv/accounts/templates/accounts/user_confirm_delete.html
+++ b/daiv/accounts/templates/accounts/user_confirm_delete.html
@@ -1,12 +1,13 @@
 {% extends "base_app.html" %}
-{% load static icon_tags %}
+{% load icon_tags static %}
 
 {% block title %}Delete User — DAIV{% endblock %}
+
 {% block container_width %}max-w-3xl{% endblock %}
 
 {% block breadcrumb %}
 {% include "accounts/_breadcrumb.html" with crumbs=breadcrumbs %}
-{% endblock %}
+{% endblock breadcrumb %}
 
 {% block app_content %}
 <div class="animate-fade-up">
@@ -38,4 +39,4 @@
         </a>
     </form>
 </div>
-{% endblock %}
+{% endblock app_content %}

--- a/daiv/accounts/templates/accounts/user_form.html
+++ b/daiv/accounts/templates/accounts/user_form.html
@@ -2,11 +2,12 @@
 {% load static %}
 
 {% block title %}{% if object %}Edit User{% else %}Create User{% endif %} — DAIV{% endblock %}
+
 {% block container_width %}max-w-3xl{% endblock %}
 
 {% block breadcrumb %}
 {% include "accounts/_breadcrumb.html" with crumbs=breadcrumbs %}
-{% endblock %}
+{% endblock breadcrumb %}
 
 {% block app_content %}
 <div class="animate-fade-up">
@@ -91,4 +92,4 @@
                 {% endif %}
             </div>
         </form>
-{% endblock %}
+{% endblock app_content %}

--- a/daiv/accounts/templates/accounts/users.html
+++ b/daiv/accounts/templates/accounts/users.html
@@ -2,6 +2,7 @@
 {% load static %}
 
 {% block title %}Users — DAIV{% endblock %}
+
 {% block container_width %}max-w-screen-2xl{% endblock %}
 
 {% block app_content %}
@@ -79,4 +80,4 @@
     </div>
     {% endif %}
 </div>
-{% endblock %}
+{% endblock app_content %}

--- a/daiv/accounts/templates/base.html
+++ b/daiv/accounts/templates/base.html
@@ -12,7 +12,7 @@
     <meta property="og:title" content="DAIV — Open-source async SWE agent for your Git platform">
     <meta property="og:description" content="DAIV integrates directly with GitLab and GitHub through webhooks. Create an issue, get a merge request. No context switching, no separate tools.">
     <meta property="og:site_name" content="DAIV">
-    {% endblock %}
+    {% endblock open_graph %}
     <meta name="twitter:card" content="summary">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/daiv/accounts/templates/base_app.html
+++ b/daiv/accounts/templates/base_app.html
@@ -47,4 +47,4 @@
     </main>
   </div>
 </div>
-{% endblock %}
+{% endblock content %}

--- a/daiv/accounts/templates/oauth2_provider/authorize.html
+++ b/daiv/accounts/templates/oauth2_provider/authorize.html
@@ -1,9 +1,12 @@
 {% extends "base.html" %}
-{% load static i18n icon_tags %}
+{% load i18n icon_tags static %}
 
 {% block title %}Authorize — DAIV{% endblock %}
+
 {% block meta_description %}{% endblock %}
+
 {% block meta_robots %}<meta name="robots" content="noindex">{% endblock %}
+
 {% block open_graph %}{% endblock %}
 
 {% block content %}
@@ -35,7 +38,7 @@
             <a href="/">
                 <img src="{% static 'accounts/img/logo.svg' %}" alt="DAIV" class="h-10">
             </a>
-            <p class="mt-4 text-[15px] font-light tracking-wide text-gray-400">{% trans "Authorization request" %}</p>
+            <p class="mt-4 text-[15px] font-light tracking-wide text-gray-400">{% translate "Authorization request" %}</p>
         </div>
 
         <!-- Application info -->
@@ -47,7 +50,7 @@
                 </div>
                 <div class="min-w-0">
                     <h2 class="text-base font-semibold text-white truncate">{{ application.name }}</h2>
-                    <p class="mt-0.5 text-sm text-gray-400">{% trans "wants to access your account" %}</p>
+                    <p class="mt-0.5 text-sm text-gray-400">{% translate "wants to access your account" %}</p>
                 </div>
             </div>
 
@@ -56,7 +59,7 @@
 
             <!-- Permissions -->
             <div>
-                <p class="mb-3 text-[13px] font-medium uppercase tracking-[0.15em] text-gray-400">{% trans "Permissions requested" %}</p>
+                <p class="mb-3 text-[13px] font-medium uppercase tracking-[0.15em] text-gray-400">{% translate "Permissions requested" %}</p>
                 <ul class="space-y-2.5">
                     {% for scope in scopes_descriptions %}
                     <li class="flex items-center gap-3">
@@ -75,7 +78,7 @@
                 <div class="flex items-start gap-2.5">
                     {% icon "link" "mt-0.5 h-3.5 w-3.5 shrink-0 text-gray-400" %}
                     <p class="text-[13px] leading-relaxed text-gray-400">
-                        {% trans "Will redirect to" %}
+                        {% translate "Will redirect to" %}
                         <span class="font-medium text-gray-400 break-all">{{ application.redirect_uris }}</span>
                     </p>
                 </div>
@@ -102,17 +105,17 @@
             {% endfor %}
 
             <button type="submit" class="btn-secondary flex-1 px-4 py-3">
-                {% trans "Deny" %}
+                {% translate "Deny" %}
             </button>
             <button type="submit" name="allow" value="Authorize"
                     class="btn-primary flex-1 px-4 py-3">
-                {% trans "Authorize" %}
+                {% translate "Authorize" %}
             </button>
         </form>
 
         <!-- Fine print -->
         <p class="animate-fade-up mt-5 text-center text-[13px] font-light tracking-wide text-gray-400" style="animation-delay: 220ms">
-            {% trans "Authorizing will grant this application access to your DAIV account" %}
+            {% translate "Authorizing will grant this application access to your DAIV account" %}
         </p>
 
         {% else %}
@@ -133,4 +136,4 @@
         {% endif %}
     </div>
 </div>
-{% endblock %}
+{% endblock content %}

--- a/daiv/accounts/templates/socialaccount/authentication_error.html
+++ b/daiv/accounts/templates/socialaccount/authentication_error.html
@@ -1,9 +1,12 @@
 {% extends "base.html" %}
-{% load static icon_tags %}
+{% load icon_tags static %}
 
 {% block title %}Authentication error — DAIV{% endblock %}
+
 {% block meta_description %}{% endblock %}
+
 {% block meta_robots %}<meta name="robots" content="noindex">{% endblock %}
+
 {% block open_graph %}{% endblock %}
 
 {% block content %}
@@ -33,4 +36,4 @@
         </a>
     </div>
 </div>
-{% endblock %}
+{% endblock content %}

--- a/daiv/accounts/templates/socialaccount/login.html
+++ b/daiv/accounts/templates/socialaccount/login.html
@@ -2,8 +2,11 @@
 {% load static %}
 
 {% block title %}Sign in via {{ provider.name }} — DAIV{% endblock %}
+
 {% block meta_description %}{% endblock %}
+
 {% block meta_robots %}<meta name="robots" content="noindex">{% endblock %}
+
 {% block open_graph %}{% endblock %}
 
 {% block content %}
@@ -31,4 +34,4 @@
         </p>
     </div>
 </div>
-{% endblock %}
+{% endblock content %}

--- a/daiv/accounts/templates/socialaccount/login_cancelled.html
+++ b/daiv/accounts/templates/socialaccount/login_cancelled.html
@@ -2,8 +2,11 @@
 {% load static %}
 
 {% block title %}Sign in cancelled — DAIV{% endblock %}
+
 {% block meta_description %}{% endblock %}
+
 {% block meta_robots %}<meta name="robots" content="noindex">{% endblock %}
+
 {% block open_graph %}{% endblock %}
 
 {% block content %}
@@ -30,4 +33,4 @@
         </a>
     </div>
 </div>
-{% endblock %}
+{% endblock content %}

--- a/daiv/activity/templates/activity/_agent_run_fields.html
+++ b/daiv/activity/templates/activity/_agent_run_fields.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-{% trans "Repository already in the list: __LABEL__." as conflict_message_template %}
+{% translate "Repository already in the list: __LABEL__." as conflict_message_template %}
 
 <div x-data='promptBox({
         initialRepos: {{ form.repos.value|default:"[]" }},
@@ -11,7 +11,7 @@
      })'
      class="relative rounded-2xl border border-white/[0.06] bg-white/[0.02] transition-colors focus-within:border-white/[0.18]">
 
-    <label for="id_prompt" class="sr-only">{% trans "Prompt" %}</label>
+    <label for="id_prompt" class="sr-only">{% translate "Prompt" %}</label>
 
     <textarea name="prompt" id="id_prompt" rows="2" required
               x-ref="prompt"
@@ -19,7 +19,7 @@
               x-init="$nextTick(() => autosize($refs.prompt))"
               @keydown.meta.enter.prevent="$el.form?.requestSubmit()"
               @keydown.ctrl.enter.prevent="$el.form?.requestSubmit()"
-              placeholder="{% trans 'Describe what the agent should do in each run...' %}"
+              placeholder="{% translate 'Describe what the agent should do in each run...' %}"
               class="block w-full resize-none !border-0 !bg-transparent !px-5 !pt-4 !pb-3 !text-[15px] !text-white placeholder-gray-500 focus:!ring-0">{{ form.prompt.value|default:'' }}</textarea>
 
     <div class="border-t border-white/[0.05]"></div>
@@ -29,8 +29,8 @@
         {% include "codebase/_repo_picker.html" with with_x_data=False initial_repos=form.repos.value|default:"[]" max_repos=20 show_conflict_message=False required=repos_required %}
 
         <label class="inline-flex shrink-0 cursor-pointer items-center gap-2 text-[13px] text-gray-400"
-               title="{% trans 'More capable model with thinking set to high.' %}">
-            <span>{% trans "Max" %}</span>
+               title="{% translate 'More capable model with thinking set to high.' %}">
+            <span>{% translate "Max" %}</span>
             <span class="relative inline-block h-[18px] w-[30px] shrink-0 rounded-full bg-white/[0.1] transition-colors"
                   :class="useMax && '!bg-white'">
                 <span class="absolute left-[2px] top-[2px] h-[14px] w-[14px] rounded-full bg-white transition-all"

--- a/daiv/activity/templates/activity/activity_detail.html
+++ b/daiv/activity/templates/activity/activity_detail.html
@@ -2,17 +2,18 @@
 {% load activity_tags static %}
 
 {% block title %}{% activity_title activity %} — DAIV{% endblock %}
+
 {% block container_width %}max-w-screen-2xl{% endblock %}
 
 {% block alpine_plugins %}
 {% if is_in_flight %}
 <script defer src="{% static 'activity/js/activity-stream.js' %}"></script>
 {% endif %}
-{% endblock %}
+{% endblock alpine_plugins %}
 
 {% block breadcrumb %}
 {% include "accounts/_breadcrumb.html" with crumbs=breadcrumbs %}
-{% endblock %}
+{% endblock breadcrumb %}
 
 {% block app_content %}
 <div {% if is_in_flight %}x-data="activityDetail('{% url "activity_stream" %}', '{{ activity.pk }}', '{{ activity.status }}')"{% endif %}>
@@ -50,4 +51,4 @@
         </aside>
     </div>
 </div>
-{% endblock %}
+{% endblock app_content %}

--- a/daiv/activity/templates/activity/activity_list.html
+++ b/daiv/activity/templates/activity/activity_list.html
@@ -2,6 +2,7 @@
 {% load activity_tags dashboard_tags humanize i18n icon_tags l10n static %}
 
 {% block title %}Agent Activity — DAIV{% endblock %}
+
 {% block container_width %}max-w-screen-2xl{% endblock %}
 
 {% block alpine_plugins %}
@@ -10,7 +11,7 @@
         crossorigin="anonymous"></script>
 <script defer src="{% static 'codebase/js/repo-search.js' %}"></script>
 <script defer src="{% static 'activity/js/activity-stream.js' %}"></script>
-{% endblock %}
+{% endblock alpine_plugins %}
 
 {% block app_content %}
 <div x-data="activityStream('{% url "activity_stream" %}', '{{ in_flight_ids }}')">
@@ -98,10 +99,10 @@
 
                 {% if current_batch %}
                 <span class="inline-flex items-center gap-1 rounded-full border border-blue-400/30 bg-blue-500/10 py-1 pl-3 pr-1 text-[13px] font-medium text-blue-300">
-                    <span>{% blocktrans with id=current_batch_short %}Batch {{ id }}{% endblocktrans %}</span>
+                    <span>{% blocktranslate with id=current_batch_short %}Batch {{ id }}{% endblocktranslate %}</span>
                     <a href="?{% querystring_without 'batch' 'page' %}"
-                       aria-label="{% trans 'Clear batch filter' %}"
-                       title="{% trans 'Clear batch filter' %}"
+                       aria-label="{% translate 'Clear batch filter' %}"
+                       title="{% translate 'Clear batch filter' %}"
                        class="inline-flex h-5 w-5 items-center justify-center rounded-full text-blue-300/70 hover:bg-white/[0.05] hover:text-white">×</a>
                 </span>
                 {% endif %}
@@ -178,4 +179,4 @@
             {% endif %}
         </div>
 </div>
-{% endblock %}
+{% endblock app_content %}

--- a/daiv/activity/templates/activity/agent_run_form.html
+++ b/daiv/activity/templates/activity/agent_run_form.html
@@ -2,15 +2,16 @@
 {% load i18n static %}
 
 {% block title %}{% if source_activity %}Retry run{% else %}Start a run{% endif %} — DAIV{% endblock %}
+
 {% block container_width %}max-w-3xl{% endblock %}
 
 {% block alpine_plugins %}
 <script defer src="{% static 'activity/js/prompt-box.js' %}"></script>
-{% endblock %}
+{% endblock alpine_plugins %}
 
 {% block breadcrumb %}
 {% include "accounts/_breadcrumb.html" with crumbs=breadcrumbs %}
-{% endblock %}
+{% endblock breadcrumb %}
 
 {% block app_content %}
 <div class="animate-fade-up">
@@ -56,4 +57,4 @@
         </a>
     </div>
 </form>
-{% endblock %}
+{% endblock app_content %}

--- a/daiv/chat/templates/chat/_composer.html
+++ b/daiv/chat/templates/chat/_composer.html
@@ -10,7 +10,7 @@
             class="chat-jump"
             x-show="showJumpToLatest"
             @click="scrollToBottom({force: true})"
-            x-transition.opacity>↓ {% trans "Jump to latest" %}</button>
+            x-transition.opacity>↓ {% translate "Jump to latest" %}</button>
 
     {% comment %}
     Chip is suppressed while the user is still composing their first prompt — the picker's
@@ -51,16 +51,16 @@
               <path d="M6 8.5v7"/>
               <path d="M6 6h7a5 5 0 015 5v4.5"/>
             </svg>
-            <span x-text="thread.merge_request.id ? '!' + thread.merge_request.id : '{% trans "MR" %}'"></span>
+            <span x-text="thread.merge_request.id ? '!' + thread.merge_request.id : '{% translate "MR" %}'"></span>
             <span x-show="thread.merge_request.draft"
                   class="repo-chip__badge"
-                  x-cloak>{% trans "draft" %}</span>
+                  x-cloak>{% translate "draft" %}</span>
           </span>
         </a>
       </template>
     </div>
 
-    <label for="chat_prompt" class="sr-only">{% trans "Message DAIV" %}</label>
+    <label for="chat_prompt" class="sr-only">{% translate "Message DAIV" %}</label>
     <textarea id="chat_prompt"
               x-ref="prompt"
               x-model="draftMessage"
@@ -69,21 +69,21 @@
               @keydown.ctrl.enter.prevent="submit()"
               rows="2"
               :disabled="(streaming || resuming)"
-              placeholder="{% trans 'Describe the change, the bug, or what to explore…' %}"
+              placeholder="{% translate 'Describe the change, the bug, or what to explore…' %}"
               class="chat-composer__textarea"></textarea>
 
     <div class="chat-composer__actions">
       <div class="chat-composer__hint">
         <kbd class="chat-composer__kbd">⌘</kbd>
         <kbd class="chat-composer__kbd">↵</kbd>
-        <span>{% trans "to send" %}</span>
+        <span>{% translate "to send" %}</span>
       </div>
       <div style="display: inline-flex; gap: 8px;">
         <button type="button" x-show="(streaming || resuming)" @click="stop()"
-                class="chat-composer__btn chat-composer__btn--stop">{% trans "Stop" %}</button>
+                class="chat-composer__btn chat-composer__btn--stop">{% translate "Stop" %}</button>
         <button type="submit" :disabled="(streaming || resuming) || !canSend()"
                 class="chat-composer__btn chat-composer__btn--send">
-          <span x-text="(streaming || resuming) ? '{% trans 'Sending…' %}' : '{% trans 'Send' %}'"></span>
+          <span x-text="(streaming || resuming) ? '{% translate 'Sending…' %}' : '{% translate 'Send' %}'"></span>
           <svg x-show="!(streaming || resuming)" class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
             <path d="M10.22 16.78a.75.75 0 0 1-1.06-1.06l4.47-4.47H4a.75.75 0 0 1 0-1.5h9.63l-4.47-4.47a.75.75 0 1 1 1.06-1.06l5.75 5.75a.75.75 0 0 1 0 1.06l-5.75 5.75Z"/>
           </svg>
@@ -93,6 +93,6 @@
   </form>
 
   <p class="chat-dock__disclaimer">
-    {% trans "DAIV can make mistakes. Verify important information." %}
+    {% translate "DAIV can make mistakes. Verify important information." %}
   </p>
 </div>

--- a/daiv/chat/templates/chat/_rail.html
+++ b/daiv/chat/templates/chat/_rail.html
@@ -1,8 +1,8 @@
 {% load i18n %}
-<aside class="chat-rail" aria-label="{% trans 'Session context' %}">
+<aside class="chat-rail" aria-label="{% translate 'Session context' %}">
   <div class="chat-rail__block">
     <div class="chat-rail__label">
-      {% trans "Todos" %} <span x-show="latestTodos.length" x-text="`· ${todosDone}/${latestTodos.length}`"></span>
+      {% translate "Todos" %} <span x-show="latestTodos.length" x-text="`· ${todosDone}/${latestTodos.length}`"></span>
     </div>
     <template x-if="!latestTodos.length">
       <div style="color: #64748b;">—</div>
@@ -16,7 +16,7 @@
   </div>
 
   <div class="chat-rail__block">
-    <div class="chat-rail__label">{% trans "Files changed" %}</div>
+    <div class="chat-rail__label">{% translate "Files changed" %}</div>
     <template x-if="!filesTouched.length">
       <div style="color: #64748b;">—</div>
     </template>
@@ -33,7 +33,7 @@
             style="color: #64748b; padding-top: 6px;"
             x-show="filesTouched.length > filesTouchedLimit"
             @click="filesTouchedLimit = filesTouched.length">
-      {% trans "Show all" %} (<span x-text="filesTouched.length"></span>)
+      {% translate "Show all" %} (<span x-text="filesTouched.length"></span>)
     </button>
   </div>
 </aside>

--- a/daiv/chat/templates/chat/chat_detail.html
+++ b/daiv/chat/templates/chat/chat_detail.html
@@ -1,7 +1,8 @@
 {% extends "base_app.html" %}
-{% load static i18n %}
+{% load i18n static %}
 
 {% block title %}{% if thread.title %}{{ thread.title }} — {% endif %}DAIV Chat{% endblock %}
+
 {% block container_width %}max-w-6xl flex flex-col min-h-full{% endblock %}
 
 {% block head_extra %}
@@ -9,7 +10,7 @@
   <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:ital,wght@0,400;0,500;0,600;1,400&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="{% static 'chat/css/diff.css' %}">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11.11.1/build/styles/github-dark-dimmed.min.css">
-{% endblock %}
+{% endblock head_extra %}
 
 {% block alpine_plugins %}
   <script defer src="https://cdn.jsdelivr.net/npm/marked@18.0.2/lib/marked.umd.min.js"></script>
@@ -20,7 +21,7 @@
   <script defer src="{% static 'chat/js/tool-renderers.js' %}"></script>
   <script defer src="{% static 'activity/js/prompt-box.js' %}"></script>
   <script defer src="{% static 'chat/js/chat-stream.js' %}"></script>
-{% endblock %}
+{% endblock alpine_plugins %}
 
 {% block breadcrumb %}{% include "accounts/_breadcrumb.html" %}{% endblock %}
 
@@ -49,8 +50,8 @@
          :class="{ 'chat-column--empty': !thread && turns.length === 0 }">
       {% if expired %}
         <div class="mb-4 flex flex-wrap items-center justify-between gap-3 rounded-lg border border-amber-500/25 bg-amber-500/[0.08] px-4 py-3 text-sm text-amber-200">
-          <span>{% trans "This conversation's state has expired. Start a new chat to continue." %}</span>
-          <a href="{% url 'chat_new' %}" class="btn-primary">{% trans "New chat" %}</a>
+          <span>{% translate "This conversation's state has expired. Start a new chat to continue." %}</span>
+          <a href="{% url 'chat_new' %}" class="btn-primary">{% translate "New chat" %}</a>
         </div>
       {% endif %}
 
@@ -71,14 +72,14 @@
         {# Empty state — pick a repo first, then the composer fades in. #}
         <template x-if="!thread && turns.length === 0">
           <div class="chat-hero">
-            <span class="chat-hero__eyebrow">{% trans "New chat" %}</span>
-            <h1 class="chat-hero__title">{% trans "What are we building today?" %}</h1>
+            <span class="chat-hero__eyebrow">{% translate "New chat" %}</span>
+            <h1 class="chat-hero__title">{% translate "What are we building today?" %}</h1>
             <div class="chat-hero__subtitle-stack">
               <p class="chat-hero__subtitle" :class="{ 'chat-hero__subtitle--hidden': draftRepoId }">
-                {% trans "Pick a repository to get started." %}
+                {% translate "Pick a repository to get started." %}
               </p>
               <p class="chat-hero__subtitle" :class="{ 'chat-hero__subtitle--hidden': !draftRepoId }">
-                {% trans "Ready when you are — describe the change, the bug, or what to explore." %}
+                {% translate "Ready when you are — describe the change, the bug, or what to explore." %}
               </p>
             </div>
             <div class="chat-hero__picker">
@@ -155,7 +156,7 @@
                 <p class="text-sm text-red-400 mt-2" x-text="turn.error"></p>
               </template>
               <template x-if="turn.aborted">
-                <p class="text-sm text-gray-500 mt-2">{% trans "You stopped this run." %}</p>
+                <p class="text-sm text-gray-500 mt-2">{% translate "You stopped this run." %}</p>
               </template>
             </div>
           </article>
@@ -175,4 +176,4 @@
 
     {% include "chat/_rail.html" %}
   </div>
-{% endblock %}
+{% endblock app_content %}

--- a/daiv/chat/templates/chat/chat_list.html
+++ b/daiv/chat/templates/chat/chat_list.html
@@ -5,8 +5,8 @@
 
 {% block app_content %}
 <div class="mb-6 flex items-center justify-between">
-  <h1 class="text-2xl font-semibold text-white">{% trans "Chat" %}</h1>
-  <a href="{% url 'chat_new' %}" class="btn-primary">{% trans "New chat" %}</a>
+  <h1 class="text-2xl font-semibold text-white">{% translate "Chat" %}</h1>
+  <a href="{% url 'chat_new' %}" class="btn-primary">{% translate "New chat" %}</a>
 </div>
 
 {% if threads %}
@@ -19,9 +19,9 @@
             {% if t.title %}
             <span class="truncate font-medium text-white">{{ t.title }}</span>
             {% else %}
-            <span class="truncate text-sm italic text-gray-500">{% trans "generating title…" %}</span>
+            <span class="truncate text-sm italic text-gray-500">{% translate "generating title…" %}</span>
             {% endif %}
-            <span class="shrink-0 text-xs text-gray-500">{{ t.last_active_at|timesince }} {% trans "ago" %}</span>
+            <span class="shrink-0 text-xs text-gray-500">{{ t.last_active_at|timesince }} {% translate "ago" %}</span>
           </div>
           <div class="mt-1.5 flex flex-wrap items-center gap-1.5">
             <span class="inline-flex items-center rounded-md border border-white/[0.08] bg-white/[0.04] px-1.5 py-0.5 text-xs text-gray-400">{{ t.repo_id }}</span>
@@ -30,7 +30,7 @@
             {% endif %}
             {% if t.active_run_id %}
             <span class="inline-flex items-center gap-1 text-xs text-green-400">
-              <span class="h-1.5 w-1.5 rounded-full bg-green-400"></span>{% trans "active" %}
+              <span class="h-1.5 w-1.5 rounded-full bg-green-400"></span>{% translate "active" %}
             </span>
             {% endif %}
           </div>
@@ -41,8 +41,8 @@
   {% include "accounts/_pagination.html" %}
 {% else %}
   <div class="rounded-xl border border-dashed border-white/[0.08] p-12 text-center">
-    <p class="text-gray-400">{% trans "No conversations yet." %}</p>
-    <a href="{% url 'chat_new' %}" class="btn-primary mt-4 inline-flex">{% trans "Start a chat" %}</a>
+    <p class="text-gray-400">{% translate "No conversations yet." %}</p>
+    <a href="{% url 'chat_new' %}" class="btn-primary mt-4 inline-flex">{% translate "Start a chat" %}</a>
   </div>
 {% endif %}
-{% endblock %}
+{% endblock app_content %}

--- a/daiv/codebase/templates/codebase/_branch_picker_list.html
+++ b/daiv/codebase/templates/codebase/_branch_picker_list.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 {% if error %}
-<ul><li class="px-3 py-2 text-[15px] text-red-400">{% trans "Could not load branches." %}</li></ul>
+<ul><li class="px-3 py-2 text-[15px] text-red-400">{% translate "Could not load branches." %}</li></ul>
 {% else %}
 <ul>
 {% for branch in branches %}
@@ -13,7 +13,7 @@
     </button>
   </li>
 {% empty %}
-  <li class="px-3 py-2 text-[15px] text-gray-400">{% trans "No branches found." %}</li>
+  <li class="px-3 py-2 text-[15px] text-gray-400">{% translate "No branches found." %}</li>
 {% endfor %}
 </ul>
 {% endif %}

--- a/daiv/codebase/templates/codebase/_repo_picker.html
+++ b/daiv/codebase/templates/codebase/_repo_picker.html
@@ -1,11 +1,11 @@
 {% load i18n icon_tags %}
 {% url 'codebase:picker-repositories' as repo_picker_url %}
 {% url 'codebase:picker-branches' slug='__SLUG__' as branch_picker_template %}
-{% trans "Choose repository" as choose_repo_label %}
-{% trans "Search repositories..." as search_repos_placeholder %}
-{% trans "Search branches..." as search_branches_placeholder %}
-{% trans "default" as default_branch_label %}
-{% trans "Repository already in the list: __LABEL__." as conflict_message_template %}
+{% translate "Choose repository" as choose_repo_label %}
+{% translate "Search repositories..." as search_repos_placeholder %}
+{% translate "Search branches..." as search_branches_placeholder %}
+{% translate "default" as default_branch_label %}
+{% translate "Repository already in the list: __LABEL__." as conflict_message_template %}
 
 {% comment %}
 Reusable repo + branch picker. Renders the chip list, both popovers, and (optionally)
@@ -86,8 +86,8 @@ Parameters:
         <button type="button"
                 x-show="repos.length > 0 && repos.length < maxRepos"
                 @click.stop="openRepoPicker()"
-                aria-label="{% trans 'Add repository' %}"
-                title="{% trans 'Add repository' %}"
+                aria-label="{% translate 'Add repository' %}"
+                title="{% translate 'Add repository' %}"
                 class="inline-flex h-[26px] w-[26px] items-center justify-center rounded-full border border-white/[0.08] bg-white/[0.05] text-gray-400 hover:bg-white/[0.08] hover:text-white">
             <svg class="h-3.5 w-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
                 <path d="M12 5v14M5 12h14"/>

--- a/daiv/codebase/templates/codebase/_repo_picker_list.html
+++ b/daiv/codebase/templates/codebase/_repo_picker_list.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 {% if error %}
-<ul><li class="px-3 py-2 text-[15px] text-red-400">{% trans "Could not load repositories." %}</li></ul>
+<ul><li class="px-3 py-2 text-[15px] text-red-400">{% translate "Could not load repositories." %}</li></ul>
 {% else %}
 <ul>
 {% for repo in repos %}
@@ -15,7 +15,7 @@
     </button>
   </li>
 {% empty %}
-  <li class="px-3 py-2 text-[15px] text-gray-400">{% trans "No repositories found." %}</li>
+  <li class="px-3 py-2 text-[15px] text-gray-400">{% translate "No repositories found." %}</li>
 {% endfor %}
 </ul>
 {% endif %}

--- a/daiv/core/templates/core/_web_fetch_auth_headers_section.html
+++ b/daiv/core/templates/core/_web_fetch_auth_headers_section.html
@@ -1,13 +1,13 @@
 {% load i18n %}
 <div class="mt-6 border-t border-white/[0.06] pt-5">
     <div class="flex items-center justify-between">
-        <h3 class="text-sm font-semibold text-white">{% trans "Per-domain auth headers" %}</h3>
+        <h3 class="text-sm font-semibold text-white">{% translate "Per-domain auth headers" %}</h3>
         {% if web_fetch_auth_headers_env_locked %}
             {% include "core/_env_lock_badge.html" %}
         {% endif %}
     </div>
     <p class="mt-1 text-xs text-gray-400">
-        {% trans "Send custom HTTP headers when web_fetch contacts a domain. Match is exact (no subdomains)." %}
+        {% translate "Send custom HTTP headers when web_fetch contacts a domain. Match is exact (no subdomains)." %}
     </p>
 
     {% if web_fetch_auth_headers_env_locked %}
@@ -21,7 +21,7 @@
                     </div>
                 {% endfor %}
             {% empty %}
-                <p class="text-xs text-gray-500">{% trans "No headers configured via DAIV_WEB_FETCH_AUTH_HEADERS." %}</p>
+                <p class="text-xs text-gray-500">{% translate "No headers configured via DAIV_WEB_FETCH_AUTH_HEADERS." %}</p>
             {% endfor %}
         </div>
     {% else %}
@@ -33,9 +33,9 @@
             {% endif %}
             <div x-show="total > 0"
                  class="grid grid-cols-12 gap-3 mb-2 text-xs font-medium uppercase tracking-wide text-gray-400">
-                <div class="col-span-4">{% trans "Domain" %}</div>
-                <div class="col-span-3">{% trans "Header name" %}</div>
-                <div class="col-span-4">{% trans "Header value" %}</div>
+                <div class="col-span-4">{% translate "Domain" %}</div>
+                <div class="col-span-3">{% translate "Header name" %}</div>
+                <div class="col-span-4">{% translate "Header value" %}</div>
                 <div class="col-span-1"></div>
             </div>
             <div x-ref="rows" class="space-y-3">
@@ -47,7 +47,7 @@
                 {% include "core/web_fetch_auth_header_row.html" with row=web_fetch_auth_headers_formset.empty_form %}
             </template>
             <button type="button" class="btn-secondary mt-4" @click="addRow()">
-                {% trans "Add header" %}
+                {% translate "Add header" %}
             </button>
         </div>
     {% endif %}

--- a/daiv/core/templates/core/emails/base.html
+++ b/daiv/core/templates/core/emails/base.html
@@ -20,7 +20,7 @@
                             <p style="margin: 0; font-size: 12px; color: #9ca3af;">
                                 — DAIV
                             </p>
-                            {% endblock %}
+                            {% endblock footer %}
                         </td>
                     </tr>
                 </table>

--- a/daiv/core/templates/core/site_configuration.html
+++ b/daiv/core/templates/core/site_configuration.html
@@ -2,11 +2,12 @@
 {% load configuration_tags icon_tags static %}
 
 {% block title %}Configuration — DAIV{% endblock %}
+
 {% block container_width %}max-w-none{% endblock %}
 
 {% block alpine_plugins %}
 <script defer src="{% static 'core/js/web-fetch-auth-headers-formset.js' %}"></script>
-{% endblock %}
+{% endblock alpine_plugins %}
 
 {% block app_content %}
 <div class="animate-fade-up">
@@ -130,4 +131,4 @@
 
     sections.forEach(section => observer.observe(section));
 </script>
-{% endblock %}
+{% endblock app_content %}

--- a/daiv/core/templates/core/web_fetch_auth_header_row.html
+++ b/daiv/core/templates/core/web_fetch_auth_header_row.html
@@ -19,7 +19,7 @@
     <div class="col-span-4">
         {{ row.header_value }}
         {% if row.fields.header_value.secret_hint %}
-            <p class="mt-1 text-xs text-gray-400">{% trans "Stored:" %} <code>{{ row.fields.header_value.secret_hint }}</code></p>
+            <p class="mt-1 text-xs text-gray-400">{% translate "Stored:" %} <code>{{ row.fields.header_value.secret_hint }}</code></p>
         {% endif %}
         {% if row.errors.header_value %}
             <p class="mt-1 text-xs text-red-300">{{ row.errors.header_value.0 }}</p>
@@ -31,8 +31,8 @@
         <button type="button"
                 class="inline-flex h-9 w-9 items-center justify-center rounded-md text-gray-400 hover:bg-white/[0.06] hover:text-red-300 focus:outline-none focus:ring-2 focus:ring-red-400/40"
                 @click="removeRow($el.closest('[data-row]'))"
-                aria-label="{% trans 'Remove' %}"
-                title="{% trans 'Remove' %}">
+                aria-label="{% translate 'Remove' %}"
+                title="{% translate 'Remove' %}">
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="h-5 w-5" aria-hidden="true">
                 <path fill-rule="evenodd" d="M8.75 1A2.75 2.75 0 0 0 6 3.75v.443c-.795.077-1.584.176-2.365.298a.75.75 0 1 0 .23 1.482l.149-.022.841 10.518A2.75 2.75 0 0 0 7.596 19h4.807a2.75 2.75 0 0 0 2.742-2.53l.841-10.52.149.023a.75.75 0 0 0 .23-1.482A41.03 41.03 0 0 0 14 4.193V3.75A2.75 2.75 0 0 0 11.25 1h-2.5ZM10 4c.84 0 1.673.025 2.5.075V3.75c0-.69-.56-1.25-1.25-1.25h-2.5c-.69 0-1.25.56-1.25 1.25v.325C8.327 4.025 9.16 4 10 4ZM8.58 7.72a.75.75 0 0 0-1.5.06l.3 7.5a.75.75 0 1 0 1.5-.06l-.3-7.5Zm4.34.06a.75.75 0 1 0-1.5-.06l-.3 7.5a.75.75 0 1 0 1.5.06l.3-7.5Z" clip-rule="evenodd" />
             </svg>

--- a/daiv/notifications/templates/notifications/channels_page.html
+++ b/daiv/notifications/templates/notifications/channels_page.html
@@ -2,6 +2,7 @@
 {% load i18n %}
 
 {% block title %}{% translate "Notification channels" %} — DAIV{% endblock %}
+
 {% block container_width %}max-w-3xl{% endblock %}
 
 {% block app_content %}
@@ -53,4 +54,4 @@
     </div>
   {% endfor %}
 </div>
-{% endblock %}
+{% endblock app_content %}

--- a/daiv/notifications/templates/notifications/emails/notification.html
+++ b/daiv/notifications/templates/notifications/emails/notification.html
@@ -1,5 +1,5 @@
 {% extends "core/emails/base.html" %}
-{% load i18n activity_tags %}
+{% load activity_tags i18n %}
 
 {% block content %}
 <h1 style="margin: 0 0 8px; font-size: 20px; font-weight: 600; color: #111827;">
@@ -52,4 +52,4 @@
     </tr>
 </table>
 {% endif %}
-{% endblock %}
+{% endblock content %}

--- a/daiv/notifications/templates/notifications/notification_list.html
+++ b/daiv/notifications/templates/notifications/notification_list.html
@@ -2,6 +2,7 @@
 {% load dashboard_tags i18n %}
 
 {% block title %}{% translate "Notifications" %} — DAIV{% endblock %}
+
 {% block container_width %}max-w-3xl{% endblock %}
 
 {% block app_content %}
@@ -40,4 +41,4 @@
     {% if page_obj.has_next %}<a href="?{{ qs }}page={{ page_obj.next_page_number }}">→</a>{% endif %}
   </div>
 {% endif %}
-{% endblock %}
+{% endblock app_content %}

--- a/daiv/schedules/templates/schedules/_subscriber_picker.html
+++ b/daiv/schedules/templates/schedules/_subscriber_picker.html
@@ -1,8 +1,8 @@
 {% load i18n %}
 <div class="mt-6"
      x-data="subscriberPicker({ initial: {{ subscriber_initial_json|default:'[]' }} })">
-    <label class="block text-[15px] font-medium text-gray-400">{% trans "Subscribers" %}</label>
-    <p class="mt-1 text-sm text-gray-400">{% trans "Other users CC'd on this schedule's finish notifications." %}</p>
+    <label class="block text-[15px] font-medium text-gray-400">{% translate "Subscribers" %}</label>
+    <p class="mt-1 text-sm text-gray-400">{% translate "Other users CC'd on this schedule's finish notifications." %}</p>
 
     <select name="{{ form.subscribers.html_name }}" id="{{ form.subscribers.id_for_label }}" multiple class="hidden">
         <template x-for="u in selected" :key="u.id">
@@ -24,12 +24,12 @@
                 </button>
             </span>
         </template>
-        <p x-show="selected.length === 0" class="text-sm text-gray-500">{% trans "No subscribers yet." %}</p>
+        <p x-show="selected.length === 0" class="text-sm text-gray-500">{% translate "No subscribers yet." %}</p>
     </div>
 
     <div class="relative mt-3">
         <input type="text" :value="query" @input="search($event.target.value)"
-               placeholder="{% trans 'Search users by name, email, or username...' %}"
+               placeholder="{% translate 'Search users by name, email, or username...' %}"
                autocomplete="off" class="w-full">
         <div x-show="results.length > 0 || isLoading" x-cloak
              class="absolute z-20 mt-1 max-h-56 w-full overflow-auto rounded-xl border border-white/[0.06] bg-[#0d1117] shadow-lg">
@@ -43,7 +43,7 @@
                         <span x-show="u.name" class="ml-auto text-xs text-gray-500" x-text="u.email"></span>
                     </li>
                 </template>
-                <li x-show="isLoading" class="px-3 py-2 text-sm text-gray-400">{% trans "Searching..." %}</li>
+                <li x-show="isLoading" class="px-3 py-2 text-sm text-gray-400">{% translate "Searching..." %}</li>
             </ul>
         </div>
     </div>

--- a/daiv/schedules/templates/schedules/schedule_confirm_delete.html
+++ b/daiv/schedules/templates/schedules/schedule_confirm_delete.html
@@ -1,12 +1,13 @@
 {% extends "base_app.html" %}
-{% load static icon_tags %}
+{% load icon_tags static %}
 
 {% block title %}Delete Schedule — DAIV{% endblock %}
+
 {% block container_width %}max-w-3xl{% endblock %}
 
 {% block breadcrumb %}
 {% include "accounts/_breadcrumb.html" with crumbs=breadcrumbs %}
-{% endblock %}
+{% endblock breadcrumb %}
 
 {% block app_content %}
 <div class="animate-fade-up">
@@ -41,4 +42,4 @@
         </a>
     </form>
 </div>
-{% endblock %}
+{% endblock app_content %}

--- a/daiv/schedules/templates/schedules/schedule_form.html
+++ b/daiv/schedules/templates/schedules/schedule_form.html
@@ -2,6 +2,7 @@
 {% load i18n static %}
 
 {% block title %}{% if object %}Edit Schedule{% else %}Create Schedule{% endif %} — DAIV{% endblock %}
+
 {% block container_width %}max-w-3xl{% endblock %}
 
 {% block alpine_plugins %}
@@ -12,11 +13,11 @@
 <script defer src="{% static 'activity/js/prompt-box.js' %}"></script>
 <script defer src="{% static 'schedules/js/subscriber-picker.js' %}"></script>
 <script defer src="{% static 'schedules/js/template-gallery.js' %}"></script>
-{% endblock %}
+{% endblock alpine_plugins %}
 
 {% block breadcrumb %}
 {% include "accounts/_breadcrumb.html" with crumbs=breadcrumbs %}
-{% endblock %}
+{% endblock breadcrumb %}
 
 {% block app_content %}
 <div class="animate-fade-up">
@@ -26,7 +27,7 @@
     </p>
 </div>
 
-        {% if not object and schedule_templates %}
+        {% if not object and not schedule_templates %}
         <div class="mt-6 flex items-center justify-between rounded-xl border border-white/[0.06] bg-white/[0.02] px-4 py-3">
             <div>
                 <p class="text-[15px] font-medium text-gray-200">{% translate "Start from a template" %}</p>
@@ -149,4 +150,4 @@
                 {% endif %}
             </div>
         </form>
-{% endblock %}
+{% endblock app_content %}

--- a/daiv/schedules/templates/schedules/schedule_list.html
+++ b/daiv/schedules/templates/schedules/schedule_list.html
@@ -1,12 +1,13 @@
 {% extends "base_app.html" %}
-{% load i18n static dashboard_tags %}
+{% load dashboard_tags i18n static %}
 
 {% block title %}Scheduled Jobs — DAIV{% endblock %}
+
 {% block container_width %}max-w-screen-2xl{% endblock %}
 
 {% block alpine_plugins %}
 <script defer src="{% static 'schedules/js/template-gallery.js' %}"></script>
-{% endblock %}
+{% endblock alpine_plugins %}
 
 {% block app_content %}
 <div class="animate-fade-up flex items-center justify-between">
@@ -53,4 +54,4 @@
         showToast('Cannot resume schedule \u2014 the cron configuration may be invalid. Edit the schedule to fix it.', 'error');
     });
 </script>
-{% endblock %}
+{% endblock app_content %}

--- a/daiv/schedules/templates/schedules/template_confirm_delete.html
+++ b/daiv/schedules/templates/schedules/template_confirm_delete.html
@@ -2,11 +2,12 @@
 {% load icon_tags %}
 
 {% block title %}Delete Template — DAIV{% endblock %}
+
 {% block container_width %}max-w-3xl{% endblock %}
 
 {% block breadcrumb %}
 {% include "accounts/_breadcrumb.html" with crumbs=breadcrumbs %}
-{% endblock %}
+{% endblock breadcrumb %}
 
 {% block app_content %}
 <div class="animate-fade-up">
@@ -31,4 +32,4 @@
         <a href="{{ cancel_url }}" class="btn-secondary">Cancel</a>
     </form>
 </div>
-{% endblock %}
+{% endblock app_content %}

--- a/daiv/schedules/templates/schedules/template_form.html
+++ b/daiv/schedules/templates/schedules/template_form.html
@@ -2,16 +2,17 @@
 {% load i18n static %}
 
 {% block title %}{% if object %}Edit Template{% else %}New Template{% endif %} — DAIV{% endblock %}
+
 {% block container_width %}max-w-3xl{% endblock %}
 
 {% block alpine_plugins %}
 <script defer src="{% static 'codebase/js/repo-search.js' %}"></script>
 <script defer src="{% static 'activity/js/prompt-box.js' %}"></script>
-{% endblock %}
+{% endblock alpine_plugins %}
 
 {% block breadcrumb %}
 {% include "accounts/_breadcrumb.html" with crumbs=breadcrumbs %}
-{% endblock %}
+{% endblock breadcrumb %}
 
 {% block app_content %}
 <div class="animate-fade-up">
@@ -55,7 +56,7 @@
         {% include "activity/_agent_run_fields.html" with form=form repos_required=False %}
     </div>
     <p class="mt-2 text-sm text-gray-500">
-        {% trans "Repositories selected here pre-fill the schedule picker. Leave empty to let users choose." %}
+        {% translate "Repositories selected here pre-fill the schedule picker. Leave empty to let users choose." %}
     </p>
 
     <div class="mt-6 grid grid-cols-3 gap-4">
@@ -95,4 +96,4 @@
         {% endif %}
     </div>
 </form>
-{% endblock %}
+{% endblock app_content %}

--- a/daiv/schedules/templates/schedules/template_list.html
+++ b/daiv/schedules/templates/schedules/template_list.html
@@ -1,11 +1,12 @@
 {% extends "base_app.html" %}
 
 {% block title %}Schedule Templates — DAIV{% endblock %}
+
 {% block container_width %}max-w-screen-2xl{% endblock %}
 
 {% block breadcrumb %}
 {% include "accounts/_breadcrumb.html" with crumbs=breadcrumbs %}
-{% endblock %}
+{% endblock breadcrumb %}
 
 {% block app_content %}
 <div class="animate-fade-up flex items-center justify-between">
@@ -54,4 +55,4 @@
     </div>
     {% endif %}
 </div>
-{% endblock %}
+{% endblock app_content %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ urls.source = "https://github.com/srtab/daiv"
 dev = [
   "coverage==7.13.5",
   "datasets==4.8.5",
+  "djade==1.9.0",
   "openevals==0.2.0",
   "prek==0.3.13",
   "pyproject-fmt==2.21.2",

--- a/tests/unit_tests/schedules/test_template_views.py
+++ b/tests/unit_tests/schedules/test_template_views.py
@@ -252,7 +252,8 @@ class TestScheduleCreateViewTemplateContext:
 
 @pytest.mark.django_db
 class TestScheduleFormGalleryWiring:
-    """The create form renders the gallery trigger when templates exist."""
+    """The create form promotes the gallery when no templates exist yet,
+    and renders the gallery data whenever templates exist."""
 
     @pytest.fixture
     def tpl(self, admin_user):
@@ -266,18 +267,18 @@ class TestScheduleFormGalleryWiring:
             created_by=admin_user,
         )
 
-    def test_create_renders_trigger_and_gallery_when_templates_exist(self, member_client, tpl):
+    def test_create_renders_gallery_data_when_templates_exist(self, member_client, tpl):
         response = member_client.get(reverse("schedule_create"))
         body = response.content.decode()
         assert "schedule-templates-data" in body
-        assert "Browse templates" in body
+        assert "Browse templates" not in body
         assert "open-template-gallery" in body
 
-    def test_create_omits_trigger_when_no_templates(self, member_client):
+    def test_create_renders_trigger_when_no_templates(self, member_client):
         response = member_client.get(reverse("schedule_create"))
         body = response.content.decode()
         assert "schedule-templates-data" not in body
-        assert "Browse templates" not in body
+        assert "Browse templates" in body
 
     def test_edit_omits_trigger_and_gallery(self, member_client, member_user, tpl):
         schedule = ScheduledJob(

--- a/uv.lock
+++ b/uv.lock
@@ -529,6 +529,7 @@ dependencies = [
 dev = [
     { name = "coverage" },
     { name = "datasets" },
+    { name = "djade" },
     { name = "openevals" },
     { name = "prek" },
     { name = "pyproject-fmt" },
@@ -608,6 +609,7 @@ requires-dist = [
 dev = [
     { name = "coverage", specifier = "==7.13.5" },
     { name = "datasets", specifier = "==4.8.5" },
+    { name = "djade", specifier = "==1.9.0" },
     { name = "openevals", specifier = "==0.2.0" },
     { name = "prek", specifier = "==0.3.13" },
     { name = "pyproject-fmt", specifier = "==2.21.2" },
@@ -727,6 +729,23 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
+name = "djade"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/2e/655cc12eefa761d54b9cb956b8650f83675fd144fda641b03d4172d2e0c2/djade-1.9.0.tar.gz", hash = "sha256:e07dcec03982af3f12e46e42661c83ba6835edbde3597e0385ecfe7385527721", size = 41968, upload-time = "2026-02-27T00:07:02.57Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/1c/40f332f13fc63495677aca02a22a74e5dd596f85d762fd34dcad7177a878/djade-1.9.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:9523c5eebf67bdf4037cbaa3c79fbb453ee883c370e772f2dbb767c753971ac7", size = 1167298, upload-time = "2026-02-27T00:06:46.75Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/02/2098990d681265e84e8d0d2b4548279dcaae07195d217f71e799f4006025/djade-1.9.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:8da28ee6ac2e163283c1f19965f04cb4ca1e4e9fd9edc4c1f4cf183cab98384e", size = 1106315, upload-time = "2026-02-27T00:06:48.756Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/95/e6f43a63e9c6297e3117d5e8415c78c64f4403cace455641b6eb6590d7e5/djade-1.9.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fbfc70ad912b54329363de7a5b62afd6bf4b92a49c12e2a155be1138cef01424", size = 1150821, upload-time = "2026-02-27T00:06:50.551Z" },
+    { url = "https://files.pythonhosted.org/packages/90/8d/cb656b034477b734adefa69c7ada69d17bde4a7bf5a69e797f53ac59ecc3/djade-1.9.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d9d828aaa871c02655d0a6b2d9fd2a677cd4b16bd101015728dd5db418b8225b", size = 1085847, upload-time = "2026-02-27T00:06:52.372Z" },
+    { url = "https://files.pythonhosted.org/packages/01/9a/59396b03db75dd14f74402adb7348362863fde05313f643542dc24ae665e/djade-1.9.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9b90e709d21c3f953b52fc5a021b8ef69b0790f23aa308923992af1fc3c2353f", size = 1228570, upload-time = "2026-02-27T00:06:54.167Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/22/6713dd41f6c6615bf6f11f552286f2ff0e56e4eb0050f6223d1932b38678/djade-1.9.0-py3-none-musllinux_1_1_aarch64.whl", hash = "sha256:183b828ffcedb0122bcf0b5eaa008bb288c344a80946c3f372d583f3944c1394", size = 1147326, upload-time = "2026-02-27T00:06:55.864Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/ea/190854396549d3741b70fd5f828ca0cfeee203e7a6219500cc9bc97bab76/djade-1.9.0-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:1981f77ef3c8b73860e492918ce235e46ab4e62a63c8101dd379e204c8a162de", size = 1287672, upload-time = "2026-02-27T00:06:57.421Z" },
+    { url = "https://files.pythonhosted.org/packages/70/dd/bbbf681b4918fd178bd6586b28146af55e8f0c833e6ce26f255fe4f0271a/djade-1.9.0-py3-none-win_amd64.whl", hash = "sha256:bb2b62e22971173dae63bb2d18b24fe85bf3470ca1aabf1b8320a578832d64a2", size = 1110197, upload-time = "2026-02-27T00:06:59.124Z" },
+    { url = "https://files.pythonhosted.org/packages/43/14/e39757938c1387c29b27e9362f3b567a8f6b24bd223137a11253b0c315e7/djade-1.9.0-py3-none-win_arm64.whl", hash = "sha256:b90633a53bb996e0fffd9bd26ed995a78b15f368aea77348e35e67151de4fd13", size = 1041427, upload-time = "2026-02-27T00:07:01.007Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add `djade` (Django template formatter) as a dev dependency.
- Wire it into `.pre-commit-config.yaml` and the `lint-format` / `lint-fix` Make targets (scoped to `*templates/*.html`).
- Apply djade formatting across all existing templates.

## Test plan
- [ ] `make lint-format` passes locally
- [ ] `make lint-fix` is a no-op on a clean tree
- [ ] Pre-commit `djade` hook runs on staged template changes