### PR TITLE
chore: Local dev environment tweaks

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,5 @@
+docker/local/app/config.secrets.env
+docker/local/gitlab-runner/config.toml
+data/certs
+data/db
+data/gitlab

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -120,6 +120,16 @@ services:
         gitaly['logging_level'] = 'warn'
         nginx['error_log_level'] = 'warn'
         puma['log_level'] = 'warn'
+
+        puma['worker_processes'] = 2
+        sidekiq['max_concurrency'] = 5
+        postgresql['shared_buffers'] = '128MB'
+
+        prometheus_monitoring['enable'] = false
+        gitlab_kas['enable'] = false
+        registry['enable'] = false
+        mattermost['enable'] = false
+        gitlab_pages['enable'] = false
     ports:
       - "8929:8929"
       - "2224:22"


### PR DESCRIPTION
## Summary
- Trim the local docker-compose GitLab footprint: fewer Puma workers and Sidekiq threads, smaller Postgres `shared_buffers`, and disable Prometheus, KAS, registry, Mattermost, and Pages.
- Add `.worktreeinclude` listing local-only paths (secrets, certs, DB and GitLab data) to share into git worktrees.

## Test plan
- [ ] `docker compose up gitlab` boots and the instance is reachable on the usual ports.
- [ ] New worktrees pick up the listed paths.