### PR TITLE
fix(sandbox_envs): Preserve is_default when editing the global default env

### DIFF
--- a/daiv/sandbox_envs/forms.py
+++ b/daiv/sandbox_envs/forms.py
@@ -41,14 +41,16 @@ class SandboxEnvironmentForm(forms.ModelForm):
 
     class Meta:
         model = SandboxEnvironment
-        fields = ("name", "description", "scope", "base_image", "cpus", "is_default")
+        # Excludes ``is_default`` deliberately: the template renders no checkbox,
+        # so including it here would demote the default on save (missing
+        # BooleanField → ``False``). Promotion is handled by a dedicated view.
+        fields = ("name", "description", "scope", "base_image", "cpus")
         widgets = {"description": forms.Textarea(attrs={"rows": 2})}
 
-    def __init__(self, *args, user=None, is_admin=False, is_default_form=False, **kwargs):
+    def __init__(self, *args, user=None, is_admin=False, **kwargs):
         super().__init__(*args, **kwargs)
         self.user = user
         self.is_admin = is_admin
-        self.is_default_form = is_default_form
         if not is_admin:
             # Non-admins cannot select GLOBAL. We restrict the available choices
             # rather than disabling the field, so a submitted GLOBAL value is
@@ -56,7 +58,6 @@ class SandboxEnvironmentForm(forms.ModelForm):
             # silently coerced to the initial value.
             self.fields["scope"].choices = [(Scope.USER.value, Scope.USER.label)]
             self.fields["scope"].initial = Scope.USER
-            self.fields.pop("is_default", None)
         instance = self.instance
         if instance.pk is not None:
             self.initial.setdefault("network_choice", _NETWORK_TO_CHOICE[instance.network_enabled])

--- a/daiv/sandbox_envs/views.py
+++ b/daiv/sandbox_envs/views.py
@@ -65,11 +65,7 @@ class EnvFormView(LoginRequiredMixin, View):
 
     def _make_form(self, *, instance, data=None):
         return SandboxEnvironmentForm(
-            data,
-            instance=instance,
-            user=self.request.user,
-            is_admin=self.request.user.is_admin,
-            is_default_form=self._is_default_form(instance),
+            data, instance=instance, user=self.request.user, is_admin=self.request.user.is_admin
         )
 
     @cached_property

--- a/tests/unit_tests/sandbox_envs/test_views.py
+++ b/tests/unit_tests/sandbox_envs/test_views.py
@@ -314,6 +314,61 @@ def test_edit_global_default_sets_is_default_form_true(client, admin):
 
 
 @pytest.mark.django_db
+def test_edit_global_default_post_preserves_is_default(client, admin):
+    env = SandboxEnvironment.objects.create(
+        scope=Scope.GLOBAL, name="Default", base_image="python:3.14", is_default=True
+    )
+    client.force_login(admin)
+    resp = client.post(
+        reverse("sandbox_envs:edit", args=[env.id]),
+        data={
+            "name": "Default",
+            "description": "edited",
+            "scope": Scope.GLOBAL,
+            "base_image": "python:3.14",
+            "memory_value": "",
+            "memory_unit": "MiB",
+            "network_choice": "default",
+            "env_vars_json": "[]",
+        },
+        HTTP_HX_REQUEST="true",
+    )
+    assert resp.status_code == 204
+    env.refresh_from_db()
+    assert env.is_default is True
+    assert env.description == "edited"
+
+
+@pytest.mark.django_db
+def test_edit_post_cannot_promote_via_is_default_field(client, admin):
+    """Promotion is owned by ``EnvSetDefaultView``; submitting ``is_default=true``
+    in an edit POST must be ignored."""
+    SandboxEnvironment.objects.create(scope=Scope.GLOBAL, name="Current", base_image="python:3.14", is_default=True)
+    candidate = SandboxEnvironment.objects.create(
+        scope=Scope.GLOBAL, name="Candidate", base_image="python:3.14", is_default=False
+    )
+    client.force_login(admin)
+    resp = client.post(
+        reverse("sandbox_envs:edit", args=[candidate.id]),
+        data={
+            "name": "Candidate",
+            "description": "",
+            "scope": Scope.GLOBAL,
+            "base_image": "python:3.14",
+            "memory_value": "",
+            "memory_unit": "MiB",
+            "network_choice": "default",
+            "env_vars_json": "[]",
+            "is_default": "true",
+        },
+        HTTP_HX_REQUEST="true",
+    )
+    assert resp.status_code == 204
+    candidate.refresh_from_db()
+    assert candidate.is_default is False
+
+
+@pytest.mark.django_db
 def test_edit_non_default_user_env_sets_is_default_form_false(client, user):
     env = SandboxEnvironment.objects.create(scope=Scope.USER, user=user, name="dev", base_image="alpine")
     client.force_login(user)


### PR DESCRIPTION
## Summary
- `SandboxEnvironmentForm.Meta.fields` listed `is_default` but the template renders no checkbox for it, so on every edit POST Django's `BooleanField` saw the missing key, coerced it to `False`, and silently demoted the global default.
- Fix: remove `is_default` from `Meta.fields`. Promotion is owned by `EnvSetDefaultView.promote_as_default()` (separate endpoint), so the edit form should never touch the flag.
- Cleanup: drop the dead `is_default_form` kwarg + attribute on the form — the view already wires the template context for the "Unconstrained" UI labels directly via `_render`.

## Test plan
- [x] Added `test_edit_global_default_post_preserves_is_default` — POSTs an edit to the global default and asserts `is_default` survives and the description was saved.
- [x] Added `test_edit_post_cannot_promote_via_is_default_field` — submits `is_default=true` in form data on a non-default env and asserts it is ignored (locks the "promotion only via the dedicated view" invariant).
- [x] Full `tests/unit_tests/sandbox_envs/` suite: 134 passed.