### PR TITLE
feat(notifications): Render Rocket Chat as event-typed attachments

### DIFF
--- a/daiv/notifications/channels/rocketchat.py
+++ b/daiv/notifications/channels/rocketchat.py
@@ -12,6 +12,7 @@ from core.site_settings import site_settings
 from core.utils import build_absolute_url, build_uri
 from notifications.channels.base import NotificationChannel
 from notifications.channels.registry import register_channel
+from notifications.channels.rocketchat_renderers.registry import get_renderer
 from notifications.choices import ChannelType
 from notifications.exceptions import UnrecoverableDeliveryError
 
@@ -159,6 +160,20 @@ def _compose_text(notification: Notification) -> str:
     return "\n".join(parts)
 
 
+def _build_payload(notification: Notification, delivery: NotificationDelivery) -> dict:
+    """Build the ``chat.postMessage`` body for ``notification``.
+
+    Falls back to a plain-text message when no renderer is registered for the
+    event type, so newly-introduced events deliver before their renderer ships.
+    """
+    channel = f"@{delivery.address}"
+    renderer = get_renderer(notification.event_type)
+    if renderer is None:
+        return {"channel": channel, "text": _compose_text(notification)}
+    text, attachments = renderer.render(notification)
+    return {"channel": channel, "text": text, "attachments": attachments}
+
+
 @register_channel
 class RocketChatChannel(NotificationChannel):
     channel_type = ChannelType.ROCKETCHAT
@@ -176,9 +191,8 @@ class RocketChatChannel(NotificationChannel):
         if client is None:
             raise UnrecoverableDeliveryError("Rocket Chat not configured")
 
-        text = _compose_text(notification)
         try:
-            _rc_post(client, "chat.postMessage", {"channel": f"@{delivery.address}", "text": text})
+            _rc_post(client, "chat.postMessage", _build_payload(notification, delivery))
         except RocketChatPermanentError as exc:
             logger.error("Rocket Chat delivery %s permanently failed: %s", delivery.id, exc)
             raise UnrecoverableDeliveryError(str(exc)) from exc

--- a/daiv/notifications/channels/rocketchat.py
+++ b/daiv/notifications/channels/rocketchat.py
@@ -169,6 +169,8 @@ def _build_payload(notification: Notification, delivery: NotificationDelivery) -
     channel = f"@{delivery.address}"
     renderer = get_renderer(notification.event_type)
     if renderer is None:
+        # Log so a missing renderer doesn't silently degrade to plain text forever.
+        logger.warning("Rocket Chat: no renderer for event_type=%r; sending plain text", notification.event_type)
         return {"channel": channel, "text": _compose_text(notification)}
     text, attachments = renderer.render(notification)
     return {"channel": channel, "text": text, "attachments": attachments}

--- a/daiv/notifications/channels/rocketchat_renderers/__init__.py
+++ b/daiv/notifications/channels/rocketchat_renderers/__init__.py
@@ -1,0 +1,7 @@
+"""Per-event Rocket Chat renderers. Each submodule self-registers via ``@register_renderer``."""
+
+from notifications.channels.rocketchat_renderers import (  # noqa: F401
+    job_batch_finished,
+    job_finished,
+    schedule_finished,
+)

--- a/daiv/notifications/channels/rocketchat_renderers/base.py
+++ b/daiv/notifications/channels/rocketchat_renderers/base.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, ClassVar
+
+from core.utils import build_absolute_url
+
+if TYPE_CHECKING:
+    from notifications.choices import EventType
+    from notifications.models import Notification
+
+
+# Slack-compatible attachment colors (Rocket Chat accepts hex).
+COLOR_SUCCESS = "#22c55e"  # green
+COLOR_FAILURE = "#ef4444"  # red
+COLOR_PARTIAL = "#eab308"  # yellow
+
+FOOTER = "DAIV"
+
+
+class RocketChatRenderer(ABC):
+    """Base for per-event Rocket Chat attachment renderers.
+
+    Subclasses set ``event_type`` and implement ``render``. They are registered
+    with the ``@register_renderer`` decorator from ``.registry``.
+    """
+
+    event_type: ClassVar[EventType]
+
+    @abstractmethod
+    def render(self, notification: Notification) -> tuple[str, list[dict]]:
+        """Return ``(text, attachments)`` to send via Rocket Chat's ``chat.postMessage``."""
+
+    @staticmethod
+    def _fmt_tokens(n: int | None) -> str | None:
+        if n is None:
+            return None
+        if n < 1000:
+            return str(n)
+        return f"{n / 1000:.1f}k"
+
+    @staticmethod
+    def _fmt_cost(usd: float | None) -> str | None:
+        if usd is None:
+            return None
+        return f"${usd:.2f}"
+
+    @staticmethod
+    def _fmt_duration(seconds: float | None) -> str:
+        if seconds is None:
+            return "—"
+        total = int(seconds)
+        if total < 60:
+            return f"{total}s"
+        if total < 3600:
+            return f"{total // 60}m {total % 60:02d}s"
+        return f"{total // 3600}h {(total % 3600) // 60:02d}m"
+
+    def _usage_field(self, ctx: dict) -> dict | None:
+        """Combine input/output tokens into one short field; ``None`` if both are missing."""
+        in_tokens = self._fmt_tokens(ctx.get("input_tokens"))
+        out_tokens = self._fmt_tokens(ctx.get("output_tokens"))
+        if in_tokens is None and out_tokens is None:
+            return None
+        return {"title": "Usage", "value": f"{in_tokens or '—'} in · {out_tokens or '—'} out", "short": True}
+
+    def _cost_field(self, ctx: dict) -> dict | None:
+        """One-field cost, or ``None`` when no cost data is available."""
+        cost = self._fmt_cost(ctx.get("cost_usd"))
+        if cost is None:
+            return None
+        return {"title": "Cost", "value": cost, "short": True}
+
+    @staticmethod
+    def _link(notification: Notification) -> str:
+        return build_absolute_url(notification.link_url) if notification.link_url else ""
+
+    def _color(self, ctx: dict) -> str:
+        return COLOR_SUCCESS if ctx.get("is_successful") else COLOR_FAILURE

--- a/daiv/notifications/channels/rocketchat_renderers/base.py
+++ b/daiv/notifications/channels/rocketchat_renderers/base.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, ClassVar
 
@@ -26,6 +27,13 @@ class RocketChatRenderer(ABC):
     """
 
     event_type: ClassVar[EventType]
+
+    def __init_subclass__(cls, **kwargs) -> None:
+        super().__init_subclass__(**kwargs)
+        # Concrete renderers must declare ``event_type`` so the registry can key them and
+        # so a forgotten assignment surfaces at import time rather than inside chat.postMessage.
+        if not inspect.isabstract(cls) and "event_type" not in cls.__dict__:
+            raise TypeError(f"{cls.__name__} must define `event_type` (a notifications.choices.EventType value)")
 
     @abstractmethod
     def render(self, notification: Notification) -> tuple[str, list[dict]]:
@@ -56,17 +64,19 @@ class RocketChatRenderer(ABC):
             return f"{total // 60}m {total % 60:02d}s"
         return f"{total // 3600}h {(total % 3600) // 60:02d}m"
 
-    def _usage_field(self, ctx: dict) -> dict | None:
+    @staticmethod
+    def _usage_field(ctx: dict) -> dict | None:
         """Combine input/output tokens into one short field; ``None`` if both are missing."""
-        in_tokens = self._fmt_tokens(ctx.get("input_tokens"))
-        out_tokens = self._fmt_tokens(ctx.get("output_tokens"))
+        in_tokens = RocketChatRenderer._fmt_tokens(ctx.get("input_tokens"))
+        out_tokens = RocketChatRenderer._fmt_tokens(ctx.get("output_tokens"))
         if in_tokens is None and out_tokens is None:
             return None
         return {"title": "Usage", "value": f"{in_tokens or '—'} in · {out_tokens or '—'} out", "short": True}
 
-    def _cost_field(self, ctx: dict) -> dict | None:
+    @staticmethod
+    def _cost_field(ctx: dict) -> dict | None:
         """One-field cost, or ``None`` when no cost data is available."""
-        cost = self._fmt_cost(ctx.get("cost_usd"))
+        cost = RocketChatRenderer._fmt_cost(ctx.get("cost_usd"))
         if cost is None:
             return None
         return {"title": "Cost", "value": cost, "short": True}
@@ -75,5 +85,6 @@ class RocketChatRenderer(ABC):
     def _link(notification: Notification) -> str:
         return build_absolute_url(notification.link_url) if notification.link_url else ""
 
-    def _color(self, ctx: dict) -> str:
+    @staticmethod
+    def _color(ctx: dict) -> str:
         return COLOR_SUCCESS if ctx.get("is_successful") else COLOR_FAILURE

--- a/daiv/notifications/channels/rocketchat_renderers/job_batch_finished.py
+++ b/daiv/notifications/channels/rocketchat_renderers/job_batch_finished.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from notifications.channels.rocketchat_renderers.base import (
+    COLOR_FAILURE,
+    COLOR_PARTIAL,
+    COLOR_SUCCESS,
+    FOOTER,
+    RocketChatRenderer,
+)
+from notifications.channels.rocketchat_renderers.registry import register_renderer
+from notifications.choices import EventType
+
+if TYPE_CHECKING:
+    from notifications.models import Notification
+
+
+_REPO_BREAKDOWN_LIMIT = 8
+
+
+@register_renderer
+class JobBatchFinishedRenderer(RocketChatRenderer):
+    event_type = EventType.JOB_BATCH_FINISHED
+
+    def render(self, notification: Notification) -> tuple[str, list[dict]]:
+        ctx = notification.context
+        successful = ctx.get("successful_count", 0)
+        failed = ctx.get("failed_count", 0)
+        total = ctx.get("total", successful + failed)
+
+        if failed == 0:
+            color, emoji = COLOR_SUCCESS, "✅"
+        elif successful == 0:
+            color, emoji = COLOR_FAILURE, "❌"
+        else:
+            color, emoji = COLOR_PARTIAL, "⚠️"
+
+        fields: list[dict] = [
+            {"title": "Results", "value": f"✓ {successful} · ✗ {failed} of {total}", "short": True},
+            {"title": "Duration", "value": self._fmt_duration(ctx.get("duration_seconds")), "short": True},
+        ]
+        if owner := ctx.get("trigger_owner"):
+            fields.append({"title": "Owner", "value": owner, "short": True})
+        if (usage := self._usage_field(ctx)) is not None:
+            fields.append(usage)
+        if (cost := self._cost_field(ctx)) is not None:
+            fields.append({"title": "Total cost", "value": cost["value"], "short": True})
+        if breakdown := self._repo_breakdown(ctx.get("repo_results") or []):
+            fields.append({"title": "Repositories", "value": breakdown, "short": False})
+
+        attachment = {
+            "color": color,
+            "title": notification.subject,
+            "title_link": self._link(notification),
+            "fields": fields,
+            "footer": FOOTER,
+            "ts": int(notification.created.timestamp()),
+        }
+        return f"{emoji} {notification.subject}", [attachment]
+
+    @staticmethod
+    def _repo_breakdown(repo_results: list[dict]) -> str:
+        """Format per-repo outcomes as ``✓ a/b · ✓ c/d · ✗ e/f`` with overflow truncation."""
+        if not repo_results:
+            return ""
+        head = repo_results[:_REPO_BREAKDOWN_LIMIT]
+        parts = [f"{'✓' if r.get('ok') else '✗'} {r.get('repo', '?')}" for r in head]
+        overflow = len(repo_results) - len(head)
+        if overflow > 0:
+            parts.append(f"… and {overflow} more")
+        return " · ".join(parts)

--- a/daiv/notifications/channels/rocketchat_renderers/job_finished.py
+++ b/daiv/notifications/channels/rocketchat_renderers/job_finished.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from notifications.channels.rocketchat_renderers.base import FOOTER, RocketChatRenderer
+from notifications.channels.rocketchat_renderers.registry import register_renderer
+from notifications.choices import EventType
+
+if TYPE_CHECKING:
+    from notifications.models import Notification
+
+
+@register_renderer
+class JobFinishedRenderer(RocketChatRenderer):
+    event_type = EventType.JOB_FINISHED
+
+    def render(self, notification: Notification) -> tuple[str, list[dict]]:
+        ctx = notification.context
+        ok = ctx.get("is_successful", False)
+        emoji = "✅" if ok else "❌"
+
+        fields: list[dict] = [
+            {"title": "Trigger", "value": ctx.get("trigger_label") or "—", "short": True},
+            {"title": "Duration", "value": self._fmt_duration(ctx.get("duration_seconds")), "short": True},
+        ]
+        if (usage := self._usage_field(ctx)) is not None:
+            fields.append(usage)
+        if (cost := self._cost_field(ctx)) is not None:
+            fields.append(cost)
+
+        attachment = {
+            "color": self._color(ctx),
+            "title": notification.subject,
+            "title_link": self._link(notification),
+            "fields": fields,
+            "footer": FOOTER,
+            "ts": int(notification.created.timestamp()),
+        }
+        return f"{emoji} {notification.subject}", [attachment]

--- a/daiv/notifications/channels/rocketchat_renderers/registry.py
+++ b/daiv/notifications/channels/rocketchat_renderers/registry.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from notifications.channels.rocketchat_renderers.base import RocketChatRenderer
+    from notifications.choices import EventType
+
+_registry: dict[str, type[RocketChatRenderer]] = {}
+
+
+def register_renderer(cls: type[RocketChatRenderer]) -> type[RocketChatRenderer]:
+    """Decorator — registers a Rocket Chat renderer under its ``event_type``."""
+    event_type = cls.event_type
+    if event_type in _registry:
+        raise ValueError(f"Rocket Chat renderer for {event_type!r} already registered")
+    _registry[event_type] = cls
+    return cls
+
+
+def get_renderer(event_type: str | EventType) -> RocketChatRenderer | None:
+    """Return a renderer instance for ``event_type``, or ``None`` if no renderer is registered."""
+    cls = _registry.get(event_type)
+    return cls() if cls is not None else None

--- a/daiv/notifications/channels/rocketchat_renderers/schedule_finished.py
+++ b/daiv/notifications/channels/rocketchat_renderers/schedule_finished.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from notifications.channels.rocketchat_renderers.base import FOOTER, RocketChatRenderer
+from notifications.channels.rocketchat_renderers.registry import register_renderer
+from notifications.choices import EventType
+
+if TYPE_CHECKING:
+    from notifications.models import Notification
+
+
+@register_renderer
+class ScheduleFinishedRenderer(RocketChatRenderer):
+    event_type = EventType.SCHEDULE_FINISHED
+
+    def render(self, notification: Notification) -> tuple[str, list[dict]]:
+        ctx = notification.context
+        ok = ctx.get("is_successful", False)
+        emoji = "✅" if ok else "❌"
+
+        fields: list[dict] = [
+            {"title": "Repository", "value": ctx.get("repo_id") or "—", "short": True},
+            {"title": "Owner", "value": ctx.get("trigger_owner") or "—", "short": True},
+            {"title": "Duration", "value": self._fmt_duration(ctx.get("duration_seconds")), "short": True},
+        ]
+        if (usage := self._usage_field(ctx)) is not None:
+            fields.append(usage)
+        if (cost := self._cost_field(ctx)) is not None:
+            fields.append(cost)
+
+        attachment = {
+            "color": self._color(ctx),
+            "title": notification.subject,
+            "title_link": self._link(notification),
+            "fields": fields,
+            "footer": FOOTER,
+            "ts": int(notification.created.timestamp()),
+        }
+        return f"{emoji} {notification.subject}", [attachment]

--- a/tests/unit_tests/notifications/test_rocketchat_channel.py
+++ b/tests/unit_tests/notifications/test_rocketchat_channel.py
@@ -174,12 +174,16 @@ class TestVerifyUsername:
 
 @pytest.mark.django_db
 class TestSend:
-    def test_happy_path_posts_to_user_dm(self, httpx_mock, notification_with_delivery, rocketchat_configured):
+    def test_happy_path_posts_renderer_payload_to_user_dm(
+        self, httpx_mock, notification_with_delivery, rocketchat_configured
+    ):
+        # event_type="schedule.finished" on the fixture → uses ScheduleFinishedRenderer.
         n, d = notification_with_delivery
         d.channel_type = ChannelType.ROCKETCHAT
         d.address = "alice"
         d.save()
         n.subject, n.body, n.link_url = "Subject", "Body line", "/x/"
+        n.context = {"is_successful": True, "repo_id": "acme/api", "trigger_owner": "alice", "duration_seconds": 47}
         n.save()
 
         httpx_mock.add_response(
@@ -190,7 +194,33 @@ class TestSend:
         request = httpx_mock.get_requests()[0]
         body = json.loads(request.content)
         assert body["channel"] == "@alice"
+        # `text` is the OS-notification line; structured detail lives in attachments.
+        assert "Subject" in body["text"]
+        assert body["attachments"][0]["title"] == "Subject"
+        assert body["attachments"][0]["color"]  # color is set per outcome
+        # `Body line` is intentionally NOT in the payload — renderer surfaces structured fields.
+        assert "Body line" not in json.dumps(body)
+
+    def test_unknown_event_type_falls_back_to_plain_text(
+        self, httpx_mock, notification_with_delivery, rocketchat_configured
+    ):
+        n, d = notification_with_delivery
+        d.channel_type = ChannelType.ROCKETCHAT
+        d.address = "alice"
+        d.save()
+        n.event_type = "some.future.event"  # no renderer registered
+        n.subject, n.body, n.link_url = "Subject", "Body line", "/x/"
+        n.save()
+
+        httpx_mock.add_response(
+            method="POST", url="https://rc.example.com/api/v1/chat.postMessage", json={"success": True}, status_code=200
+        )
+        RocketChatChannel().send(n, d)
+
+        body = json.loads(httpx_mock.get_requests()[0].content)
+        assert body["channel"] == "@alice"
         assert "Subject" in body["text"] and "Body line" in body["text"]
+        assert "attachments" not in body
 
     def test_missing_configuration_raises_unrecoverable(
         self, notification_with_delivery, rocketchat_configured, monkeypatch

--- a/tests/unit_tests/notifications/test_rocketchat_channel.py
+++ b/tests/unit_tests/notifications/test_rocketchat_channel.py
@@ -236,6 +236,55 @@ class TestSend:
             RocketChatChannel().send(n, d)
         assert "not configured" in str(exc.value)
 
+    def test_disabled_channel_raises_unrecoverable(
+        self, notification_with_delivery, rocketchat_configured, monkeypatch
+    ):
+        from core.site_settings import site_settings
+
+        monkeypatch.setattr(site_settings, "rocketchat_enabled", False)
+        n, d = notification_with_delivery
+        d.channel_type = ChannelType.ROCKETCHAT
+        d.address = "alice"
+        d.save()
+        with pytest.raises(UnrecoverableDeliveryError) as exc:
+            RocketChatChannel().send(n, d)
+        assert "disabled" in str(exc.value)
+
+    def test_job_batch_finished_renders_repo_breakdown_on_the_wire(
+        self, httpx_mock, notification_with_delivery, rocketchat_configured
+    ):
+        # End-to-end pin: a JOB_BATCH_FINISHED notification dispatched through send() must
+        # produce a payload whose attachments include the per-repo ✓/✗ breakdown. Catches
+        # any regression in the renderer-registry wiring for the most complex event.
+        from notifications.choices import EventType
+
+        n, d = notification_with_delivery
+        d.channel_type = ChannelType.ROCKETCHAT
+        d.address = "alice"
+        d.save()
+        n.event_type = EventType.JOB_BATCH_FINISHED
+        n.subject = "'nightly' batch: 1/2 succeeded — alice"
+        n.context = {
+            "successful_count": 1,
+            "failed_count": 1,
+            "total": 2,
+            "duration_seconds": 90,
+            "trigger_owner": "alice",
+            "repo_results": [{"repo": "acme/api", "ok": True}, {"repo": "acme/legacy", "ok": False}],
+        }
+        n.save()
+
+        httpx_mock.add_response(
+            method="POST", url="https://rc.example.com/api/v1/chat.postMessage", json={"success": True}, status_code=200
+        )
+        RocketChatChannel().send(n, d)
+
+        body = json.loads(httpx_mock.get_requests()[0].content)
+        fields_by_title = {f["title"]: f["value"] for f in body["attachments"][0]["fields"]}
+        assert fields_by_title["Results"] == "✓ 1 · ✗ 1 of 2"
+        assert "✓ acme/api" in fields_by_title["Repositories"]
+        assert "✗ acme/legacy" in fields_by_title["Repositories"]
+
     def test_permanent_rc_error_raises_unrecoverable(
         self, httpx_mock, notification_with_delivery, rocketchat_configured
     ):

--- a/tests/unit_tests/notifications/test_rocketchat_renderers.py
+++ b/tests/unit_tests/notifications/test_rocketchat_renderers.py
@@ -1,0 +1,205 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+import pytest
+from notifications.channels.rocketchat_renderers.base import (
+    COLOR_FAILURE,
+    COLOR_PARTIAL,
+    COLOR_SUCCESS,
+    RocketChatRenderer,
+)
+from notifications.channels.rocketchat_renderers.job_batch_finished import JobBatchFinishedRenderer
+from notifications.channels.rocketchat_renderers.job_finished import JobFinishedRenderer
+from notifications.channels.rocketchat_renderers.registry import get_renderer
+from notifications.channels.rocketchat_renderers.schedule_finished import ScheduleFinishedRenderer
+from notifications.choices import EventType
+
+
+@pytest.fixture(autouse=True)
+def _stub_build_absolute_url(monkeypatch):
+    # Renderer tests don't need the Sites framework; mock the helper that would hit the DB.
+    monkeypatch.setattr(
+        "notifications.channels.rocketchat_renderers.base.build_absolute_url", lambda path: f"https://example.com{path}"
+    )
+
+
+def _stub_notification(subject="s", body="b", link_url="/x/", context=None):
+    return SimpleNamespace(
+        subject=subject,
+        body=body,
+        link_url=link_url,
+        context=context or {},
+        created=datetime(2026, 5, 20, 12, 0, tzinfo=UTC),
+    )
+
+
+def _fields_by_title(attachment):
+    return {f["title"]: f["value"] for f in attachment.get("fields", [])}
+
+
+class TestRegistryLookup:
+    def test_all_three_event_types_are_registered(self):
+        assert isinstance(get_renderer(EventType.JOB_FINISHED), JobFinishedRenderer)
+        assert isinstance(get_renderer(EventType.SCHEDULE_FINISHED), ScheduleFinishedRenderer)
+        assert isinstance(get_renderer(EventType.JOB_BATCH_FINISHED), JobBatchFinishedRenderer)
+
+    def test_lookup_works_with_bare_string_value(self):
+        # Callers receive notification.event_type as a string off the CharField; the registry
+        # is keyed by EventType but must resolve via the underlying str (TextChoices is-a str).
+        assert isinstance(get_renderer("job.finished"), JobFinishedRenderer)
+
+    def test_unknown_event_type_returns_none(self):
+        assert get_renderer("does.not.exist") is None
+
+
+class TestFormatHelpers:
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [(None, None), (0, "0"), (42, "42"), (999, "999"), (1000, "1.0k"), (12432, "12.4k"), (596891, "596.9k")],
+    )
+    def test_fmt_tokens(self, value, expected):
+        assert RocketChatRenderer._fmt_tokens(value) == expected
+
+    @pytest.mark.parametrize(
+        ("value", "expected"), [(None, None), (0, "$0.00"), (0.214321, "$0.21"), (1.5, "$1.50"), (12.345, "$12.35")]
+    )
+    def test_fmt_cost(self, value, expected):
+        assert RocketChatRenderer._fmt_cost(value) == expected
+
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [(None, "—"), (0, "0s"), (47, "47s"), (60, "1m 00s"), (84, "1m 24s"), (3600, "1h 00m"), (3725, "1h 02m")],
+    )
+    def test_fmt_duration(self, value, expected):
+        assert RocketChatRenderer._fmt_duration(value) == expected
+
+    def test_usage_field_returns_none_when_both_tokens_missing(self):
+        assert JobFinishedRenderer()._usage_field({"cost_usd": 0.10}) is None
+
+    def test_usage_field_renders_when_only_one_side_present(self):
+        field = JobFinishedRenderer()._usage_field({"input_tokens": 1000, "output_tokens": None})
+        assert field == {"title": "Usage", "value": "1.0k in · — out", "short": True}
+
+    def test_cost_field_skipped_when_cost_missing(self):
+        assert JobFinishedRenderer()._cost_field({"input_tokens": 1000}) is None
+
+
+class TestJobFinishedRenderer:
+    def test_success_renders_green_attachment_with_usage_and_cost(self):
+        notif = _stub_notification(
+            subject="Agent run on acme/api succeeded",
+            link_url="/activities/1/",
+            context={
+                "is_successful": True,
+                "trigger_label": "Manual",
+                "duration_seconds": 84,
+                "input_tokens": 12432,
+                "output_tokens": 38123,
+                "cost_usd": 0.214,
+            },
+        )
+        text, attachments = JobFinishedRenderer().render(notif)
+
+        assert text.startswith("✅ ")
+        assert "Agent run on acme/api succeeded" in text
+        assert len(attachments) == 1
+        attachment = attachments[0]
+        assert attachment["color"] == COLOR_SUCCESS
+        assert attachment["title"] == "Agent run on acme/api succeeded"
+        fields = _fields_by_title(attachment)
+        assert fields["Trigger"] == "Manual"
+        assert fields["Duration"] == "1m 24s"
+        assert fields["Usage"] == "12.4k in · 38.1k out"
+        assert fields["Cost"] == "$0.21"
+        assert attachment["footer"] == "DAIV"
+
+    def test_failure_uses_red_color_and_x_emoji(self):
+        notif = _stub_notification(context={"is_successful": False, "trigger_label": "Issue webhook"})
+        text, attachments = JobFinishedRenderer().render(notif)
+        assert text.startswith("❌ ")
+        assert attachments[0]["color"] == COLOR_FAILURE
+
+    def test_usage_and_cost_fields_omitted_when_data_missing(self):
+        notif = _stub_notification(context={"is_successful": True, "trigger_label": "Manual"})
+        _text, attachments = JobFinishedRenderer().render(notif)
+        titles = {f["title"] for f in attachments[0]["fields"]}
+        assert "Usage" not in titles
+        assert "Cost" not in titles
+
+
+class TestScheduleFinishedRenderer:
+    def test_success_includes_repository_and_owner_fields(self):
+        notif = _stub_notification(
+            subject="'nightly' succeeded on acme/api — alice",
+            context={"is_successful": True, "repo_id": "acme/api", "trigger_owner": "alice", "duration_seconds": 47},
+        )
+        text, attachments = ScheduleFinishedRenderer().render(notif)
+        assert text.startswith("✅ ")
+        fields = _fields_by_title(attachments[0])
+        assert fields["Repository"] == "acme/api"
+        assert fields["Owner"] == "alice"
+        assert fields["Duration"] == "47s"
+
+
+class TestJobBatchFinishedRenderer:
+    def _ctx(self, **overrides):
+        base = {
+            "successful_count": 4,
+            "failed_count": 1,
+            "total": 5,
+            "duration_seconds": 371,
+            "trigger_owner": "alice",
+            "repo_results": [
+                {"repo": "acme/api", "ok": True},
+                {"repo": "acme/web", "ok": True},
+                {"repo": "acme/cli", "ok": True},
+                {"repo": "acme/db", "ok": True},
+                {"repo": "acme/legacy", "ok": False},
+            ],
+            "input_tokens": 184_217,
+            "output_tokens": 412_780,
+            "cost_usd": 0.83,
+        }
+        base.update(overrides)
+        return base
+
+    def test_partial_batch_uses_warning_color_and_emoji(self):
+        notif = _stub_notification(subject="'nightly' batch: 4/5 succeeded — alice", context=self._ctx())
+        text, attachments = JobBatchFinishedRenderer().render(notif)
+        assert text.startswith("⚠️ ")
+        assert attachments[0]["color"] == COLOR_PARTIAL
+        fields = _fields_by_title(attachments[0])
+        assert fields["Results"] == "✓ 4 · ✗ 1 of 5"
+        assert fields["Owner"] == "alice"
+        assert fields["Usage"] == "184.2k in · 412.8k out"
+        assert fields["Total cost"] == "$0.83"
+        assert "✓ acme/api" in fields["Repositories"]
+        assert "✗ acme/legacy" in fields["Repositories"]
+
+    def test_all_succeed_uses_green(self):
+        notif = _stub_notification(context=self._ctx(successful_count=5, failed_count=0))
+        text, attachments = JobBatchFinishedRenderer().render(notif)
+        assert text.startswith("✅ ")
+        assert attachments[0]["color"] == COLOR_SUCCESS
+
+    def test_all_fail_uses_red(self):
+        notif = _stub_notification(context=self._ctx(successful_count=0, failed_count=5))
+        text, attachments = JobBatchFinishedRenderer().render(notif)
+        assert text.startswith("❌ ")
+        assert attachments[0]["color"] == COLOR_FAILURE
+
+    def test_repo_breakdown_truncates_past_limit(self):
+        repo_results = [{"repo": f"acme/r{i}", "ok": True} for i in range(12)]
+        notif = _stub_notification(context=self._ctx(repo_results=repo_results))
+        _text, attachments = JobBatchFinishedRenderer().render(notif)
+        breakdown = _fields_by_title(attachments[0])["Repositories"]
+        # 8-item cap + overflow marker.
+        assert "and 4 more" in breakdown
+        assert "acme/r11" not in breakdown  # past the cap
+
+    def test_empty_repo_results_drops_repositories_field(self):
+        notif = _stub_notification(context=self._ctx(repo_results=[]))
+        _text, attachments = JobBatchFinishedRenderer().render(notif)
+        assert "Repositories" not in _fields_by_title(attachments[0])

--- a/tests/unit_tests/notifications/test_rocketchat_renderers.py
+++ b/tests/unit_tests/notifications/test_rocketchat_renderers.py
@@ -142,6 +142,25 @@ class TestScheduleFinishedRenderer:
         assert fields["Owner"] == "alice"
         assert fields["Duration"] == "47s"
 
+    def test_usage_and_cost_fields_appended_when_present(self):
+        # The production signal handler emits these keys for every schedule run, so the
+        # append branches in schedule_finished.py need explicit coverage.
+        notif = _stub_notification(
+            context={
+                "is_successful": True,
+                "repo_id": "acme/api",
+                "trigger_owner": "alice",
+                "duration_seconds": 47,
+                "input_tokens": 8123,
+                "output_tokens": 22456,
+                "cost_usd": 0.14,
+            }
+        )
+        _text, attachments = ScheduleFinishedRenderer().render(notif)
+        fields = _fields_by_title(attachments[0])
+        assert fields["Usage"] == "8.1k in · 22.5k out"
+        assert fields["Cost"] == "$0.14"
+
 
 class TestJobBatchFinishedRenderer:
     def _ctx(self, **overrides):


### PR DESCRIPTION
**Stacked on #1237** — please merge that one first; this PR's diff includes only the Piece 2+3 changes once #1237 is in.

## Summary
Replaces the plain-text RC payload with class-based renderers keyed by `EventType`, mirroring the existing `@register_channel` pattern.

**New package** [\`daiv/notifications/channels/rocketchat_renderers/\`](daiv/notifications/channels/rocketchat_renderers/)
- \`base.py\` — \`RocketChatRenderer\` ABC + shared helpers (\`_fmt_tokens\`, \`_fmt_cost\`, \`_fmt_duration\`, \`_usage_field\`, \`_cost_field\`, \`_link\`) + color constants.
- \`registry.py\` — \`@register_renderer\` decorator + \`get_renderer(event_type)\` lookup.
- \`job_finished.py\`, \`schedule_finished.py\`, \`job_batch_finished.py\` — one renderer per terminal event.

**Channel change** ([\`rocketchat.py\`](daiv/notifications/channels/rocketchat.py))
- New \`_build_payload(notification, delivery)\` calls \`get_renderer(event_type)\` and renders to \`(text, attachments)\`.
- **Falls back to \`_compose_text\`** when no renderer is registered, so any new \`EventType\` ships before its renderer.

## What the user sees now

```
✅ Agent run on acme/api succeeded
┌─ (green sidebar)
│ Agent run on acme/api succeeded                                  ← clickable
│ ┌─────────────────────┬──────────────────────┐
│ │ Trigger             │ Duration             │
│ │ Manual              │ 1m 24s               │
│ ├─────────────────────┼──────────────────────┤
│ │ Usage               │ Cost                 │
│ │ 12.4k in · 38.1k out│ \$0.21                │
│ └─────────────────────┴──────────────────────┘
│ DAIV · just now
```

Three colors: green (success), red (failure), yellow (partial batch). Batch rollups also include a per-repo \`✓ / ✗\` breakdown (capped at 8 with overflow marker).

## Notes
- Missing data hides fields rather than rendering \`—\`: a notification with no token/cost data shows just Trigger + Duration.
- Top-level \`text\` is the OS-notification line (\`✅ Subject\`); structured detail lives in attachments. Body content is intentionally not duplicated.
- The existing \`test_happy_path_posts_to_user_dm\` was updated to assert the new payload shape; \`test_unknown_event_type_falls_back_to_plain_text\` covers the fallback.

## Test plan
- [x] New \`test_rocketchat_renderers.py\` (35 tests): registry lookup (incl. EventType-vs-str equality), helper formatters (parametrized over None / 0 / k-rounding / edge cases), each renderer × success/failure, batch × {all-green, all-red, partial-yellow}, repo breakdown truncation.
- [x] Updated \`test_rocketchat_channel.py\`: happy path now asserts attachment shape; new test for unknown-event-type fallback.
- [x] Full notifications suite: 185 tests passing.
- [ ] CI: \`make test\` + lint + ty.
- [ ] Manual smoke: send a real notification to a Rocket Chat DM and confirm rendering matches the mockup.