### PR TITLE
chore(mcp): Expand Sentry allowlist and pin MCP server versions

### DIFF
--- a/daiv/automation/agent/mcp/schemas.py
+++ b/daiv/automation/agent/mcp/schemas.py
@@ -18,7 +18,12 @@ class ToolFilter(BaseModel):
     mode: Literal["allow", "block"] = Field(
         ..., description="Filtering mode - 'allow' to whitelist tools, 'block' to blacklist tools"
     )
-    items: list[str] = Field(..., alias="list", description="List of tool names to filter based on the mode")
+    items: list[str] = Field(
+        ...,
+        validation_alias="list",
+        serialization_alias="list",
+        description="List of tool names to filter based on the mode",
+    )
 
 
 class UserMcpServer(BaseModel):

--- a/daiv/automation/agent/mcp/servers.py
+++ b/daiv/automation/agent/mcp/servers.py
@@ -8,8 +8,29 @@ from .schemas import ToolFilter
 
 @mcp_server
 class SentryMCPServer(MCPServer):
+    """
+    Read-only tools allowed.
+    """
+
     name = "sentry"
-    tool_filter = ToolFilter(mode="allow", items=["find_organizations", "find_projects", "list_issues", "list_events"])
+    tool_filter = ToolFilter(
+        mode="allow",
+        items=[
+            "whoami",
+            "find_teams",
+            "get_issue_tag_values",
+            "get_event_attachment",
+            "get_replay_details",
+            "get_profile_details",
+            "get_sentry_resource",
+            "find_organizations",
+            "find_projects",
+            "find_releases",
+            "search_events",
+            "search_issue",
+            "search_issue_events",
+        ],
+    )
 
     def is_enabled(self) -> bool:
         return settings.SENTRY_URL is not None

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -184,7 +184,7 @@ services:
     container_name: daiv-mcp-sentry
     command:
       - --stdio
-      - "npx @sentry/mcp-server@latest"
+      - "npx @sentry/mcp-server@0.34.0"
       - --outputTransport
       - streamableHttp
       - --healthEndpoint
@@ -209,7 +209,7 @@ services:
     container_name: daiv-mcp-context7
     command:
       - --stdio
-      - "npx @upstash/context7-mcp@latest"
+      - "npx @upstash/context7-mcp@2.2.5"
       - --outputTransport
       - streamableHttp
       - --healthEndpoint

--- a/tests/unit_tests/automation/agent/mcp/test_servers.py
+++ b/tests/unit_tests/automation/agent/mcp/test_servers.py
@@ -28,7 +28,7 @@ class TestSentryMCPServer:
         assert server.tool_filter is not None
         assert server.tool_filter.mode == "allow"
         assert "find_organizations" in server.tool_filter.items
-        assert "list_issues" in server.tool_filter.items
+        assert "search_issue" in server.tool_filter.items
 
     @patch("automation.agent.mcp.servers.settings")
     def test_sentry_get_connection_returns_correct_url(self, mock_settings):


### PR DESCRIPTION
## Summary
- Expand the Sentry MCP server allowlist with additional read-only tools (`whoami`, `find_teams`, `find_releases`, `search_events`, `search_issue`, `search_issue_events`, plus tag/event/replay/profile/resource getters)
- Pin `@sentry/mcp-server` to `0.34.0` and `@upstash/context7-mcp` to `2.2.5` in `docker-compose.yml` for reproducible builds (was `@latest`)
- Split `ToolFilter`'s `alias="list"` into explicit `validation_alias` + `serialization_alias` for clarity

## Test plan
- [ ] `make lint` passes
- [ ] `make test` passes
- [ ] Sentry MCP server starts and exposes the expanded toolset