### PR TITLE
fix(sandbox_envs): Default-flag-on-edit + webhook env persistence

### DIFF
--- a/daiv/codebase/clients/github/api/callbacks.py
+++ b/daiv/codebase/clients/github/api/callbacks.py
@@ -6,6 +6,7 @@ from activity.models import TriggerType
 from activity.services import acreate_activity
 from asgiref.sync import sync_to_async
 from github.GithubException import GithubException
+from sandbox_envs.services import resolve_env_for_run
 
 from accounts.utils import resolve_user
 from codebase.api.callbacks import BaseCallback
@@ -99,8 +100,16 @@ class IssueCallback(GitHubCallback):
         thread_id = compute_thread_id(
             repo_slug=self.repository.full_name, scope=Scope.ISSUE, entity_iid=self.issue.number
         )
+        # user=None: webhook triggers are not scoped to the commenter's USER envs (the webhook
+        # fires for whoever interacted with the issue/PR, not the configured agent owner). Only
+        # GLOBAL repo envs and the GLOBAL default apply — mirroring set_runtime_ctx's contract.
+        sandbox_env = await resolve_env_for_run(user=None, repo_id=self.repository.full_name)
+        sandbox_environment_id = str(sandbox_env.id) if sandbox_env is not None else None
         result = await address_issue_task.aenqueue(
-            repo_id=self.repository.full_name, issue_iid=self.issue.number, thread_id=thread_id
+            repo_id=self.repository.full_name,
+            issue_iid=self.issue.number,
+            thread_id=thread_id,
+            sandbox_environment_id=sandbox_environment_id,
         )
         daiv_user = await resolve_user("github", self.sender.id, username=self.sender.username)
         try:
@@ -114,6 +123,7 @@ class IssueCallback(GitHubCallback):
                 external_username=self.sender.username,
                 title=self.issue.title,
                 thread_id=thread_id,
+                sandbox_environment_id=sandbox_environment_id,
             )
         except Exception:
             logger.exception("Failed to create activity for issue %s#%s", self.repository.full_name, self.issue.number)
@@ -171,11 +181,14 @@ class IssueCommentCallback(GitHubCallback):
             thread_id = compute_thread_id(
                 repo_slug=self.repository.full_name, scope=Scope.ISSUE, entity_iid=self.issue.number
             )
+            sandbox_env = await resolve_env_for_run(user=None, repo_id=self.repository.full_name)
+            sandbox_environment_id = str(sandbox_env.id) if sandbox_env is not None else None
             result = await address_issue_task.aenqueue(
                 repo_id=self.repository.full_name,
                 issue_iid=self.issue.number,
                 mention_comment_id=str(self.comment.id),
                 thread_id=thread_id,
+                sandbox_environment_id=sandbox_environment_id,
             )
             try:
                 await acreate_activity(
@@ -189,6 +202,7 @@ class IssueCommentCallback(GitHubCallback):
                     external_username=self.comment.user.username,
                     title=self.issue.title,
                     thread_id=thread_id,
+                    sandbox_environment_id=sandbox_environment_id,
                 )
             except Exception:
                 logger.exception(
@@ -205,11 +219,14 @@ class IssueCommentCallback(GitHubCallback):
             thread_id = compute_thread_id(
                 repo_slug=self.repository.full_name, scope=Scope.MERGE_REQUEST, entity_iid=self.issue.number
             )
+            sandbox_env = await resolve_env_for_run(user=None, repo_id=self.repository.full_name)
+            sandbox_environment_id = str(sandbox_env.id) if sandbox_env is not None else None
             result = await address_mr_comments_task.aenqueue(
                 repo_id=self.repository.full_name,
                 merge_request_id=self.issue.number,
                 mention_comment_id=str(self.comment.id),
                 thread_id=thread_id,
+                sandbox_environment_id=sandbox_environment_id,
             )
             # GitHub's issue_comment payload omits head.ref, so fetch the PR. If that
             # fails the activity is still useful without a branch — don't drop it.
@@ -234,6 +251,7 @@ class IssueCommentCallback(GitHubCallback):
                     external_username=self.comment.user.username,
                     title=self.issue.title,
                     thread_id=thread_id,
+                    sandbox_environment_id=sandbox_environment_id,
                 )
             except Exception:
                 logger.exception(

--- a/daiv/codebase/clients/gitlab/api/callbacks.py
+++ b/daiv/codebase/clients/gitlab/api/callbacks.py
@@ -5,6 +5,7 @@ from typing import Any, Literal
 from activity.models import TriggerType
 from activity.services import acreate_activity
 from gitlab.exceptions import GitlabError
+from sandbox_envs.services import resolve_env_for_run
 
 from accounts.utils import resolve_user
 from codebase.api.callbacks import BaseCallback
@@ -114,8 +115,16 @@ class IssueCallback(BaseCallback):
         thread_id = compute_thread_id(
             repo_slug=self.project.path_with_namespace, scope=Scope.ISSUE, entity_iid=self.object_attributes.iid
         )
+        # user=None: webhook triggers are not scoped to the commenter's USER envs (the webhook
+        # fires for whoever interacted with the issue/MR, not the configured agent owner). Only
+        # GLOBAL repo envs and the GLOBAL default apply — mirroring set_runtime_ctx's contract.
+        sandbox_env = await resolve_env_for_run(user=None, repo_id=self.project.path_with_namespace)
+        sandbox_environment_id = str(sandbox_env.id) if sandbox_env is not None else None
         result = await address_issue_task.aenqueue(
-            repo_id=self.project.path_with_namespace, issue_iid=self.object_attributes.iid, thread_id=thread_id
+            repo_id=self.project.path_with_namespace,
+            issue_iid=self.object_attributes.iid,
+            thread_id=thread_id,
+            sandbox_environment_id=sandbox_environment_id,
         )
         daiv_user = await resolve_user("gitlab", self.user.id, username=self.user.username, email=self.user.email)
         try:
@@ -129,6 +138,7 @@ class IssueCallback(BaseCallback):
                 external_username=self.user.username,
                 title=self.object_attributes.title,
                 thread_id=thread_id,
+                sandbox_environment_id=sandbox_environment_id,
             )
         except Exception:
             logger.exception(
@@ -194,11 +204,14 @@ class NoteCallback(BaseCallback):
             thread_id = compute_thread_id(
                 repo_slug=self.project.path_with_namespace, scope=Scope.ISSUE, entity_iid=self.issue.iid
             )
+            sandbox_env = await resolve_env_for_run(user=None, repo_id=self.project.path_with_namespace)
+            sandbox_environment_id = str(sandbox_env.id) if sandbox_env is not None else None
             result = await address_issue_task.aenqueue(
                 repo_id=self.project.path_with_namespace,
                 issue_iid=self.issue.iid,
                 mention_comment_id=self.object_attributes.discussion_id,
                 thread_id=thread_id,
+                sandbox_environment_id=sandbox_environment_id,
             )
             try:
                 await acreate_activity(
@@ -212,6 +225,7 @@ class NoteCallback(BaseCallback):
                     external_username=self.user.username,
                     title=self.issue.title,
                     thread_id=thread_id,
+                    sandbox_environment_id=sandbox_environment_id,
                 )
             except Exception:
                 logger.exception(
@@ -230,11 +244,14 @@ class NoteCallback(BaseCallback):
             thread_id = compute_thread_id(
                 repo_slug=self.project.path_with_namespace, scope=Scope.MERGE_REQUEST, entity_iid=self.merge_request.iid
             )
+            sandbox_env = await resolve_env_for_run(user=None, repo_id=self.project.path_with_namespace)
+            sandbox_environment_id = str(sandbox_env.id) if sandbox_env is not None else None
             result = await address_mr_comments_task.aenqueue(
                 repo_id=self.project.path_with_namespace,
                 merge_request_id=self.merge_request.iid,
                 mention_comment_id=self.object_attributes.discussion_id,
                 thread_id=thread_id,
+                sandbox_environment_id=sandbox_environment_id,
             )
             try:
                 await acreate_activity(
@@ -249,6 +266,7 @@ class NoteCallback(BaseCallback):
                     external_username=self.user.username,
                     title=self.merge_request.title,
                     thread_id=thread_id,
+                    sandbox_environment_id=sandbox_environment_id,
                 )
             except Exception:
                 logger.exception(

--- a/daiv/codebase/tasks.py
+++ b/daiv/codebase/tasks.py
@@ -41,6 +41,7 @@ async def address_issue_task(
     mention_comment_id: str | None = None,
     ref: str | None = None,
     thread_id: str | None = None,
+    sandbox_environment_id: str | None = None,
 ) -> AgentResult:
     """
     Address an issue by creating a merge request with the changes described on the issue description.
@@ -52,10 +53,16 @@ async def address_issue_task(
         ref (str | None): The reference. Defaults to None.
         thread_id (str | None): The LangGraph checkpoint key minted by the caller. When ``None``
             the addressor recomputes it from the runtime context.
+        sandbox_environment_id (str | None): Per-run sandbox env id resolved at webhook time.
+            When ``None``, ``set_runtime_ctx`` auto-resolves via
+            :func:`sandbox_envs.services.resolve_env_for_run` (USER tier skipped) and ultimately
+            falls back to the GLOBAL ``is_default=True`` env — so a non-None env may still apply.
     """
     client = RepoClient.create_instance()
     issue = client.get_issue(repo_id, issue_iid)
-    async with set_runtime_ctx(repo_id, scope=Scope.ISSUE, ref=ref, issue=issue) as runtime_ctx:
+    async with set_runtime_ctx(
+        repo_id, scope=Scope.ISSUE, ref=ref, issue=issue, sandbox_env_id=sandbox_environment_id
+    ) as runtime_ctx:
         return await IssueAddressorManager.address_issue(
             issue=issue, mention_comment_id=mention_comment_id, runtime_ctx=runtime_ctx, thread_id=thread_id
         )
@@ -191,7 +198,11 @@ async def record_merge_metrics_task(
 
 @task(dedup=True)
 async def address_mr_comments_task(
-    repo_id: str, merge_request_id: int, mention_comment_id: str, thread_id: str | None = None
+    repo_id: str,
+    merge_request_id: int,
+    mention_comment_id: str,
+    thread_id: str | None = None,
+    sandbox_environment_id: str | None = None,
 ) -> AgentResult:
     """
     Address comments left directly on the merge request (not in the diff or thread) that mention DAIV.
@@ -202,11 +213,19 @@ async def address_mr_comments_task(
         mention_comment_id (str): The mention comment id.
         thread_id (str | None): The LangGraph checkpoint key minted by the caller. When ``None``
             the addressor recomputes it from the runtime context.
+        sandbox_environment_id (str | None): Per-run sandbox env id resolved at webhook time.
+            When ``None``, ``set_runtime_ctx`` auto-resolves via
+            :func:`sandbox_envs.services.resolve_env_for_run` (USER tier skipped) and ultimately
+            falls back to the GLOBAL ``is_default=True`` env — so a non-None env may still apply.
     """
     client = RepoClient.create_instance()
     merge_request = client.get_merge_request(repo_id, merge_request_id)
     async with set_runtime_ctx(
-        repo_id, scope=Scope.MERGE_REQUEST, ref=merge_request.source_branch, merge_request=merge_request
+        repo_id,
+        scope=Scope.MERGE_REQUEST,
+        ref=merge_request.source_branch,
+        merge_request=merge_request,
+        sandbox_env_id=sandbox_environment_id,
     ) as runtime_ctx:
         return await CommentsAddressorManager.address_comments(
             merge_request=merge_request,

--- a/daiv/sandbox_envs/forms.py
+++ b/daiv/sandbox_envs/forms.py
@@ -41,14 +41,16 @@ class SandboxEnvironmentForm(forms.ModelForm):
 
     class Meta:
         model = SandboxEnvironment
-        fields = ("name", "description", "scope", "base_image", "cpus", "is_default")
+        # Excludes ``is_default`` deliberately: the template renders no checkbox,
+        # so including it here would demote the default on save (missing
+        # BooleanField → ``False``). Promotion is handled by a dedicated view.
+        fields = ("name", "description", "scope", "base_image", "cpus")
         widgets = {"description": forms.Textarea(attrs={"rows": 2})}
 
-    def __init__(self, *args, user=None, is_admin=False, is_default_form=False, **kwargs):
+    def __init__(self, *args, user=None, is_admin=False, **kwargs):
         super().__init__(*args, **kwargs)
         self.user = user
         self.is_admin = is_admin
-        self.is_default_form = is_default_form
         if not is_admin:
             # Non-admins cannot select GLOBAL. We restrict the available choices
             # rather than disabling the field, so a submitted GLOBAL value is
@@ -56,7 +58,6 @@ class SandboxEnvironmentForm(forms.ModelForm):
             # silently coerced to the initial value.
             self.fields["scope"].choices = [(Scope.USER.value, Scope.USER.label)]
             self.fields["scope"].initial = Scope.USER
-            self.fields.pop("is_default", None)
         instance = self.instance
         if instance.pk is not None:
             self.initial.setdefault("network_choice", _NETWORK_TO_CHOICE[instance.network_enabled])

--- a/daiv/sandbox_envs/views.py
+++ b/daiv/sandbox_envs/views.py
@@ -65,11 +65,7 @@ class EnvFormView(LoginRequiredMixin, View):
 
     def _make_form(self, *, instance, data=None):
         return SandboxEnvironmentForm(
-            data,
-            instance=instance,
-            user=self.request.user,
-            is_admin=self.request.user.is_admin,
-            is_default_form=self._is_default_form(instance),
+            data, instance=instance, user=self.request.user, is_admin=self.request.user.is_admin
         )
 
     @cached_property

--- a/tests/unit_tests/codebase/clients/github/api/test_callbacks.py
+++ b/tests/unit_tests/codebase/clients/github/api/test_callbacks.py
@@ -318,6 +318,7 @@ class TestProcessCallbackThreadId:
             patch("codebase.clients.github.api.callbacks.address_issue_task") as mock_task,
             patch("codebase.clients.github.api.callbacks.acreate_activity") as mock_activity,
             patch("codebase.clients.github.api.callbacks.resolve_user", new=AsyncMock(return_value=None)),
+            patch("codebase.clients.github.api.callbacks.resolve_env_for_run", new=AsyncMock(return_value=None)),
         ):
             mock_task.aenqueue = AsyncMock(return_value=type("R", (), {"id": "task-1"})())
             mock_activity.side_effect = AsyncMock(return_value=None)
@@ -346,6 +347,7 @@ class TestProcessCallbackThreadId:
             patch("codebase.clients.github.api.callbacks.acreate_activity") as mock_activity,
             patch("codebase.clients.github.api.callbacks.note_mentions_daiv", return_value=True),
             patch("codebase.clients.github.api.callbacks.resolve_user", new=AsyncMock(return_value=None)),
+            patch("codebase.clients.github.api.callbacks.resolve_env_for_run", new=AsyncMock(return_value=None)),
         ):
             mock_task.aenqueue = AsyncMock(return_value=type("R", (), {"id": "task-1"})())
             mock_activity.side_effect = AsyncMock(return_value=None)
@@ -378,6 +380,7 @@ class TestProcessCallbackThreadId:
             patch("codebase.clients.github.api.callbacks.acreate_activity") as mock_activity,
             patch("codebase.clients.github.api.callbacks.note_mentions_daiv", return_value=True),
             patch("codebase.clients.github.api.callbacks.resolve_user", new=AsyncMock(return_value=None)),
+            patch("codebase.clients.github.api.callbacks.resolve_env_for_run", new=AsyncMock(return_value=None)),
         ):
             mock_task.aenqueue = AsyncMock(return_value=type("R", (), {"id": "task-1"})())
             mock_activity.side_effect = AsyncMock(return_value=None)
@@ -387,3 +390,83 @@ class TestProcessCallbackThreadId:
         assert mock_task.aenqueue.call_args.kwargs["thread_id"] == expected
         assert mock_activity.call_args.kwargs["thread_id"] == expected
         assert mock_activity.call_args.kwargs["ref"] == "feat/x"
+
+
+class TestProcessCallbackSandboxEnvironment:
+    """Webhook callbacks must forward the resolved env id to both the task and the Activity row."""
+
+    async def test_issue_callback_propagates_env_id(self, monkeypatch_dependencies, mock_repo_client):
+        from unittest.mock import AsyncMock, Mock, patch
+
+        callback = create_issue_callback(action="opened", issue_labels=[Label(id=1, name=BOT_LABEL)])
+        callback.sender = User(**{"id": 10, "login": "testuser"})
+        env_row = Mock(id="env-uuid-1")
+
+        with (
+            patch("codebase.clients.github.api.callbacks.address_issue_task") as mock_task,
+            patch("codebase.clients.github.api.callbacks.acreate_activity") as mock_activity,
+            patch("codebase.clients.github.api.callbacks.resolve_user", new=AsyncMock(return_value=None)),
+            patch("codebase.clients.github.api.callbacks.resolve_env_for_run", new=AsyncMock(return_value=env_row)),
+        ):
+            mock_task.aenqueue = AsyncMock(return_value=type("R", (), {"id": "task-1"})())
+            mock_activity.side_effect = AsyncMock(return_value=None)
+            await callback.process_callback()
+
+        assert mock_task.aenqueue.call_args.kwargs["sandbox_environment_id"] == "env-uuid-1"
+        assert mock_activity.call_args.kwargs["sandbox_environment_id"] == "env-uuid-1"
+
+    async def test_pr_review_comment_callback_propagates_env_id(self, monkeypatch_dependencies, mock_repo_config):
+        from unittest.mock import AsyncMock, Mock, patch
+
+        mock_repo_config.pull_request_assistant.enabled = True
+
+        callback = IssueCommentCallback(
+            action="created",
+            repository=Repository(id=1, full_name="owner/repo", default_branch="main"),
+            issue=Issue(
+                id=100, number=99, title="PR", state="open", labels=[], pull_request={"url": "https://example/pr/99"}
+            ),
+            comment=Comment(id=300, body="@daiv review", user=User(**{"id": 10, "login": "alice"})),
+        )
+        env_row = Mock(id="env-uuid-2")
+
+        with (
+            patch("codebase.clients.github.api.callbacks.address_mr_comments_task") as mock_task,
+            patch("codebase.clients.github.api.callbacks.acreate_activity") as mock_activity,
+            patch("codebase.clients.github.api.callbacks.note_mentions_daiv", return_value=True),
+            patch("codebase.clients.github.api.callbacks.resolve_user", new=AsyncMock(return_value=None)),
+            patch("codebase.clients.github.api.callbacks.resolve_env_for_run", new=AsyncMock(return_value=env_row)),
+        ):
+            mock_task.aenqueue = AsyncMock(return_value=type("R", (), {"id": "task-1"})())
+            mock_activity.side_effect = AsyncMock(return_value=None)
+            callback._client.get_merge_request = Mock(return_value=Mock(source_branch="feat/x"))
+            await callback.process_callback()
+
+        assert mock_task.aenqueue.call_args.kwargs["sandbox_environment_id"] == "env-uuid-2"
+        assert mock_activity.call_args.kwargs["sandbox_environment_id"] == "env-uuid-2"
+
+    async def test_issue_comment_callback_propagates_env_id(self, monkeypatch_dependencies, mock_repo_config):
+        from unittest.mock import AsyncMock, Mock, patch
+
+        # Plain issue (no pull_request) → ISSUE-comment branch.
+        callback = IssueCommentCallback(
+            action="created",
+            repository=Repository(id=1, full_name="owner/repo", default_branch="main"),
+            issue=Issue(id=100, number=42, title="Bug", state="open", labels=[]),
+            comment=Comment(id=200, body="@daiv help", user=User(**{"id": 10, "login": "alice"})),
+        )
+        env_row = Mock(id="env-uuid-3")
+
+        with (
+            patch("codebase.clients.github.api.callbacks.address_issue_task") as mock_task,
+            patch("codebase.clients.github.api.callbacks.acreate_activity") as mock_activity,
+            patch("codebase.clients.github.api.callbacks.note_mentions_daiv", return_value=True),
+            patch("codebase.clients.github.api.callbacks.resolve_user", new=AsyncMock(return_value=None)),
+            patch("codebase.clients.github.api.callbacks.resolve_env_for_run", new=AsyncMock(return_value=env_row)),
+        ):
+            mock_task.aenqueue = AsyncMock(return_value=type("R", (), {"id": "task-1"})())
+            mock_activity.side_effect = AsyncMock(return_value=None)
+            await callback.process_callback()
+
+        assert mock_task.aenqueue.call_args.kwargs["sandbox_environment_id"] == "env-uuid-3"
+        assert mock_activity.call_args.kwargs["sandbox_environment_id"] == "env-uuid-3"

--- a/tests/unit_tests/codebase/clients/gitlab/api/test_callbacks.py
+++ b/tests/unit_tests/codebase/clients/gitlab/api/test_callbacks.py
@@ -539,6 +539,7 @@ class TestProcessCallbackThreadId:
             patch("codebase.clients.gitlab.api.callbacks.address_issue_task") as mock_task,
             patch("codebase.clients.gitlab.api.callbacks.acreate_activity") as mock_activity,
             patch("codebase.clients.gitlab.api.callbacks.resolve_user", new=AsyncMock(return_value=None)),
+            patch("codebase.clients.gitlab.api.callbacks.resolve_env_for_run", new=AsyncMock(return_value=None)),
         ):
             mock_task.aenqueue = AsyncMock(return_value=type("R", (), {"id": "task-1"})())
             mock_activity.return_value = None
@@ -561,6 +562,7 @@ class TestProcessCallbackThreadId:
             patch("codebase.clients.gitlab.api.callbacks.address_mr_comments_task") as mock_task,
             patch("codebase.clients.gitlab.api.callbacks.acreate_activity") as mock_activity,
             patch("codebase.clients.gitlab.api.callbacks.resolve_user", new=AsyncMock(return_value=None)),
+            patch("codebase.clients.gitlab.api.callbacks.resolve_env_for_run", new=AsyncMock(return_value=None)),
         ):
             mock_task.aenqueue = AsyncMock(return_value=type("R", (), {"id": "task-1"})())
             mock_activity.side_effect = AsyncMock(return_value=None)
@@ -607,6 +609,7 @@ class TestProcessCallbackThreadId:
             patch("codebase.clients.gitlab.api.callbacks.address_issue_task") as mock_task,
             patch("codebase.clients.gitlab.api.callbacks.acreate_activity") as mock_activity,
             patch("codebase.clients.gitlab.api.callbacks.resolve_user", new=AsyncMock(return_value=None)),
+            patch("codebase.clients.gitlab.api.callbacks.resolve_env_for_run", new=AsyncMock(return_value=None)),
         ):
             mock_task.aenqueue = AsyncMock(return_value=type("R", (), {"id": "task-1"})())
             mock_activity.side_effect = AsyncMock(return_value=None)
@@ -614,3 +617,106 @@ class TestProcessCallbackThreadId:
 
         assert mock_task.aenqueue.call_args.kwargs["thread_id"] == expected
         assert mock_activity.call_args.kwargs["thread_id"] == expected
+
+
+class TestProcessCallbackSandboxEnvironment:
+    """Webhook callbacks must forward the resolved env id to both the task and the Activity row."""
+
+    async def test_issue_callback_propagates_env_id(self, monkeypatch_dependencies):
+        from unittest.mock import AsyncMock, Mock, patch
+
+        callback = create_issue_callback(action=IssueAction.OPEN, issue_labels=[Label(title="daiv")])
+        env_row = Mock(id="env-uuid-1")
+
+        with (
+            patch("codebase.clients.gitlab.api.callbacks.address_issue_task") as mock_task,
+            patch("codebase.clients.gitlab.api.callbacks.acreate_activity") as mock_activity,
+            patch("codebase.clients.gitlab.api.callbacks.resolve_user", new=AsyncMock(return_value=None)),
+            patch("codebase.clients.gitlab.api.callbacks.resolve_env_for_run", new=AsyncMock(return_value=env_row)),
+        ):
+            mock_task.aenqueue = AsyncMock(return_value=type("R", (), {"id": "task-1"})())
+            mock_activity.side_effect = AsyncMock(return_value=None)
+            await callback.process_callback()
+
+        assert mock_task.aenqueue.call_args.kwargs["sandbox_environment_id"] == "env-uuid-1"
+        assert mock_activity.call_args.kwargs["sandbox_environment_id"] == "env-uuid-1"
+
+    async def test_note_callback_on_mr_propagates_env_id(self, monkeypatch_dependencies):
+        from unittest.mock import AsyncMock, Mock, patch
+
+        callback = create_note_callback("@daiv please review")
+        env_row = Mock(id="env-uuid-2")
+
+        with (
+            patch("codebase.clients.gitlab.api.callbacks.address_mr_comments_task") as mock_task,
+            patch("codebase.clients.gitlab.api.callbacks.acreate_activity") as mock_activity,
+            patch("codebase.clients.gitlab.api.callbacks.resolve_user", new=AsyncMock(return_value=None)),
+            patch("codebase.clients.gitlab.api.callbacks.resolve_env_for_run", new=AsyncMock(return_value=env_row)),
+        ):
+            mock_task.aenqueue = AsyncMock(return_value=type("R", (), {"id": "task-1"})())
+            mock_activity.side_effect = AsyncMock(return_value=None)
+            await callback.process_callback()
+
+        assert mock_task.aenqueue.call_args.kwargs["sandbox_environment_id"] == "env-uuid-2"
+        assert mock_activity.call_args.kwargs["sandbox_environment_id"] == "env-uuid-2"
+
+    async def test_issue_callback_no_env_resolves_to_none(self, monkeypatch_dependencies):
+        from unittest.mock import AsyncMock, patch
+
+        callback = create_issue_callback(action=IssueAction.OPEN, issue_labels=[Label(title="daiv")])
+
+        with (
+            patch("codebase.clients.gitlab.api.callbacks.address_issue_task") as mock_task,
+            patch("codebase.clients.gitlab.api.callbacks.acreate_activity") as mock_activity,
+            patch("codebase.clients.gitlab.api.callbacks.resolve_user", new=AsyncMock(return_value=None)),
+            patch("codebase.clients.gitlab.api.callbacks.resolve_env_for_run", new=AsyncMock(return_value=None)),
+        ):
+            mock_task.aenqueue = AsyncMock(return_value=type("R", (), {"id": "task-1"})())
+            mock_activity.side_effect = AsyncMock(return_value=None)
+            await callback.process_callback()
+
+        assert mock_task.aenqueue.call_args.kwargs["sandbox_environment_id"] is None
+        assert mock_activity.call_args.kwargs["sandbox_environment_id"] is None
+
+    async def test_note_callback_on_issue_propagates_env_id(self, monkeypatch_dependencies):
+        from unittest.mock import AsyncMock, Mock, patch
+
+        callback = NoteCallback(
+            object_kind="note",
+            project=Project(id=1, path_with_namespace="group/repo", default_branch="main"),
+            user=User(id=2, username="reviewer", name="Reviewer", email="reviewer@example.com"),
+            issue=Issue(
+                id=100,
+                iid=7,
+                title="Bug",
+                description="x",
+                state="opened",
+                assignee_id=None,
+                action=IssueAction.OPEN,
+                labels=[],
+                type="Issue",
+            ),
+            object_attributes=Note(
+                id=200,
+                action=NoteAction.CREATE,
+                noteable_type=NoteableType.ISSUE,
+                noteable_id=7,
+                discussion_id="discussion_2",
+                note="@daiv please look",
+                system=False,
+            ),
+        )
+        env_row = Mock(id="env-uuid-3")
+
+        with (
+            patch("codebase.clients.gitlab.api.callbacks.address_issue_task") as mock_task,
+            patch("codebase.clients.gitlab.api.callbacks.acreate_activity") as mock_activity,
+            patch("codebase.clients.gitlab.api.callbacks.resolve_user", new=AsyncMock(return_value=None)),
+            patch("codebase.clients.gitlab.api.callbacks.resolve_env_for_run", new=AsyncMock(return_value=env_row)),
+        ):
+            mock_task.aenqueue = AsyncMock(return_value=type("R", (), {"id": "task-1"})())
+            mock_activity.side_effect = AsyncMock(return_value=None)
+            await callback.process_callback()
+
+        assert mock_task.aenqueue.call_args.kwargs["sandbox_environment_id"] == "env-uuid-3"
+        assert mock_activity.call_args.kwargs["sandbox_environment_id"] == "env-uuid-3"

--- a/tests/unit_tests/sandbox_envs/test_views.py
+++ b/tests/unit_tests/sandbox_envs/test_views.py
@@ -314,6 +314,61 @@ def test_edit_global_default_sets_is_default_form_true(client, admin):
 
 
 @pytest.mark.django_db
+def test_edit_global_default_post_preserves_is_default(client, admin):
+    env = SandboxEnvironment.objects.create(
+        scope=Scope.GLOBAL, name="Default", base_image="python:3.14", is_default=True
+    )
+    client.force_login(admin)
+    resp = client.post(
+        reverse("sandbox_envs:edit", args=[env.id]),
+        data={
+            "name": "Default",
+            "description": "edited",
+            "scope": Scope.GLOBAL,
+            "base_image": "python:3.14",
+            "memory_value": "",
+            "memory_unit": "MiB",
+            "network_choice": "default",
+            "env_vars_json": "[]",
+        },
+        HTTP_HX_REQUEST="true",
+    )
+    assert resp.status_code == 204
+    env.refresh_from_db()
+    assert env.is_default is True
+    assert env.description == "edited"
+
+
+@pytest.mark.django_db
+def test_edit_post_cannot_promote_via_is_default_field(client, admin):
+    """Promotion is owned by ``EnvSetDefaultView``; submitting ``is_default=true``
+    in an edit POST must be ignored."""
+    SandboxEnvironment.objects.create(scope=Scope.GLOBAL, name="Current", base_image="python:3.14", is_default=True)
+    candidate = SandboxEnvironment.objects.create(
+        scope=Scope.GLOBAL, name="Candidate", base_image="python:3.14", is_default=False
+    )
+    client.force_login(admin)
+    resp = client.post(
+        reverse("sandbox_envs:edit", args=[candidate.id]),
+        data={
+            "name": "Candidate",
+            "description": "",
+            "scope": Scope.GLOBAL,
+            "base_image": "python:3.14",
+            "memory_value": "",
+            "memory_unit": "MiB",
+            "network_choice": "default",
+            "env_vars_json": "[]",
+            "is_default": "true",
+        },
+        HTTP_HX_REQUEST="true",
+    )
+    assert resp.status_code == 204
+    candidate.refresh_from_db()
+    assert candidate.is_default is False
+
+
+@pytest.mark.django_db
 def test_edit_non_default_user_env_sets_is_default_form_false(client, user):
     env = SandboxEnvironment.objects.create(scope=Scope.USER, user=user, name="dev", base_image="alpine")
     client.force_login(user)


### PR DESCRIPTION
## Summary

Two independent fixes in the sandbox_envs area.

- **Preserve `is_default` when editing the global default env**: the edit ModelForm included `is_default` in `Meta.fields` but the template rendered no checkbox, so POSTs silently coerced it to `False` and demoted the global default on every save. The form now omits the field; promotion remains owned by `EnvSetDefaultView`.
- **Persist resolved env on webhook-triggered activities**: webhook callbacks (GitLab/GitHub issue, issue-comment, MR/PR-comment) never resolved an env at submission time, leaving `Activity.sandbox_environment` NULL. The dashboard rail then rendered `(deleted)` even though `set_runtime_ctx` was auto-resolving one at runtime — i.e. the run used an env the UI couldn't show. Each webhook now calls `resolve_env_for_run(user=None, ...)` (mirroring `set_runtime_ctx`'s own contract for webhook-triggered runs) and passes the id to both the addressor task and `acreate_activity`, locking the env at submission time as the chat/MCP/API/scheduled paths already do. `address_issue_task` and `address_mr_comments_task` gain an optional `sandbox_environment_id` kwarg.

## Test plan

- [x] `make test` — 2276 passed (added 5 env-propagation tests across both platforms)
- [x] `make lint-fix` — clean
- [x] `make lint-typing` — no new errors introduced
- [ ] Trigger a webhook (issue label / @daiv comment) on a repo with a matching GLOBAL env and verify the dashboard activity rail shows the env name, not `(deleted)`
- [ ] Trigger a webhook on a repo with no matching env and verify the run still proceeds (falls back to GLOBAL default via runtime auto-resolution); rail will continue to show `(deleted)` only for pre-fix legacy rows
- [ ] Edit the GLOBAL default env via the admin form, save, and confirm it remains the default