### PR TITLE
feat(accounts): Break out API jobs in dashboard breakdown

### DIFF
--- a/daiv/accounts/views.py
+++ b/daiv/accounts/views.py
@@ -143,6 +143,7 @@ class DashboardView(LoginRequiredMixin, TemplateView):
         mr_trigger = Q(trigger_type=TriggerType.MR_WEBHOOK)
         mcp_trigger = Q(trigger_type=TriggerType.MCP_JOB)
         schedule_trigger = Q(trigger_type=TriggerType.SCHEDULE)
+        api_trigger = Q(trigger_type=TriggerType.API_JOB)
         duration_expr = ExpressionWrapper(F("finished_at") - F("started_at"), output_field=DurationField())
 
         stats = activities.aggregate(
@@ -153,6 +154,7 @@ class DashboardView(LoginRequiredMixin, TemplateView):
             mrs=Count("id", filter=mr_trigger & ~failed),
             mcp_jobs=Count("id", filter=mcp_trigger & ~failed),
             scheduled=Count("id", filter=schedule_trigger & ~failed),
+            api_jobs=Count("id", filter=api_trigger & ~failed),
             code_changes=Count("id", filter=successful & Q(code_changes=True)),
             avg_duration=Avg(duration_expr, filter=successful),
         )
@@ -169,17 +171,21 @@ class DashboardView(LoginRequiredMixin, TemplateView):
         mrs_count = stats["mrs"]
         mcp_jobs_count = stats["mcp_jobs"]
         scheduled_count = stats["scheduled"]
+        api_jobs_count = stats["api_jobs"]
         activity_url = reverse("activity_list")
 
         # Non-overlapping segments for the breakdown bar.
-        # Trigger types are mutually exclusive, so issues/mrs/mcp/scheduled never overlap.
-        # Each segment excludes failed; "Other" absorbs the remainder (e.g. API jobs).
-        other_count = max(0, total - issues_count - mrs_count - mcp_jobs_count - scheduled_count - failed_count)
+        # Trigger types are mutually exclusive, so the trigger-keyed segments never overlap.
+        # Each segment excludes failed; "Other" absorbs the remainder (e.g. UI jobs).
+        other_count = max(
+            0, total - issues_count - mrs_count - mcp_jobs_count - scheduled_count - api_jobs_count - failed_count
+        )
         raw_segments = [
             ("Issues", issues_count, "bg-amber-500/50", f"{activity_url}?trigger={TriggerType.ISSUE_WEBHOOK}"),
             ("MR/PR", mrs_count, "bg-cyan-500/50", f"{activity_url}?trigger={TriggerType.MR_WEBHOOK}"),
             ("MCP Job", mcp_jobs_count, "bg-indigo-500/50", f"{activity_url}?trigger={TriggerType.MCP_JOB}"),
             ("Scheduled", scheduled_count, "bg-violet-500/40", f"{activity_url}?trigger={TriggerType.SCHEDULE}"),
+            ("API", api_jobs_count, "bg-emerald-500/50", f"{activity_url}?trigger={TriggerType.API_JOB}"),
             ("Other", other_count, "bg-gray-500/30", None),
             ("Failed", failed_count, "bg-red-500/40", f"{activity_url}?status={ActivityStatus.FAILED}"),
         ]


### PR DESCRIPTION
## Summary
- Add a dedicated **API** segment (emerald) to the dashboard outcome breakdown bar so `TriggerType.API_JOB` runs are no longer hidden in the "Other" catchall.
- Segment links to the activity list filtered by `?trigger=api_job`, matching the existing trigger-keyed segments.
- "Other" now only catches UI runs and any future trigger types without a dedicated segment; comment updated accordingly.

## Test plan
- [x] `uv run pytest tests/unit_tests/accounts/` — 163 passed
- [x] `uv run ruff check daiv/accounts/views.py` — clean
- [ ] Manual: load `/dashboard`, confirm new emerald **API** chip appears when API jobs exist and clicks through to `?trigger=api_job`