### PR TITLE
feat(titling): Generate one shared title per batch run

### DIFF
--- a/daiv/activity/services.py
+++ b/daiv/activity/services.py
@@ -10,7 +10,7 @@ from asgiref.sync import async_to_sync
 from jobs.tasks import run_job_task
 
 from activity.models import Activity, TriggerType
-from automation.titling.tasks import generate_title_task
+from automation.titling.tasks import generate_batch_title_task
 
 _PROMPT_DRIVEN = {TriggerType.API_JOB, TriggerType.MCP_JOB, TriggerType.UI_JOB}
 
@@ -229,13 +229,6 @@ async def asubmit_batch_runs(
             )
             return BatchSubmitFailure(repo_id=target.repo_id, ref=target.ref, error="ActivityCreationFailed")
 
-        if trigger_type in _PROMPT_DRIVEN and prompt:
-            try:
-                await generate_title_task.aenqueue(
-                    entity_type="activity", pk=str(activity.pk), prompt=prompt, repo_id=target.repo_id, ref=target.ref
-                )
-            except Exception:  # noqa: BLE001
-                logger.exception("Failed to enqueue title task for activity %s", activity.pk)
         return activity
 
     # return_exceptions=True guards against BaseException (CancelledError, etc.) aborting the
@@ -254,6 +247,18 @@ async def asubmit_batch_runs(
             failed.append(outcome)
         else:
             activities.append(outcome)
+
+    if activities and trigger_type in _PROMPT_DRIVEN and prompt:
+        try:
+            await generate_batch_title_task.aenqueue(batch_id=str(batch_id), prompt=prompt)
+        except Exception:  # noqa: BLE001
+            logger.exception(
+                "Failed to enqueue batch title task for batch_id=%s user=%s trigger=%s activities=%d",
+                batch_id,
+                user.pk if user is not None else None,
+                trigger_type,
+                len(activities),
+            )
 
     return BatchSubmitResult(batch_id=batch_id, activities=activities, failed=failed)
 

--- a/daiv/automation/titling/tasks.py
+++ b/daiv/automation/titling/tasks.py
@@ -38,6 +38,49 @@ class GeneratedTitle(BaseModel):
     )
 
 
+def _build_structured_llm():
+    """Build the structured LLM chain with fallback. Raises ``RuntimeError`` if no model is configured."""
+
+    def _structured(model_name: str):
+        return (
+            BaseAgent
+            .get_model(model=model_name, max_tokens=60)
+            .with_structured_output(GeneratedTitle)
+            .with_retry(stop_after_attempt=2)
+        )
+
+    return _structured(site_settings.titling_model_name).with_fallbacks([
+        _structured(site_settings.titling_fallback_model_name)
+    ])
+
+
+def _invoke_titler(structured_llm, *, prompt: str, repo_id: str = "", ref: str = "", run_metadata: dict) -> str:
+    """Invoke the titler chain and return the cleaned title string.
+
+    ``repo_id`` and ``ref`` are optional context: omitted for batches that span multiple repos.
+    """
+    ref = ref.strip()
+    user_text = ""
+    if repo_id:
+        user_text += f"Repository: {repo_id}\n"
+    if _ref_is_informative(ref):
+        user_text += f"Branch: {ref}\n"
+    user_text += f"Task: {prompt[:500]}"
+
+    run_name = "Titling"
+    tags = [run_name]
+    if entity_type := run_metadata.get("entity_type"):
+        tags.append(f"entity:{entity_type}")
+    result = cast(
+        "GeneratedTitle",
+        structured_llm.with_config(run_name=run_name, tags=tags, metadata=run_metadata).invoke([
+            SystemMessage(content=_SYSTEM_PROMPT),
+            HumanMessage(content=user_text),
+        ]),
+    )
+    return result.title.strip()
+
+
 @task()
 def generate_title_task(
     entity_type: Literal["chat_thread", "activity"], pk: str, prompt: str, repo_id: str, ref: str = ""
@@ -63,18 +106,8 @@ def generate_title_task(
         logger.warning("generate_title_task: %s with pk=%s not found, skipping", entity_type, pk)
         return
 
-    def _structured(model_name: str):
-        return (
-            BaseAgent
-            .get_model(model=model_name, max_tokens=60)
-            .with_structured_output(GeneratedTitle)
-            .with_retry(stop_after_attempt=2)
-        )
-
     try:
-        structured_llm = _structured(site_settings.titling_model_name).with_fallbacks([
-            _structured(site_settings.titling_fallback_model_name)
-        ])
+        structured_llm = _build_structured_llm()
     except RuntimeError:
         logger.exception(
             "generate_title_task: model not configured for %s pk=%s — feature disabled until API key is set",
@@ -83,21 +116,45 @@ def generate_title_task(
         )
         return
 
-    ref = ref.strip()
-    user_text = f"Repository: {repo_id}\n"
-    if _ref_is_informative(ref):
-        user_text += f"Branch: {ref}\n"
-    user_text += f"Task: {prompt[:500]}"
-
-    run_name = "Titling"
-    result = cast(
-        "GeneratedTitle",
-        structured_llm.with_config(
-            run_name=run_name,
-            tags=[run_name, f"entity:{entity_type}"],
-            metadata={"entity_type": entity_type, "entity_pk": pk, "repo_id": repo_id, "ref": ref},
-        ).invoke([SystemMessage(content=_SYSTEM_PROMPT), HumanMessage(content=user_text)]),
+    title = _invoke_titler(
+        structured_llm,
+        prompt=prompt,
+        repo_id=repo_id,
+        ref=ref,
+        run_metadata={"entity_type": entity_type, "entity_pk": pk, "repo_id": repo_id, "ref": ref},
     )
 
-    entity.title = result.title.strip()
+    entity.title = title
     entity.save(update_fields=["title"])
+
+
+@task()
+def generate_batch_title_task(batch_id: str, prompt: str) -> None:
+    """Generate a single LLM title for an Activity batch and apply it to every untitled member.
+
+    One LLM call per batch instead of one per activity. Repo/ref context is omitted because batch
+    members typically span repos. Only rows with an empty ``title`` are updated, so synchronous
+    titles (e.g. scheduled-run templates) are preserved.
+    """
+    from activity.models import Activity
+
+    try:
+        structured_llm = _build_structured_llm()
+    except RuntimeError:
+        logger.exception(
+            "generate_batch_title_task: model not configured for batch_id=%s — feature disabled until API key is set",
+            batch_id,
+        )
+        return
+
+    title = _invoke_titler(
+        structured_llm, prompt=prompt, run_metadata={"entity_type": "activity_batch", "batch_id": batch_id}
+    )
+
+    updated = Activity.objects.by_batch(batch_id).filter(title="").update(title=title)
+    if updated == 0:
+        logger.warning(
+            "generate_batch_title_task: no rows updated for batch_id=%s (stale batch or all already titled)", batch_id
+        )
+    else:
+        logger.info("generate_batch_title_task: updated %d activities for batch_id=%s", updated, batch_id)

--- a/tests/unit_tests/activity/test_batch_submit.py
+++ b/tests/unit_tests/activity/test_batch_submit.py
@@ -232,3 +232,95 @@ class TestAsubmitBatchRuns:
 
         assert len(result.activities) == 1
         assert result.activities[0].batch_id == result.batch_id
+
+
+@pytest.mark.django_db(transaction=True)
+class TestBatchTitleEnqueue:
+    """One title task per batch — not one per activity."""
+
+    def test_single_batch_title_task_enqueued_for_n_repos(self, member_user, mock_generate_title_task):
+        async def _aenqueue(**kwargs):
+            return await _atask_result_row(uuid.uuid4())
+
+        with mock.patch("activity.services.run_job_task") as m_task:
+            m_task.aenqueue = _aenqueue
+            repos = [RepoTarget(repo_id=f"o/r{i}", ref="") for i in range(4)]
+            result = submit_batch_runs(
+                user=member_user,
+                prompt="add login",
+                repos=repos,
+                use_max=False,
+                notify_on=None,
+                trigger_type=TriggerType.UI_JOB,
+            )
+
+        assert len(result.activities) == 4
+        mock_generate_title_task.aenqueue.assert_awaited_once()
+        call_kwargs = mock_generate_title_task.aenqueue.await_args.kwargs
+        assert call_kwargs["batch_id"] == str(result.batch_id)
+        assert call_kwargs["prompt"] == "add login"
+
+    def test_no_title_task_for_schedule_trigger(self, member_user, mock_generate_title_task):
+        from schedules.models import Frequency, ScheduledJob
+
+        schedule = ScheduledJob.objects.create(
+            user=member_user,
+            name="s",
+            prompt="p",
+            repos=[{"repo_id": "x/y", "ref": ""}],
+            frequency=Frequency.DAILY,
+            time="12:00",
+        )
+        fake = _task_result_row(uuid.uuid4())
+        with mock.patch("activity.services.run_job_task") as m_task:
+            m_task.aenqueue = mock.AsyncMock(return_value=fake)
+            submit_batch_runs(
+                user=member_user,
+                prompt="p",
+                repos=[RepoTarget(repo_id="x/y", ref="")],
+                use_max=False,
+                notify_on=None,
+                trigger_type=TriggerType.SCHEDULE,
+                scheduled_job=schedule,
+            )
+        mock_generate_title_task.aenqueue.assert_not_called()
+
+    def test_no_title_task_when_no_activities_created(self, member_user, mock_generate_title_task):
+        async def _aenqueue_fails(**kwargs):
+            raise RuntimeError("queue down")
+
+        with mock.patch("activity.services.run_job_task") as m_task:
+            m_task.aenqueue = _aenqueue_fails
+            result = submit_batch_runs(
+                user=member_user,
+                prompt="p",
+                repos=[RepoTarget(repo_id="o/r", ref="")],
+                use_max=False,
+                notify_on=None,
+                trigger_type=TriggerType.UI_JOB,
+            )
+
+        assert result.activities == []
+        mock_generate_title_task.aenqueue.assert_not_called()
+
+    def test_title_enqueue_failure_does_not_abort_batch(self, member_user, mock_generate_title_task):
+        """Enqueue failures for the (best-effort) title task must not raise to the caller — submission stays green."""
+        mock_generate_title_task.aenqueue = mock.AsyncMock(side_effect=RuntimeError("title queue down"))
+
+        async def _aenqueue(**kwargs):
+            return await _atask_result_row(uuid.uuid4())
+
+        with mock.patch("activity.services.run_job_task") as m_task:
+            m_task.aenqueue = _aenqueue
+            result = submit_batch_runs(
+                user=member_user,
+                prompt="add login",
+                repos=[RepoTarget(repo_id=f"o/r{i}", ref="") for i in range(3)],
+                use_max=False,
+                notify_on=None,
+                trigger_type=TriggerType.UI_JOB,
+            )
+
+        assert len(result.activities) == 3
+        assert result.failed == []
+        mock_generate_title_task.aenqueue.assert_awaited_once()

--- a/tests/unit_tests/automation/titling/test_tasks.py
+++ b/tests/unit_tests/automation/titling/test_tasks.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
+import uuid
 from unittest.mock import MagicMock, patch
 
 import pytest
 from activity.models import Activity, TriggerType
 
 from automation.titling import tasks as titling_tasks
-from automation.titling.tasks import GeneratedTitle, _ref_is_informative, generate_title_task
+from automation.titling.tasks import GeneratedTitle, _ref_is_informative, generate_batch_title_task, generate_title_task
 
 
 @pytest.mark.parametrize(
@@ -125,3 +126,82 @@ class TestGenerateTitleTask:
         human_text = capture["messages"][-1].content
         assert human_text.endswith("x" * 500)
         assert "x" * 501 not in human_text
+
+
+@pytest.mark.django_db
+class TestGenerateBatchTitleTask:
+    def _make_activity(self, batch_id, *, title: str = "", repo_id: str = "group/repo") -> Activity:
+        return Activity.objects.create(
+            trigger_type=TriggerType.API_JOB, repo_id=repo_id, batch_id=batch_id, title=title
+        )
+
+    def test_applies_single_title_to_all_batch_members(self):
+        batch_id = uuid.uuid4()
+        members = [self._make_activity(batch_id, repo_id=f"o/r{i}") for i in range(3)]
+
+        with patch.object(titling_tasks.BaseAgent, "get_model", return_value=_fake_chain(title="Add login feature")):
+            generate_batch_title_task.func(batch_id=str(batch_id), prompt="add login")
+
+        for activity in members:
+            activity.refresh_from_db()
+            assert activity.title == "Add login feature"
+
+    def test_invokes_llm_exactly_once_for_n_repos(self):
+        batch_id = uuid.uuid4()
+        for i in range(5):
+            self._make_activity(batch_id, repo_id=f"o/r{i}")
+
+        chain = _fake_chain(title="One shared title")
+        with patch.object(titling_tasks.BaseAgent, "get_model", return_value=chain):
+            generate_batch_title_task.func(batch_id=str(batch_id), prompt="task")
+
+        # ``invoke`` is the actual LLM call; building the chain may call other Mock methods
+        # so we assert on ``invoke`` directly.
+        assert chain.invoke.call_count == 1
+
+    def test_does_not_overwrite_already_titled_activities(self):
+        batch_id = uuid.uuid4()
+        activity = self._make_activity(batch_id, title="Already set")
+
+        with patch.object(titling_tasks.BaseAgent, "get_model", return_value=_fake_chain(title="LLM choice")):
+            generate_batch_title_task.func(batch_id=str(batch_id), prompt="task")
+
+        activity.refresh_from_db()
+        assert activity.title == "Already set"
+
+    def test_preserves_pre_existing_titles_in_mixed_batch(self):
+        """Schedule runs set a synchronous title; LLM titles must not overwrite them."""
+        batch_id = uuid.uuid4()
+        prefilled = self._make_activity(batch_id, title="job · run #1", repo_id="o/sched")
+        empty = self._make_activity(batch_id, repo_id="o/r")
+
+        with patch.object(titling_tasks.BaseAgent, "get_model", return_value=_fake_chain(title="LLM choice")):
+            generate_batch_title_task.func(batch_id=str(batch_id), prompt="task")
+
+        prefilled.refresh_from_db()
+        empty.refresh_from_db()
+        assert prefilled.title == "job · run #1"
+        assert empty.title == "LLM choice"
+
+    def test_user_text_omits_repo_and_branch_context(self):
+        """Batch titling spans multiple repos, so per-repo context is intentionally dropped."""
+        batch_id = uuid.uuid4()
+        self._make_activity(batch_id, repo_id="o/r1")
+        self._make_activity(batch_id, repo_id="o/r2")
+        capture: dict = {}
+
+        with patch.object(titling_tasks.BaseAgent, "get_model", return_value=_fake_chain(capture=capture)):
+            generate_batch_title_task.func(batch_id=str(batch_id), prompt="add login")
+
+        human_text = capture["messages"][-1].content
+        assert "Repository:" not in human_text
+        assert "Branch:" not in human_text
+        assert "Task: add login" in human_text
+
+    def test_returns_when_model_not_configured(self):
+        batch_id = uuid.uuid4()
+        activity = self._make_activity(batch_id)
+        with patch.object(titling_tasks.BaseAgent, "get_model", side_effect=RuntimeError("no key")):
+            generate_batch_title_task.func(batch_id=str(batch_id), prompt="task")
+        activity.refresh_from_db()
+        assert activity.title == ""

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -70,18 +70,18 @@ def mock_settings(monkeypatch):
 
 @pytest.fixture(autouse=True)
 def mock_generate_title_task():
-    """Stub ``generate_title_task.aenqueue`` so the ImmediateBackend doesn't fire real LLM calls.
+    """Stub the titling tasks so the ImmediateBackend doesn't fire real LLM calls.
 
     Without this, every test that hits ``submit_batch_runs`` / chat thread creation
     pays for two failed LLM retries plus the fallback model — adding tens of seconds
-    to the suite. Tests that exercise titling itself import ``generate_title_task.func``
+    to the suite. Tests that exercise titling itself import the ``.func`` attribute
     directly, so they bypass this patch.
 
     Patching the module-level binding at each import site (rather than the frozen
     ``Task`` instance) avoids ``patch.object`` teardown issues on slotted dataclasses.
     """
     with (
-        patch("activity.services.generate_title_task") as m1,
+        patch("activity.services.generate_batch_title_task") as m1,
         patch("chat.models.generate_title_task") as m2,
         patch("chat.api.threads.generate_title_task") as m3,
     ):

--- a/tests/unit_tests/mcp_server/test_server.py
+++ b/tests/unit_tests/mcp_server/test_server.py
@@ -34,7 +34,7 @@ def _patch_acreate():
     acreate_patch = patch(
         "activity.services.acreate_activity", new_callable=AsyncMock, side_effect=_fake_acreate_activity
     )
-    title_patch = patch("activity.services.generate_title_task")
+    title_patch = patch("activity.services.generate_batch_title_task")
 
     class _Combined:
         def __enter__(self):


### PR DESCRIPTION
## Summary
- Multi-repo batch submissions previously enqueued one `generate_title_task` per activity — N LLM calls producing slightly different titles from the same prompt. Replaced with a single `generate_batch_title_task(batch_id, prompt)` that makes one LLM call and bulk-updates every untitled member of the batch.
- Extracted `_build_structured_llm()` and `_invoke_titler()` so the new task and the existing per-entity `generate_title_task` (still used for chat threads) share the same scaffolding. Tag inference from `run_metadata` preserves the `entity:<type>` LangSmith trace filter.
- The bulk update filters on `title=""`, so synchronous schedule-run titles (`{job_name} · run #N`) are preserved when a batch mixes triggers.

## Test plan
- [x] `uv run pytest tests/unit_tests/automation/titling/test_tasks.py tests/unit_tests/activity/test_batch_submit.py tests/unit_tests/mcp_server/test_server.py` — 62 passed
- [x] `make lint` clean
- [x] New `TestGenerateBatchTitleTask` covers: single LLM call for N repos, preservation of pre-existing titles, no-op when no rows match, omitted repo/branch context, model-not-configured handling
- [x] New `TestBatchTitleEnqueue` covers: one enqueue per batch, no enqueue for `SCHEDULE` trigger, no enqueue when zero activities created, batch-result resilient to title enqueue failure