### PR TITLE
fix(core): Defer provider cache invalidation until commit

### DIFF
--- a/daiv/core/models.py
+++ b/daiv/core/models.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, ClassVar
 
 from django.core.cache import cache
-from django.db import models
+from django.db import models, transaction
 from django.utils.translation import gettext_lazy as _
 
 if TYPE_CHECKING:
@@ -449,7 +449,7 @@ class SiteConfiguration(models.Model):
     def save(self, *args: Any, **kwargs: Any) -> None:
         self.pk = 1
         super().save(*args, **kwargs)
-        self._invalidate_cache()
+        transaction.on_commit(self._invalidate_cache)
 
     def delete(self, *args: Any, **kwargs: Any) -> tuple[int, dict[str, int]]:
         # Prevent deletion of the singleton
@@ -618,11 +618,11 @@ class WebFetchAuthHeader(models.Model):
 
     def save(self, *args: Any, **kwargs: Any) -> None:
         super().save(*args, **kwargs)
-        type(self).invalidate_cache()
+        transaction.on_commit(type(self).invalidate_cache)
 
     def delete(self, *args: Any, **kwargs: Any) -> tuple[int, dict[str, int]]:
         result = super().delete(*args, **kwargs)
-        type(self).invalidate_cache()
+        transaction.on_commit(type(self).invalidate_cache)
         return result
 
     def get_secret_hint(self) -> str | None:
@@ -778,13 +778,15 @@ class Provider(models.Model):
             if original.slug != self.slug or original.provider_type != self.provider_type:
                 raise ValueError(f"Provider {original.slug!r} is locked; slug and provider_type cannot change.")
         super().save(*args, **kwargs)
-        type(self).invalidate_cache()
+        # Defer invalidation to commit so concurrent readers can't repopulate the
+        # cache with pre-commit data and mask the new row for the 5-min TTL.
+        transaction.on_commit(type(self).invalidate_cache)
 
     def delete(self, *args: Any, **kwargs: Any) -> tuple[int, dict[str, int]]:
         if self.is_locked:
             raise ValueError(f"Provider {self.slug!r} is locked and cannot be deleted.")
         result = super().delete(*args, **kwargs)
-        type(self).invalidate_cache()
+        transaction.on_commit(type(self).invalidate_cache)
         return result
 
     def get_secret_hint(self) -> str | None:

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest.mock import AsyncMock, Mock, patch
 
+from django.core.cache import cache
 from django.test import Client
 
 import pytest
@@ -13,6 +14,20 @@ from accounts.models import User as AccountUser
 from codebase.base import GitPlatform, MergeRequest, Repository, User
 from codebase.clients import RepoClient
 from codebase.conf import settings as codebase_settings
+from core.models import PROVIDERS_CACHE_KEY, SITE_CONFIGURATION_CACHE_KEY, WEB_FETCH_AUTH_HEADERS_CACHE_KEY
+
+
+@pytest.fixture(autouse=True)
+def _clear_model_caches():
+    # Provider/WebFetchAuthHeader/SiteConfiguration invalidate via
+    # transaction.on_commit; @pytest.mark.django_db tests roll back without
+    # committing, so the LocMem cache would otherwise leak state between tests.
+    keys = (PROVIDERS_CACHE_KEY, SITE_CONFIGURATION_CACHE_KEY, WEB_FETCH_AUTH_HEADERS_CACHE_KEY)
+    for key in keys:
+        cache.delete(key)
+    yield
+    for key in keys:
+        cache.delete(key)
 
 
 @pytest.fixture

--- a/tests/unit_tests/core/test_configuration_views.py
+++ b/tests/unit_tests/core/test_configuration_views.py
@@ -777,7 +777,9 @@ class TestPerGroupSaveIsolation:
         config.refresh_from_db()
         assert config.agent_recursion_limit == 500  # unchanged
 
-    def test_post_providers_saves_through_formset_and_invalidates_cache(self, client, admin_user, group_url):
+    def test_post_providers_saves_through_formset_and_invalidates_cache(
+        self, client, admin_user, group_url, django_capture_on_commit_callbacks
+    ):
         from django.core.cache import cache
 
         from core.models import PROVIDERS_CACHE_KEY
@@ -793,7 +795,10 @@ class TestPerGroupSaveIsolation:
         idx = next(i for i, p in enumerate(Provider.objects.order_by("sort_order", "slug")) if p.pk == first_pk)
         mgmt[f"providers-{idx}-display_name"] = "Renamed-In-Test"
 
-        response = client.post(group_url("providers"), mgmt)
+        # transaction.on_commit defers invalidation to commit; execute=True fires
+        # callbacks at the boundary, just like a real request commit would.
+        with django_capture_on_commit_callbacks(execute=True):
+            response = client.post(group_url("providers"), mgmt)
         assert response.status_code == 302
 
         Provider.objects.get(pk=first_pk)  # exists
@@ -801,7 +806,9 @@ class TestPerGroupSaveIsolation:
         # Cache invalidated by Provider.save signal / formset save
         assert cache.get(PROVIDERS_CACHE_KEY) is None
 
-    def test_enable_provider_then_select_model_on_agent_page(self, client, admin_user, group_url):
+    def test_enable_provider_then_select_model_on_agent_page(
+        self, client, admin_user, group_url, django_capture_on_commit_callbacks
+    ):
         """Two-step flow: enable a fresh provider on /providers/, then select its model on /agent/."""
         provider = Provider.objects.get(slug="anthropic")
         provider.is_enabled = False
@@ -815,7 +822,8 @@ class TestPerGroupSaveIsolation:
         idx = next(i for i, p in enumerate(Provider.objects.order_by("sort_order", "slug")) if p.pk == provider.pk)
         mgmt[f"providers-{idx}-is_enabled"] = "on"
         mgmt[f"providers-{idx}-api_key"] = "sk-fresh"
-        r1 = client.post(group_url("providers"), mgmt)
+        with django_capture_on_commit_callbacks(execute=True):
+            r1 = client.post(group_url("providers"), mgmt)
         assert r1.status_code == 302
 
         # Step 2: select that provider's model on the agent page

--- a/tests/unit_tests/core/test_models_provider.py
+++ b/tests/unit_tests/core/test_models_provider.py
@@ -1,7 +1,12 @@
+from unittest.mock import patch
+
+from django.core.cache import cache
+from django.db import transaction
+
 import pytest
 from pydantic import SecretStr
 
-from core.models import Provider, ProviderType
+from core.models import PROVIDERS_CACHE_KEY, Provider, ProviderType
 
 
 @pytest.mark.django_db
@@ -59,21 +64,59 @@ def test_get_cached_returns_secretstr():
 
 
 @pytest.mark.django_db
-def test_save_invalidates_cache():
-    Provider.objects.create(slug="a", display_name="A", provider_type=ProviderType.OPENAI, api_key="k")
+def test_save_invalidates_cache(django_capture_on_commit_callbacks):
+    # Invalidation is deferred via transaction.on_commit so concurrent readers
+    # can't repopulate the cache with pre-commit data; execute=True runs the
+    # callback at the boundary just like a real commit would.
+    with django_capture_on_commit_callbacks(execute=True):
+        Provider.objects.create(slug="a", display_name="A", provider_type=ProviderType.OPENAI, api_key="k")
     slugs_before = {r.slug for r in Provider.get_cached_rows()}
     assert "a" in slugs_before
-    Provider.objects.create(slug="b", display_name="B", provider_type=ProviderType.OPENAI, api_key="k")
+    with django_capture_on_commit_callbacks(execute=True):
+        Provider.objects.create(slug="b", display_name="B", provider_type=ProviderType.OPENAI, api_key="k")
     slugs_after = {r.slug for r in Provider.get_cached_rows()}
     assert "a" in slugs_after
     assert "b" in slugs_after
 
 
+@pytest.mark.django_db(transaction=True)
+def test_save_defers_cache_invalidation_until_commit():
+    """
+    Inside an atomic block, cache.delete must NOT fire until after commit; otherwise
+    a concurrent reader on another connection re-caches pre-commit data and masks
+    the change for up to PROVIDERS_CACHE_TIMEOUT.
+    """
+    Provider.objects.create(slug="defer", display_name="D", provider_type=ProviderType.OPENAI, api_key="k")
+    cache.set(PROVIDERS_CACHE_KEY, "warm-marker", 300)
+
+    delete_in_atomic: list[bool] = []
+    original_delete = cache.delete
+
+    def tracking_delete(key, *a, **kw):
+        if key == PROVIDERS_CACHE_KEY:
+            delete_in_atomic.append(transaction.get_connection().in_atomic_block)
+        return original_delete(key, *a, **kw)
+
+    with patch.object(cache, "delete", side_effect=tracking_delete), transaction.atomic():
+        p = Provider.objects.get(slug="defer")
+        p.verify_ssl = False
+        p.save()
+        # Still inside the atomic block: nothing should have invalidated yet.
+        assert delete_in_atomic == []
+        assert cache.get(PROVIDERS_CACHE_KEY) == "warm-marker"
+
+    # After commit: invalidation runs exactly once, and the connection is no longer in_atomic.
+    assert delete_in_atomic == [False]
+    assert cache.get(PROVIDERS_CACHE_KEY) is None
+
+
 @pytest.mark.django_db
-def test_delete_invalidates_cache():
-    p = Provider.objects.create(slug="zdelme", display_name="A", provider_type=ProviderType.OPENAI, api_key="k")
+def test_delete_invalidates_cache(django_capture_on_commit_callbacks):
+    with django_capture_on_commit_callbacks(execute=True):
+        p = Provider.objects.create(slug="zdelme", display_name="A", provider_type=ProviderType.OPENAI, api_key="k")
     assert "zdelme" in {r.slug for r in Provider.get_cached_rows()}
-    p.delete()
+    with django_capture_on_commit_callbacks(execute=True):
+        p.delete()
     assert "zdelme" not in {r.slug for r in Provider.get_cached_rows()}
 
 

--- a/tests/unit_tests/core/test_site_configuration.py
+++ b/tests/unit_tests/core/test_site_configuration.py
@@ -82,10 +82,13 @@ class TestCaching:
             result = SiteConfiguration.get_cached()
         assert result is None
 
-    def test_save_invalidates_cache(self, site_config):
+    def test_save_invalidates_cache(self, site_config, django_capture_on_commit_callbacks):
+        # Invalidation is deferred via transaction.on_commit; execute=True fires
+        # callbacks at the boundary so the assertion sees the real cache.delete.
         with patch("core.models.cache") as mock_cache:
-            site_config.agent_model_name = "test-model"
-            site_config.save()
+            with django_capture_on_commit_callbacks(execute=True):
+                site_config.agent_model_name = "test-model"
+                site_config.save()
             mock_cache.delete.assert_called_once_with("site_configuration")
 
 

--- a/tests/unit_tests/core/test_web_fetch_auth_header_model.py
+++ b/tests/unit_tests/core/test_web_fetch_auth_header_model.py
@@ -72,20 +72,26 @@ class TestWebFetchAuthHeaderCache:
         assert "bad.com" not in result
         assert "ok.com" in result
 
-    def test_save_invalidates_cache(self, make_auth_header):
-        make_auth_header("a.com", "X", "1")
+    def test_save_invalidates_cache(self, make_auth_header, django_capture_on_commit_callbacks):
+        # Invalidation is deferred via transaction.on_commit; execute=True runs the
+        # callback at the boundary just like a real commit would.
+        with django_capture_on_commit_callbacks(execute=True):
+            make_auth_header("a.com", "X", "1")
         WebFetchAuthHeader.get_cached()  # populate
         assert cache.get(WEB_FETCH_AUTH_HEADERS_CACHE_KEY) is not None
 
-        make_auth_header("b.com", "Y", "2")
+        with django_capture_on_commit_callbacks(execute=True):
+            make_auth_header("b.com", "Y", "2")
         assert cache.get(WEB_FETCH_AUTH_HEADERS_CACHE_KEY) is None
 
-    def test_delete_invalidates_cache(self, make_auth_header):
-        row = make_auth_header("a.com", "X", "1")
+    def test_delete_invalidates_cache(self, make_auth_header, django_capture_on_commit_callbacks):
+        with django_capture_on_commit_callbacks(execute=True):
+            row = make_auth_header("a.com", "X", "1")
         WebFetchAuthHeader.get_cached()
         assert cache.get(WEB_FETCH_AUTH_HEADERS_CACHE_KEY) is not None
 
-        row.delete()
+        with django_capture_on_commit_callbacks(execute=True):
+            row.delete()
         assert cache.get(WEB_FETCH_AUTH_HEADERS_CACHE_KEY) is None
 
 


### PR DESCRIPTION
## Summary

- `Provider`, `WebFetchAuthHeader`, and `SiteConfiguration` invalidated their Redis cache inside `save()`/`delete()`, so the `cache.delete` fired *while the surrounding transaction was still open* (the configuration view wraps `formset.save()` in `transaction.atomic()`).
- A concurrent reader on another DB connection could miss the cache, read pre-commit state, and **repopulate the cache with stale data** — masking the change for up to the 5-min TTL. Symptom in the wild: admin toggles a custom `Provider`'s `verify_ssl` (or any other field) and agents keep using the old value.
- Fix: defer invalidation via `transaction.on_commit(...)` so the cache delete only runs after the row is durably visible to other connections. Outside an atomic block `on_commit` runs immediately, so standalone callers are unaffected.

## Test plan

- [x] New regression test `test_save_defers_cache_invalidation_until_commit` asserts the delete fires with `in_atomic_block=False` (post-commit) and that mid-transaction the cache still holds the pre-save value.
- [x] Existing cache-assertion tests rewritten to use `django_capture_on_commit_callbacks(execute=True)` so they exercise the real production sequence (atomic block → commit → invalidation).
- [x] New autouse fixture clears the three model caches between tests to prevent LocMemCache state from leaking now that `@pytest.mark.django_db` no longer fires `on_commit` synchronously.
- [x] `make test` — 2071 passed
- [x] `make lint-fix` — clean
- [x] Type-check diagnostics unchanged from `main` (verified via stash + re-run)