### PR TITLE
feat(accounts): Distinguishable user avatars with 2-letter initials

### DIFF
--- a/daiv/accounts/templates/accounts/_avatar.html
+++ b/daiv/accounts/templates/accounts/_avatar.html
@@ -1,21 +1,26 @@
+{% load avatar_tags %}
 <div class="flex items-center">
     {% with owner_label=user.name|default:user.email %}
-    <span class="inline-flex h-6 w-6 items-center justify-center rounded-full bg-gradient-to-br from-violet-500 to-cyan-400 text-[10px] font-semibold text-white{% if group %} ring-2 ring-[#0a0e1a]{% endif %}"
+    {% user_initials user as owner_initials %}
+    {% user_color_index user as owner_color %}
+    <span class="avatar avatar--md avatar--c{{ owner_color }}{% if group %} avatar--stacked{% endif %}"
           title="{% if label %}{{ label }}: {% endif %}{{ owner_label }}">
-        {{ owner_label|first|upper }}
+        {{ owner_initials }}
     </span>
     {% endwith %}
     {% if group %}
     {% for member in group|slice:":3" %}
     {% with member_label=member.name|default:member.email %}
-    <span class="-ml-2 inline-flex h-6 w-6 items-center justify-center rounded-full bg-gradient-to-br from-sky-500 to-indigo-500 text-[10px] font-semibold text-white ring-2 ring-[#0a0e1a]"
+    {% user_initials member as member_initials %}
+    {% user_color_index member as member_color %}
+    <span class="avatar avatar--md avatar--stacked avatar--c{{ member_color }}"
           title="{{ member_label }}">
-        {{ member_label|first|upper }}
+        {{ member_initials }}
     </span>
     {% endwith %}
     {% endfor %}
     {% if group|length > 3 %}
-    <span class="-ml-2 inline-flex h-6 min-w-6 items-center justify-center rounded-full bg-gray-800 px-1.5 text-[10px] font-semibold text-gray-300 ring-2 ring-[#0a0e1a]">
+    <span class="avatar avatar--md avatar--more">
         +{{ group|length|add:"-3" }}
     </span>
     {% endif %}

--- a/daiv/accounts/templates/accounts/_user_menu.html
+++ b/daiv/accounts/templates/accounts/_user_menu.html
@@ -1,13 +1,12 @@
-{% load i18n icon_tags %}
+{% load avatar_tags i18n icon_tags %}
 
 <div data-testid="app-user-menu" x-data="{ open: false }" class="relative" @keydown.escape="open = false">
   <button type="button"
           @click="open = !open"
           :aria-expanded="open.toString()"
           class="flex items-center gap-2 rounded-full border border-white/[0.06] bg-white/[0.02] py-1 pl-1 pr-3 text-sm text-gray-300 transition-colors hover:bg-white/[0.04]">
-    <span class="inline-flex h-6 w-6 items-center justify-center rounded-full bg-gradient-to-br from-violet-500 to-cyan-400 text-[11px] font-semibold text-white">
-      {{ user.name|default:user.email|first|upper }}
-    </span>
+    {% user_color_index user as user_color %}
+    <span class="avatar avatar--md avatar--c{{ user_color }}">{% user_initials user %}</span>
     <span class="hidden text-[13px] text-gray-300 sm:inline">{{ user.email }}</span>
     {% icon "chevron-down" "h-3 w-3 text-gray-500" %}
   </button>

--- a/daiv/accounts/templates/accounts/_user_picker_list.html
+++ b/daiv/accounts/templates/accounts/_user_picker_list.html
@@ -1,10 +1,12 @@
-{% load i18n %}
+{% load avatar_tags i18n %}
 <ul>
 {% for u in users %}
+  {% user_initials u as u_initials %}
+  {% user_color_index u as u_color %}
   <li>
     <button type="button"
             class="flex w-full items-center gap-2 px-3 py-2 text-left text-[14px] text-gray-300 hover:bg-white/[0.06]"
-            @click="addUser({ id: {{ u.pk }}, username: '{{ u.username|escapejs }}', name: '{{ u.name|default:''|escapejs }}', email: '{{ u.email|escapejs }}' })">
+            @click="addUser({ id: {{ u.pk }}, username: '{{ u.username|escapejs }}', name: '{{ u.name|default:''|escapejs }}', email: '{{ u.email|escapejs }}', initials: '{{ u_initials|escapejs }}', color_index: {{ u_color }} })">
       {% include "accounts/_avatar.html" with user=u %}
       <span class="min-w-0 flex-1 truncate">
         <span class="block text-white">{{ u.name|default:u.username }}</span>

--- a/daiv/accounts/templatetags/avatar_tags.py
+++ b/daiv/accounts/templatetags/avatar_tags.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import hashlib
+from typing import TYPE_CHECKING
+
+from django import template
+
+if TYPE_CHECKING:
+    from accounts.models import User
+
+register = template.Library()
+
+PALETTE_SIZE = 10
+
+
+def _label(user: User | None) -> str:
+    if user is None:
+        return ""
+    name = getattr(user, "name", None) or getattr(user, "email", None) or getattr(user, "username", None) or ""
+    return name.strip()
+
+
+@register.simple_tag
+def user_initials(user: User | None) -> str:
+    """Return up to 2 uppercase characters identifying ``user`` (e.g. "Ada Lovelace" → "AL")."""
+    name = (getattr(user, "name", None) or "").strip() if user is not None else ""
+    if name:
+        parts = name.split()
+        if len(parts) >= 2:
+            return (parts[0][:1] + parts[-1][:1]).upper()
+        return parts[0][:2].upper()
+
+    email = (getattr(user, "email", None) or "").strip() if user is not None else ""
+    if email:
+        local = email.split("@", 1)[0]
+        if local:
+            return local[:2].upper()
+
+    username = (getattr(user, "username", None) or "").strip() if user is not None else ""
+    if username:
+        return username[:2].upper()
+
+    return "?"
+
+
+@register.simple_tag
+def user_color_index(user: User | None) -> int:
+    """Stable palette index in ``[0, PALETTE_SIZE)`` for ``user``.
+
+    Keyed on ``username`` (unique and stable) with fallbacks. Same input always
+    yields the same index, so two people with the same first letter still get
+    distinct gradients across the UI.
+    """
+    if user is None:
+        return 0
+    key = (getattr(user, "username", None) or getattr(user, "email", None) or _label(user)).lower().strip()
+    if not key:
+        return 0
+    digest = hashlib.md5(key.encode("utf-8"), usedforsecurity=False).digest()
+    return digest[0] % PALETTE_SIZE

--- a/daiv/schedules/templates/schedules/_subscriber_picker.html
+++ b/daiv/schedules/templates/schedules/_subscriber_picker.html
@@ -17,8 +17,9 @@
                 <span class="inline-flex items-center gap-1 rounded-full border border-white/[0.08] bg-white/[0.05] py-1 pl-1 pr-1 text-[13px] font-medium text-gray-300"
                       :title="u.email">
                     <span class="inline-flex items-center gap-1.5 rounded-full px-1.5 py-0.5">
-                        <span class="inline-flex h-4 w-4 items-center justify-center rounded-full bg-gradient-to-br from-violet-500 to-cyan-400 text-[9px] font-semibold text-white"
-                              x-text="(u.name || u.email).charAt(0).toUpperCase()"></span>
+                        <span class="avatar avatar--sm"
+                              :class="'avatar--c' + (u.color_index ?? 0)"
+                              x-text="u.initials || '?'"></span>
                         <span x-text="u.name || u.username"></span>
                     </span>
                     <button type="button"

--- a/daiv/schedules/views.py
+++ b/daiv/schedules/views.py
@@ -19,6 +19,7 @@ from activity.services import RepoTarget, submit_batch_runs
 from sandbox_envs.services import env_picker_context, resolve_repo_envs
 
 from accounts.mixins import AdminRequiredMixin, BreadcrumbMixin
+from accounts.templatetags.avatar_tags import user_color_index, user_initials
 from schedules.forms import ScheduledJobCreateForm, ScheduledJobUpdateForm, ScheduleTemplateForm
 from schedules.models import ScheduledJob, ScheduleTemplate
 
@@ -33,10 +34,24 @@ class _ScheduleOwnerMixin:
 
 
 def _subscriber_initial_json(schedule) -> str:
-    """Serialize a schedule's current subscribers for the Alpine picker."""
+    """Serialize a schedule's current subscribers for the Alpine picker.
+
+    ``initials`` and ``color_index`` are precomputed server-side so the chip
+    avatars render identically to ``_avatar.html`` without a JS hashing helper.
+    """
     if schedule is None:
         return "[]"
-    rows = [{"id": u.pk, "username": u.username, "name": u.name, "email": u.email} for u in schedule.subscribers.all()]
+    rows = [
+        {
+            "id": u.pk,
+            "username": u.username,
+            "name": u.name,
+            "email": u.email,
+            "initials": user_initials(u),
+            "color_index": user_color_index(u),
+        }
+        for u in schedule.subscribers.all()
+    ]
     return json.dumps(rows)
 
 

--- a/daiv/static_src/css/input.css
+++ b/daiv/static_src/css/input.css
@@ -206,6 +206,48 @@ main:has(.chat-shell) {
   }
 }
 
+/* -- Avatar ---------------------------------------------------------------
+
+   Shared by ``accounts/_avatar.html``, ``_user_menu.html`` and the schedule
+   subscriber picker (Alpine ``x-bind``). Initials and the palette index are
+   produced by ``accounts.templatetags.avatar_tags`` so two people sharing a
+   first letter still get distinct circles. Keep ``PALETTE_SIZE`` in the
+   templatetag in sync with the number of ``.avatar--c*`` modifiers below. */
+
+@layer components {
+  .avatar {
+    @apply inline-flex items-center justify-center rounded-full font-semibold uppercase text-white select-none;
+    /* Tighten two-letter pairs without offsetting single letters. */
+    letter-spacing: -0.02em;
+  }
+
+  .avatar--sm { @apply h-4 w-4 text-[9px]; }
+  .avatar--md { @apply h-6 w-6 text-[10px]; }
+
+  /* Stacked group of avatars (owner + N members), each subsequent circle slides
+     under the previous and gets a ring matching the page background. */
+  .avatar--stacked { @apply -ml-2 ring-2 ring-[#0a0e1a]; }
+
+  /* "+N" overflow chip rendered after a stacked group — neutral colors, wider
+     padding to fit two digits. */
+  .avatar--more {
+    @apply -ml-2 min-w-6 px-1.5 ring-2 ring-[#0a0e1a];
+    background: rgb(31 41 55);
+    color: rgb(209 213 219);
+  }
+
+  .avatar--c0 { background-image: linear-gradient(to bottom right, #8b5cf6, #22d3ee); }
+  .avatar--c1 { background-image: linear-gradient(to bottom right, #0ea5e9, #6366f1); }
+  .avatar--c2 { background-image: linear-gradient(to bottom right, #ec4899, #f43f5e); }
+  .avatar--c3 { background-image: linear-gradient(to bottom right, #10b981, #14b8a6); }
+  .avatar--c4 { background-image: linear-gradient(to bottom right, #f59e0b, #ef4444); }
+  .avatar--c5 { background-image: linear-gradient(to bottom right, #6366f1, #a855f7); }
+  .avatar--c6 { background-image: linear-gradient(to bottom right, #14b8a6, #06b6d4); }
+  .avatar--c7 { background-image: linear-gradient(to bottom right, #f43f5e, #f97316); }
+  .avatar--c8 { background-image: linear-gradient(to bottom right, #84cc16, #10b981); }
+  .avatar--c9 { background-image: linear-gradient(to bottom right, #a855f7, #ec4899); }
+}
+
 /* -- Status badge variants ------------------------------------------------ */
 
 @layer components {

--- a/tests/unit_tests/accounts/test_avatar_tags.py
+++ b/tests/unit_tests/accounts/test_avatar_tags.py
@@ -1,0 +1,87 @@
+from types import SimpleNamespace
+
+from django.template import Context, Template
+
+from accounts.templatetags.avatar_tags import PALETTE_SIZE, user_color_index, user_initials
+
+
+def _user(*, name="", email="", username=""):
+    return SimpleNamespace(name=name, email=email, username=username)
+
+
+def _render(template_source: str, context_dict: dict) -> str:
+    return Template(template_source).render(Context(context_dict))
+
+
+class TestUserInitials:
+    def test_two_word_name_uses_first_and_last_letter(self):
+        assert user_initials(_user(name="Ada Lovelace")) == "AL"
+
+    def test_three_word_name_skips_middle(self):
+        assert user_initials(_user(name="John Quincy Adams")) == "JA"
+
+    def test_single_word_name_uses_first_two_letters(self):
+        assert user_initials(_user(name="Madonna")) == "MA"
+
+    def test_single_letter_name_returns_one_letter(self):
+        assert user_initials(_user(name="X")) == "X"
+
+    def test_falls_back_to_email_local_part_when_no_name(self):
+        assert user_initials(_user(email="alice@example.com")) == "AL"
+
+    def test_falls_back_to_username_when_no_name_or_email(self):
+        # Keeps parity with ``user_color_index`` which also accepts username as
+        # a final identifier — otherwise the chip would show "?" on a hashed
+        # color, which reads as nonsense.
+        assert user_initials(_user(username="zelda")) == "ZE"
+
+    def test_lowercased_input_is_uppercased(self):
+        assert user_initials(_user(name="bob smith")) == "BS"
+
+    def test_returns_question_mark_when_user_is_none(self):
+        assert user_initials(None) == "?"
+
+    def test_returns_question_mark_when_all_fields_empty(self):
+        assert user_initials(_user()) == "?"
+
+
+class TestUserColorIndex:
+    def test_index_in_valid_range(self):
+        for u in [_user(username=f"user{i}", email=f"u{i}@x.com") for i in range(50)]:
+            idx = user_color_index(u)
+            assert 0 <= idx < PALETTE_SIZE
+
+    def test_same_user_yields_same_index(self):
+        u = _user(username="alice", email="alice@example.com")
+        assert user_color_index(u) == user_color_index(u)
+
+    def test_known_usernames_yield_known_indices(self):
+        # Pinned golden values from the current md5(username) → bucket mapping.
+        # If the hash, key choice, or PALETTE_SIZE changes, this test fails
+        # loudly instead of silently reshuffling everyone's avatar color.
+        expected = {"alice": 9, "andrew": 7, "amelia": 3, "aaron": 8, "anya": 0}
+        for username, want in expected.items():
+            assert user_color_index(_user(username=username)) == want
+
+    def test_returns_zero_when_user_is_none(self):
+        assert user_color_index(None) == 0
+
+    def test_returns_zero_when_all_keys_empty(self):
+        assert user_color_index(_user()) == 0
+
+    def test_falls_back_through_username_email_name(self):
+        only_username = user_color_index(_user(username="zelda"))
+        only_email = user_color_index(_user(email="zelda@example.com"))
+        assert 0 <= only_username < PALETTE_SIZE
+        assert 0 <= only_email < PALETTE_SIZE
+
+
+class TestTemplateIntegration:
+    def test_user_initials_tag_renders(self):
+        out = _render("{% load avatar_tags %}{% user_initials u %}", {"u": _user(name="Sandro Rodrigues")})
+        assert out.strip() == "SR"
+
+    def test_user_color_index_tag_renders_digit(self):
+        out = _render("{% load avatar_tags %}{% user_color_index u %}", {"u": _user(username="sandro")})
+        assert out.strip().isdigit()
+        assert 0 <= int(out.strip()) < PALETTE_SIZE

--- a/tests/unit_tests/accounts/test_picker_view.py
+++ b/tests/unit_tests/accounts/test_picker_view.py
@@ -75,7 +75,12 @@ class TestPickerUsersView:
         alice = User.objects.create_user(username="alice", email="a@t.com", password="x", name="Alice Doe")  # noqa: S106
         response = member_client.get(reverse("picker_users"), {"q": "ali"})
         html = response.content.decode()
-        assert f"addUser({{ id: {alice.pk}, username: 'alice', name: 'Alice Doe', email: 'a@t.com' }})" in html
+        # Avatar precomputed fields (initials, color_index) ride along so the chip
+        # renders identically once the user is added to the selected list.
+        assert (
+            f"addUser({{ id: {alice.pk}, username: 'alice', name: 'Alice Doe', email: 'a@t.com', "
+            f"initials: 'AD', color_index: " in html
+        )
 
     def test_caps_results_at_picker_limit(self, member_client):
         from accounts.views import PICKER_USERS_LIMIT

--- a/tests/unit_tests/schedules/test_views.py
+++ b/tests/unit_tests/schedules/test_views.py
@@ -375,6 +375,27 @@ class TestScheduleUpdateViewSubscribers:
         html = response.content.decode()
         assert "alice" in html
 
+    def test_subscriber_initial_json_carries_avatar_fields(self, member_client, schedule):
+        # The Alpine chip in ``_subscriber_picker.html`` reads ``u.initials`` and
+        # ``u.color_index`` — losing them from the payload would silently break
+        # the rendered avatar without failing any other test.
+        import html as _html
+        import json as _json
+        import re
+
+        alice = User.objects.create_user(username="alice", email="a@t.com", password="x", name="Alice Doe")  # noqa: S106
+        schedule.subscribers.add(alice)
+        page = member_client.get(reverse("schedule_update", args=[schedule.pk])).content.decode()
+        # `x-data="subscriberPicker({ initial: [...] })"` — JSON's double quotes
+        # get HTML-escaped to `&quot;` inside the attribute, so unescape first.
+        match = re.search(r"subscriberPicker\(\{\s*initial:\s*(\[.*?\])\s*\}\)", _html.unescape(page))
+        assert match, "subscriberPicker x-data init not found in rendered HTML"
+        rows = _json.loads(match.group(1))
+        assert len(rows) == 1
+        assert rows[0]["initials"] == "AD"
+        assert isinstance(rows[0]["color_index"], int)
+        assert 0 <= rows[0]["color_index"] < 10
+
     def test_create_form_renders_picker_markers(self, member_client):
         response = member_client.get(reverse("schedule_create"))
         html = response.content.decode()


### PR DESCRIPTION
## Summary

- Initials use up to two characters (first + last name initial, falling back through email local-part then username) — single-letter chips no longer collide for users sharing a first letter.
- Gradient is picked deterministically from a 10-color palette via `md5(username)`, so two people with the same initials still get distinct colors.
- Extracts a reusable `.avatar` component (size + stacked + 10 palette variants) in `input.css`, replacing the inline Tailwind chains repeated across `_avatar.html`, `_user_menu.html`, and the schedule subscriber picker.
- Schedule subscriber picker precomputes `initials` and `color_index` server-side (`_subscriber_initial_json`, `_user_picker_list.html` `addUser(...)` payload) so the Alpine chip stays identical to the server-rendered avatar.

## Test plan

- [x] `uv run pytest tests/unit_tests/` — 2347 pass (17 new in `test_avatar_tags.py`, 1 new payload-shape regression in `test_views.py`, 1 updated picker-view assertion).
- [x] `make lint-fix` clean.
- [x] Tailwind rebuilt; all 10 `.avatar--c*` and size/stacked/more modifiers land in `daiv/static/css/styles.css`.
- [ ] Manual: visit dashboard / user menu / schedules list and confirm chips differ by initial *and* color across users who previously collided.