### PR TITLE
fix(sandbox_envs): Restore repo-ids-editor.js used by env form

### DIFF
--- a/daiv/sandbox_envs/static/sandbox_envs/js/repo-ids-editor.js
+++ b/daiv/sandbox_envs/static/sandbox_envs/js/repo-ids-editor.js
@@ -1,0 +1,33 @@
+/**
+ * Alpine component: simple chip list of repo ids (owner/repo) bound to a
+ * hidden JSON input named `repo_ids_json`.
+ *
+ * Constructor arg: Array<string> — initial repo ids (already deduped).
+ */
+document.addEventListener("alpine:init", () => {
+    Alpine.data("repoIdsEditor", (initial = []) => ({
+        ids: Array.isArray(initial) ? [...initial] : [],
+        draft: "",
+        error: "",
+
+        addDraft() {
+            const value = this.draft.trim();
+            if (!value) return;
+            if (!/^[^\s/]+\/[^\s/]+$/.test(value)) {
+                this.error = "Use 'owner/repo' format.";
+                return;
+            }
+            if (this.ids.includes(value)) {
+                this.error = "Already added.";
+                return;
+            }
+            this.ids = [...this.ids, value];
+            this.draft = "";
+            this.error = "";
+        },
+
+        removeAt(i) {
+            this.ids = this.ids.filter((_, idx) => idx !== i);
+        },
+    }));
+});


### PR DESCRIPTION
## Summary
- Restore `daiv/sandbox_envs/static/sandbox_envs/js/repo-ids-editor.js`, deleted in 3581064c as "unused"
- The file is still referenced by [`_scripts.html`](daiv/sandbox_envs/templates/sandbox_envs/_scripts.html#L3) and the `repoIdsEditor` Alpine component is instantiated by [`_form_body.html`](daiv/sandbox_envs/templates/sandbox_envs/_form_body.html), so its absence caused `ValueError: Missing staticfiles manifest entry for 'sandbox_envs/js/repo-ids-editor.js'` when rendering the env form

## Test plan
- [ ] `collectstatic` runs cleanly and the manifest contains `sandbox_envs/js/repo-ids-editor.js`
- [ ] Sandbox env form page renders without 500
- [ ] Adding/removing repo ids in the chip editor still works