### PR TITLE
feat(notifications): Add owner and repo to schedule run notifications

### DIFF
--- a/daiv/notifications/signals.py
+++ b/daiv/notifications/signals.py
@@ -60,39 +60,22 @@ def _resolve_recipients(activity: Activity) -> dict[int, object]:
     return {}
 
 
-def _owner_display(user) -> str:
-    """Compact label for a schedule's owner — disambiguates schedules with shared names.
-
-    Prefers human-readable names over emails to keep subjects short. ``username`` is the
-    ``AbstractUser``-guaranteed floor, so this returns a non-empty string for real users.
-    """
-    if user is None:
-        return ""
-    return user.get_full_name() or user.name or user.username or user.email or ""
-
-
 def _render_payload(activity: Activity) -> tuple[str, str, dict]:
     is_schedule = _is_schedule(activity)
     ok = activity.status == ActivityStatus.SUCCESSFUL
     repo = activity.repo_id
-    owner = _owner_display(activity.scheduled_job.user) if is_schedule else ""
+    name = activity.scheduled_job.name if is_schedule else ""
+    # Owner disambiguates schedules that share a name across users.
+    owner = str(activity.scheduled_job.user) if is_schedule else ""
 
     if is_schedule:
-        name = activity.scheduled_job.name
+        params = {"name": name, "owner": owner, "repo": repo}
         if ok:
-            subject = _("'%(name)s' succeeded on %(repo)s — %(owner)s") % {"name": name, "repo": repo, "owner": owner}
-            body = _("Scheduled run '%(name)s' by %(owner)s finished on %(repo)s.") % {
-                "name": name,
-                "owner": owner,
-                "repo": repo,
-            }
+            subject = _("'%(name)s' succeeded on %(repo)s — %(owner)s") % params
+            body = _("Scheduled run '%(name)s' by %(owner)s finished on %(repo)s.") % params
         else:
-            subject = _("'%(name)s' failed on %(repo)s — %(owner)s") % {"name": name, "repo": repo, "owner": owner}
-            body = _("Scheduled run '%(name)s' by %(owner)s failed on %(repo)s.") % {
-                "name": name,
-                "owner": owner,
-                "repo": repo,
-            }
+            subject = _("'%(name)s' failed on %(repo)s — %(owner)s") % params
+            body = _("Scheduled run '%(name)s' by %(owner)s failed on %(repo)s.") % params
     else:
         if ok:
             subject = _("Agent run on %(repo)s succeeded") % {"repo": repo}
@@ -106,7 +89,7 @@ def _render_payload(activity: Activity) -> tuple[str, str, dict]:
         "status_label": activity.get_status_display(),
         "is_successful": ok,
         "trigger_label": activity.get_trigger_type_display(),
-        "trigger_name": activity.scheduled_job.name if is_schedule else "",
+        "trigger_name": name,
         "trigger_owner": owner,
         "repo_id": repo,
         "duration_seconds": activity.duration,
@@ -251,46 +234,20 @@ def _render_batch_payload(
     is_schedule = _is_schedule(activity)
     ok = failed == 0
     repo_ids = sorted({repo for repo, _start, _end in rows if repo})
-    owner = _owner_display(activity.scheduled_job.user) if is_schedule else ""
+    name = activity.scheduled_job.name if is_schedule else ""
+    owner = str(activity.scheduled_job.user) if is_schedule else ""
 
     if is_schedule:
-        name = activity.scheduled_job.name
+        params = {"name": name, "owner": owner, "total": total, "ok": successful, "failed": failed}
         if ok:
-            subject = _("'%(name)s' batch succeeded (%(total)d runs) — %(owner)s") % {
-                "name": name,
-                "total": total,
-                "owner": owner,
-            }
-            body = _("All %(total)d runs of '%(name)s' by %(owner)s finished successfully.") % {
-                "total": total,
-                "name": name,
-                "owner": owner,
-            }
+            subject = _("'%(name)s' batch succeeded (%(total)d runs) — %(owner)s") % params
+            body = _("All %(total)d runs of '%(name)s' by %(owner)s finished successfully.") % params
         elif successful == 0:
-            subject = _("'%(name)s' batch failed (%(total)d runs) — %(owner)s") % {
-                "name": name,
-                "total": total,
-                "owner": owner,
-            }
-            body = _("All %(total)d runs of '%(name)s' by %(owner)s failed.") % {
-                "total": total,
-                "name": name,
-                "owner": owner,
-            }
+            subject = _("'%(name)s' batch failed (%(total)d runs) — %(owner)s") % params
+            body = _("All %(total)d runs of '%(name)s' by %(owner)s failed.") % params
         else:
-            subject = _("'%(name)s' batch: %(ok)d/%(total)d succeeded — %(owner)s") % {
-                "name": name,
-                "ok": successful,
-                "total": total,
-                "owner": owner,
-            }
-            body = _("%(ok)d of %(total)d runs of '%(name)s' by %(owner)s succeeded; %(failed)d failed.") % {
-                "ok": successful,
-                "total": total,
-                "name": name,
-                "owner": owner,
-                "failed": failed,
-            }
+            subject = _("'%(name)s' batch: %(ok)d/%(total)d succeeded — %(owner)s") % params
+            body = _("%(ok)d of %(total)d runs of '%(name)s' by %(owner)s succeeded; %(failed)d failed.") % params
     else:
         repo_summary = _summarize_repos(repo_ids)
         if ok:
@@ -313,7 +270,7 @@ def _render_batch_payload(
         "status_label": str(ActivityStatus(agg_status).label),
         "is_successful": ok,
         "trigger_label": str(activity.get_trigger_type_display()),
-        "trigger_name": activity.scheduled_job.name if is_schedule else "",
+        "trigger_name": name,
         "trigger_owner": owner,
         "repo_id": repo_ids[0] if len(repo_ids) == 1 else "",
         "repo_ids": repo_ids,

--- a/daiv/notifications/signals.py
+++ b/daiv/notifications/signals.py
@@ -60,25 +60,46 @@ def _resolve_recipients(activity: Activity) -> dict[int, object]:
     return {}
 
 
+def _owner_display(user) -> str:
+    """Compact label for a schedule's owner — disambiguates schedules with shared names.
+
+    Prefers human-readable names over emails to keep subjects short. ``username`` is the
+    ``AbstractUser``-guaranteed floor, so this returns a non-empty string for real users.
+    """
+    if user is None:
+        return ""
+    return user.get_full_name() or user.name or user.username or user.email or ""
+
+
 def _render_payload(activity: Activity) -> tuple[str, str, dict]:
     is_schedule = _is_schedule(activity)
     ok = activity.status == ActivityStatus.SUCCESSFUL
+    repo = activity.repo_id
+    owner = _owner_display(activity.scheduled_job.user) if is_schedule else ""
 
     if is_schedule:
         name = activity.scheduled_job.name
         if ok:
-            subject = _("Scheduled job '%(name)s' succeeded") % {"name": name}
-            body = _("Your scheduled job '%(name)s' finished successfully.") % {"name": name}
+            subject = _("'%(name)s' succeeded on %(repo)s — %(owner)s") % {"name": name, "repo": repo, "owner": owner}
+            body = _("Scheduled run '%(name)s' by %(owner)s finished on %(repo)s.") % {
+                "name": name,
+                "owner": owner,
+                "repo": repo,
+            }
         else:
-            subject = _("Scheduled job '%(name)s' failed") % {"name": name}
-            body = _("Your scheduled job '%(name)s' failed.") % {"name": name}
+            subject = _("'%(name)s' failed on %(repo)s — %(owner)s") % {"name": name, "repo": repo, "owner": owner}
+            body = _("Scheduled run '%(name)s' by %(owner)s failed on %(repo)s.") % {
+                "name": name,
+                "owner": owner,
+                "repo": repo,
+            }
     else:
         if ok:
-            subject = _("Agent run on %(repo)s succeeded") % {"repo": activity.repo_id}
-            body = _("Your agent run on '%(repo)s' finished successfully.") % {"repo": activity.repo_id}
+            subject = _("Agent run on %(repo)s succeeded") % {"repo": repo}
+            body = _("Agent run on %(repo)s finished successfully.") % {"repo": repo}
         else:
-            subject = _("Agent run on %(repo)s failed") % {"repo": activity.repo_id}
-            body = _("Your agent run on '%(repo)s' failed.") % {"repo": activity.repo_id}
+            subject = _("Agent run on %(repo)s failed") % {"repo": repo}
+            body = _("Agent run on %(repo)s failed.") % {"repo": repo}
 
     context = {
         "status": activity.status,
@@ -86,7 +107,8 @@ def _render_payload(activity: Activity) -> tuple[str, str, dict]:
         "is_successful": ok,
         "trigger_label": activity.get_trigger_type_display(),
         "trigger_name": activity.scheduled_job.name if is_schedule else "",
-        "repo_id": activity.repo_id,
+        "trigger_owner": owner,
+        "repo_id": repo,
         "duration_seconds": activity.duration,
     }
     return subject, body, context
@@ -229,25 +251,44 @@ def _render_batch_payload(
     is_schedule = _is_schedule(activity)
     ok = failed == 0
     repo_ids = sorted({repo for repo, _start, _end in rows if repo})
+    owner = _owner_display(activity.scheduled_job.user) if is_schedule else ""
 
     if is_schedule:
         name = activity.scheduled_job.name
         if ok:
-            subject = _("Scheduled job '%(name)s' batch succeeded (%(total)d runs)") % {"name": name, "total": total}
-            body = _("All %(total)d runs of '%(name)s' finished successfully.") % {"total": total, "name": name}
-        elif successful == 0:
-            subject = _("Scheduled job '%(name)s' batch failed (%(total)d runs)") % {"name": name, "total": total}
-            body = _("All %(total)d runs of '%(name)s' failed.") % {"total": total, "name": name}
-        else:
-            subject = _("Scheduled job '%(name)s' batch finished: %(ok)d/%(total)d succeeded") % {
+            subject = _("'%(name)s' batch succeeded (%(total)d runs) — %(owner)s") % {
                 "name": name,
-                "ok": successful,
                 "total": total,
+                "owner": owner,
             }
-            body = _("%(ok)d of %(total)d runs of '%(name)s' succeeded; %(failed)d failed.") % {
+            body = _("All %(total)d runs of '%(name)s' by %(owner)s finished successfully.") % {
+                "total": total,
+                "name": name,
+                "owner": owner,
+            }
+        elif successful == 0:
+            subject = _("'%(name)s' batch failed (%(total)d runs) — %(owner)s") % {
+                "name": name,
+                "total": total,
+                "owner": owner,
+            }
+            body = _("All %(total)d runs of '%(name)s' by %(owner)s failed.") % {
+                "total": total,
+                "name": name,
+                "owner": owner,
+            }
+        else:
+            subject = _("'%(name)s' batch: %(ok)d/%(total)d succeeded — %(owner)s") % {
+                "name": name,
+                "ok": successful,
+                "total": total,
+                "owner": owner,
+            }
+            body = _("%(ok)d of %(total)d runs of '%(name)s' by %(owner)s succeeded; %(failed)d failed.") % {
                 "ok": successful,
                 "total": total,
                 "name": name,
+                "owner": owner,
                 "failed": failed,
             }
     else:
@@ -273,6 +314,7 @@ def _render_batch_payload(
         "is_successful": ok,
         "trigger_label": str(activity.get_trigger_type_display()),
         "trigger_name": activity.scheduled_job.name if is_schedule else "",
+        "trigger_owner": owner,
         "repo_id": repo_ids[0] if len(repo_ids) == 1 else "",
         "repo_ids": repo_ids,
         "total": total,

--- a/tests/unit_tests/notifications/test_signals.py
+++ b/tests/unit_tests/notifications/test_signals.py
@@ -139,6 +139,7 @@ class TestOnActivityFinished:
         assert n.context["is_successful"] is True
         assert n.context["status_label"] == ActivityStatus.SUCCESSFUL.label
         assert n.context["trigger_name"] == schedule.name
+        assert n.context["trigger_owner"] == member_user.username
         assert n.context["trigger_label"]
         assert n.context["repo_id"] == "acme/app"
         assert "duration_seconds" in n.context
@@ -288,6 +289,56 @@ class TestFanoutToSubscribers:
         assert Notification.objects.filter(recipient=member_user).count() == 1
         assert Notification.objects.filter(recipient=sub1).count() == 0
         assert Notification.objects.filter(recipient=sub2).count() == 1
+
+    def test_same_named_schedules_from_different_owners_are_distinguishable_to_subscriber(self, member_user):
+        """A subscriber on two schedules sharing a name must be able to tell them apart
+        from the notification alone (subject + body), without clicking through."""
+        owner_a = self._make_user("alice")
+        owner_b = self._make_user("bob")
+        sub = self._make_user("subscriber")
+
+        sched_a = ScheduledJob.objects.create(
+            user=owner_a,
+            name="nightly-sync",
+            prompt="p",
+            repos=[{"repo_id": "x/y", "ref": ""}],
+            frequency=Frequency.DAILY,
+            time="12:00",
+            notify_on=NotifyOn.ALWAYS,
+        )
+        sched_b = ScheduledJob.objects.create(
+            user=owner_b,
+            name="nightly-sync",
+            prompt="p",
+            repos=[{"repo_id": "x/y", "ref": ""}],
+            frequency=Frequency.DAILY,
+            time="12:00",
+            notify_on=NotifyOn.ALWAYS,
+        )
+        sched_a.subscribers.add(sub)
+        sched_b.subscribers.add(sub)
+
+        for sched in (sched_a, sched_b):
+            activity = Activity.objects.create(
+                trigger_type=TriggerType.SCHEDULE,
+                user=sched.user,
+                repo_id="x/y",
+                status=ActivityStatus.SUCCESSFUL,
+                scheduled_job=sched,
+            )
+            activity_finished.send(sender=Activity, activity=activity)
+
+        notifs = list(Notification.objects.filter(recipient=sub).order_by("created"))
+        assert len(notifs) == 2
+
+        # Subjects must differ — the owner is the disambiguator since the name is shared.
+        assert notifs[0].subject != notifs[1].subject
+        assert "alice" in notifs[0].subject
+        assert "bob" in notifs[1].subject
+        assert "alice" in notifs[0].body
+        assert "bob" in notifs[1].body
+        assert notifs[0].context["trigger_owner"] == "alice"
+        assert notifs[1].context["trigger_owner"] == "bob"
 
 
 @pytest.mark.django_db

--- a/tests/unit_tests/notifications/test_signals.py
+++ b/tests/unit_tests/notifications/test_signals.py
@@ -139,7 +139,7 @@ class TestOnActivityFinished:
         assert n.context["is_successful"] is True
         assert n.context["status_label"] == ActivityStatus.SUCCESSFUL.label
         assert n.context["trigger_name"] == schedule.name
-        assert n.context["trigger_owner"] == member_user.username
+        assert n.context["trigger_owner"] == str(member_user)
         assert n.context["trigger_label"]
         assert n.context["repo_id"] == "acme/app"
         assert "duration_seconds" in n.context
@@ -290,48 +290,37 @@ class TestFanoutToSubscribers:
         assert Notification.objects.filter(recipient=sub1).count() == 0
         assert Notification.objects.filter(recipient=sub2).count() == 1
 
-    def test_same_named_schedules_from_different_owners_are_distinguishable_to_subscriber(self, member_user):
-        """A subscriber on two schedules sharing a name must be able to tell them apart
-        from the notification alone (subject + body), without clicking through."""
+    @pytest.mark.parametrize("status", [ActivityStatus.SUCCESSFUL, ActivityStatus.FAILED])
+    def test_same_named_schedules_from_different_owners_are_distinguishable_to_subscriber(self, member_user, status):
         owner_a = self._make_user("alice")
         owner_b = self._make_user("bob")
         sub = self._make_user("subscriber")
 
-        sched_a = ScheduledJob.objects.create(
-            user=owner_a,
-            name="nightly-sync",
-            prompt="p",
-            repos=[{"repo_id": "x/y", "ref": ""}],
-            frequency=Frequency.DAILY,
-            time="12:00",
-            notify_on=NotifyOn.ALWAYS,
-        )
-        sched_b = ScheduledJob.objects.create(
-            user=owner_b,
-            name="nightly-sync",
-            prompt="p",
-            repos=[{"repo_id": "x/y", "ref": ""}],
-            frequency=Frequency.DAILY,
-            time="12:00",
-            notify_on=NotifyOn.ALWAYS,
-        )
+        def _make_schedule(owner):
+            return ScheduledJob.objects.create(
+                user=owner,
+                name="nightly-sync",
+                prompt="p",
+                repos=[{"repo_id": "x/y", "ref": ""}],
+                frequency=Frequency.DAILY,
+                time="12:00",
+                notify_on=NotifyOn.ALWAYS,
+            )
+
+        sched_a = _make_schedule(owner_a)
+        sched_b = _make_schedule(owner_b)
         sched_a.subscribers.add(sub)
         sched_b.subscribers.add(sub)
 
         for sched in (sched_a, sched_b):
             activity = Activity.objects.create(
-                trigger_type=TriggerType.SCHEDULE,
-                user=sched.user,
-                repo_id="x/y",
-                status=ActivityStatus.SUCCESSFUL,
-                scheduled_job=sched,
+                trigger_type=TriggerType.SCHEDULE, user=sched.user, repo_id="x/y", status=status, scheduled_job=sched
             )
             activity_finished.send(sender=Activity, activity=activity)
 
         notifs = list(Notification.objects.filter(recipient=sub).order_by("created"))
         assert len(notifs) == 2
 
-        # Subjects must differ — the owner is the disambiguator since the name is shared.
         assert notifs[0].subject != notifs[1].subject
         assert "alice" in notifs[0].subject
         assert "bob" in notifs[1].subject
@@ -427,6 +416,7 @@ class TestJobActivityNotifications:
         n = Notification.objects.get(recipient=member_user, event_type="job.finished")
         assert "acme/app" in n.subject
         assert "failed" in n.subject.lower()
+        assert "Your" not in n.body
         assert n.context["trigger_label"]
         assert n.context["repo_id"] == "acme/app"
 
@@ -619,7 +609,9 @@ class TestBatchRollup:
         sub_rollup = Notification.objects.get(recipient=sub, event_type="job_batch.finished")
         assert schedule.name in owner_rollup.subject
         assert schedule.name in sub_rollup.subject
+        assert str(member_user) in sub_rollup.subject
         assert owner_rollup.context["trigger_name"] == schedule.name
+        assert sub_rollup.context["trigger_owner"] == str(member_user)
 
     def test_user_none_does_not_emit_rollup(self):
         bid = uuid.uuid4()


### PR DESCRIPTION
## Summary

- Schedule notifications now include the schedule owner and target repo in subject and body, so subscribers on multiple schedules sharing a name can tell them apart.
- Drops the "Your scheduled job …" / "Your agent run …" wording — it was misleading to subscribers who don't own the schedule.
- Adds `trigger_owner` to the notification context dict for future template use.
- No schema change: `Notification.subject/body/context` are already denormalized at write time, so the disambiguator survives schedule deletion via the persisted snapshot.

### Copy before / after

| Scenario | Before | After |
|---|---|---|
| Schedule, single, ok | `Scheduled job 'nightly-sync' succeeded` / `Your scheduled job 'nightly-sync' finished successfully.` | `'nightly-sync' succeeded on acme/api — alice` / `Scheduled run 'nightly-sync' by alice finished on acme/api.` |
| Schedule, batch, mixed | `Scheduled job 'nightly-sync' batch finished: 2/3 succeeded` | `'nightly-sync' batch: 2/3 succeeded — alice` |
| Agent run, ok | `Your agent run on 'acme/api' finished successfully.` | `Agent run on acme/api finished successfully.` |

## Test plan

- [x] `uv run pytest tests/unit_tests/notifications/test_signals.py` — 47 passed
- [x] `uv run ruff check daiv/notifications/signals.py tests/unit_tests/notifications/test_signals.py` — clean
- [x] New test `test_same_named_schedules_from_different_owners_are_distinguishable_to_subscriber` proves the disambiguation contract directly