### PR TITLE
feat(skills): Allow shadowing built-ins and drop zip noise

### DIFF
--- a/daiv/skills/services.py
+++ b/daiv/skills/services.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING, BinaryIO
 
 from django.core.exceptions import ValidationError
 from django.db import DatabaseError, transaction
+from django.db.utils import Error as DjangoDBError
 
 import yaml
 
@@ -148,7 +149,11 @@ class SkillPackage:
             raise SkillValidationError("not a valid zip archive", code="bad_zip") from err
 
         with zf:
-            infos = [i for i in zf.infolist() if not i.is_dir()]
+            # __pycache__/*.pyc and similar hygiene noise routinely sneak into
+            # uploaded zips. Drop them silently rather than refusing the whole
+            # upload — they're not a security risk, the user almost always
+            # wants the rest of the zip, and the agent never reads bytecode.
+            infos = [i for i in zf.infolist() if not i.is_dir() and not cls._is_noise(i)]
             if len(infos) > MAX_FILES:
                 raise SkillValidationError(f"zip has too many files (max {MAX_FILES})", code="too_many_files")
 
@@ -191,6 +196,19 @@ class SkillPackage:
             )
 
     @staticmethod
+    def _is_noise(info: zipfile.ZipInfo) -> bool:
+        """Hygiene-only filter for entries we drop silently (vs reject)."""
+        parts = info.filename.split("/")
+        if any(part in FORBIDDEN_PATH_PARTS for part in parts):
+            return True
+        leaf = parts[-1]
+        if "." in leaf:
+            suffix = "." + leaf.rsplit(".", 1)[1].lower()
+            if suffix in FORBIDDEN_SUFFIXES:
+                return True
+        return False
+
+    @staticmethod
     def _check_entry(info: zipfile.ZipInfo) -> None:
         # Symlink check on unix-mode bits in external_attr (high 16 bits)
         if (info.external_attr >> 16) & 0o170000 == 0o120000:
@@ -205,10 +223,6 @@ class SkillPackage:
             raise SkillValidationError(f"path traversal is not permitted: {name}", code="unsafe_path")
 
         for part in parts:
-            if part in FORBIDDEN_PATH_PARTS:
-                raise SkillValidationError(
-                    f"path contains forbidden segment '{part}': {name}", code="forbidden_path_part"
-                )
             if part.startswith("."):
                 raise SkillValidationError(f"path contains hidden segment '{part}': {name}", code="hidden_path_part")
 
@@ -217,8 +231,6 @@ class SkillPackage:
         if "." in leaf:
             suffix = "." + leaf.rsplit(".", 1)[1].lower()
 
-        if suffix in FORBIDDEN_SUFFIXES:
-            raise SkillValidationError(f"file type not permitted: {name}", code="disallowed_suffix")
         if suffix not in ALLOWED_SUFFIXES:
             raise SkillValidationError(f"file type not permitted: {name}", code="disallowed_suffix")
 
@@ -281,18 +293,20 @@ class SkillPackage:
             )
 
 
-def _classify_source(name: str, skill_path: str) -> SkillInvocation.Source:
+async def _classify_source(name: str, skill_path: str) -> SkillInvocation.Source:
     """Classify a skill invocation by name + virtual path.
 
-    A name in ``BUILTIN_SKILL_NAMES`` is always a built-in (the storage layer
-    forbids name collisions). Any other path under ``GLOBAL_SKILLS_PATH`` is a
-    custom global. Anything else is treated as per-repo; if a new skill
-    location is introduced and not added here, the caller logs a warning.
+    A custom global skill shadows a built-in of the same name, so a
+    ``GlobalSkill`` row wins over ``BUILTIN_SKILL_NAMES`` membership when both
+    match. Anything outside ``GLOBAL_SKILLS_PATH`` is treated as per-repo; if
+    a new skill location is introduced and not added here, the caller logs a
+    warning.
     """
-    if name in BUILTIN_SKILL_NAMES:
-        return SkillInvocation.Source.BUILTIN
     if skill_path.startswith(GLOBAL_SKILLS_PATH + "/"):
-        return SkillInvocation.Source.GLOBAL
+        if await GlobalSkill.objects.filter(name=name).aexists():
+            return SkillInvocation.Source.GLOBAL
+        if name in BUILTIN_SKILL_NAMES:
+            return SkillInvocation.Source.BUILTIN
     return SkillInvocation.Source.REPO
 
 
@@ -306,7 +320,7 @@ async def _record_invocation(name: str, skill_path: str, runtime: ToolRuntime[Ru
     they still cannot be allowed to block the agent.
     """
     try:
-        source = _classify_source(name, skill_path)
+        source = await _classify_source(name, skill_path)
         # A repo-classified path that doesn't look like a per-repo .agents/skills
         # layout means a new skill location appeared and _classify_source needs
         # updating — surface it instead of silently lumping it into REPO.
@@ -324,7 +338,10 @@ async def _record_invocation(name: str, skill_path: str, runtime: ToolRuntime[Ru
             logger.exception("Failed to record skill invocation for %r: missing thread_id or repository context", name)
             return
         await SkillInvocation.objects.acreate(name=name, source=source, repo_slug=repo_slug, thread_id=thread_id)
-    except DatabaseError, ValidationError:
+    except DjangoDBError, ValidationError:
+        # ``DjangoDBError`` is the common base of ``DatabaseError`` and
+        # ``InterfaceError`` — needed because ``_classify_source`` hits the DB,
+        # so a broken connection can surface here too.
         logger.exception("Failed to record skill invocation for %r", name)
 
 
@@ -357,8 +374,6 @@ class SkillStorage:
                 fcntl.flock(lock_f.fileno(), fcntl.LOCK_UN)
 
     def replace(self, pkg: SkillPackage, *, uploaded_by) -> GlobalSkill:
-        if pkg.name in BUILTIN_SKILL_NAMES:
-            raise SkillStorageError(f"cannot upload skill '{pkg.name}': name conflicts with a built-in skill")
         staged = self._stage_extract(pkg)
         try:
             with self._lock(pkg.name):
@@ -390,8 +405,6 @@ class SkillStorage:
         return skill
 
     def delete(self, name: str) -> None:
-        if name in BUILTIN_SKILL_NAMES:
-            raise SkillStorageError(f"cannot delete built-in skill '{name}'")
         with self._lock(name):
             old_tree = self.root / name
             old_zip = self.root / ZIPS_DIR / f"{name}.zip"
@@ -433,7 +446,10 @@ class SkillStorage:
         staged = Path(tempfile.mkdtemp(prefix=f"{pkg.name}.", dir=staged_parent))
         with zipfile.ZipFile(io.BytesIO(pkg.zip_bytes)) as zf:
             for info in zf.infolist():
-                if info.is_dir():
+                # Mirror ``SkillPackage.inspect``'s noise filter so dropped
+                # entries never land on disk even though they ride along in
+                # the stored zip.
+                if info.is_dir() or SkillPackage._is_noise(info):
                     continue
                 target = staged / info.filename
                 target.parent.mkdir(parents=True, exist_ok=True)

--- a/daiv/skills/templates/skills/_custom_skills.html
+++ b/daiv/skills/templates/skills/_custom_skills.html
@@ -27,7 +27,15 @@
                 </div>
             </div>
 
-            <span class="card__title">{{ skill.name }}</span>
+            <span class="card__title flex items-center gap-1.5">
+                <span class="min-w-0 break-words">{{ skill.name }}</span>
+                {% if skill.overrides_builtin %}
+                <span class="inline-flex shrink-0 text-amber-400"
+                      title="{% translate 'Overrides built-in' %}">
+                    {% icon "exclamation-triangle" "h-4 w-4" %}
+                </span>
+                {% endif %}
+            </span>
             <span class="card__count-badge mt-1.5" title="{% translate 'Lifetime invocations' %}">
                 {% icon "bolt" "h-3 w-3" %}
                 {% blocktranslate count counter=skill.invocations_count %}{{ counter }} invocation{% plural %}{{ counter }} invocations{% endblocktranslate %}

--- a/daiv/skills/views.py
+++ b/daiv/skills/views.py
@@ -41,8 +41,13 @@ class SkillListView(AdminRequiredMixin, TemplateView):
             for row in (SkillInvocation.objects.values("name", "source").annotate(c=Count("id")))
         }
 
+        custom_names = {skill.name for skill in custom_skills}
         for skill in custom_skills:
             skill.invocations_count = counts.get((skill.name, SkillInvocation.Source.GLOBAL), 0)
+            skill.overrides_builtin = skill.name in BUILTIN_SKILL_NAMES
+        # A custom upload shadows the built-in of the same name; drop the
+        # shadowed entry so the list shows only the active skill.
+        builtin_skills = [entry for entry in builtin_skills if entry["name"] not in custom_names]
         for entry in builtin_skills:
             entry["invocations_count"] = counts.get((entry["name"], SkillInvocation.Source.BUILTIN), 0)
 
@@ -109,9 +114,13 @@ class SkillDetailView(AdminRequiredMixin, View):
     http_method_names = ["get"]
 
     def get(self, request, name):
+        # Custom global skills shadow built-ins of the same name at runtime;
+        # render the override so admins see the skill actually being invoked.
+        if GlobalSkill.objects.filter(name=name).exists():
+            return self._render_global(request, name)
         if name in BUILTIN_SKILL_NAMES:
             return self._render_builtin(request, name)
-        return self._render_global(request, name)
+        raise Http404("skill not found")
 
     def _render_builtin(self, request, name):
         root = BUILTIN_SKILLS_PATH / name

--- a/tests/unit_tests/automation/agent/middlewares/test_skills.py
+++ b/tests/unit_tests/automation/agent/middlewares/test_skills.py
@@ -1129,8 +1129,15 @@ class TestSkillToolRecordsInvocation:
         }
 
         skill_tool = middleware.tools[0]
+        # _classify_source consults GlobalSkill.aexists() to disambiguate an
+        # override from a built-in of the same name; stub it so this test does
+        # not require DB access.
+        from unittest.mock import MagicMock
+
+        no_override = MagicMock(aexists=AsyncMock(return_value=False))
         with (
             patch("skills.services.BUILTIN_SKILL_NAMES", frozenset({"code-review"})),
+            patch("skills.services.GlobalSkill.objects.filter", return_value=no_override),
             patch("skills.services.SkillInvocation.objects.acreate", new=AsyncMock(return_value=None)) as mock_acreate,
         ):
             # The deepagents backend's adownload_files needs a stub since we never wrote the

--- a/tests/unit_tests/skills/test_services.py
+++ b/tests/unit_tests/skills/test_services.py
@@ -4,7 +4,7 @@ import uuid
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from skills.models import SkillInvocation
+from skills.models import GlobalSkill, SkillInvocation
 from skills.services import _classify_source, list_builtins
 
 
@@ -21,21 +21,39 @@ def test_list_builtins_returns_dicts_with_name_and_description():
         assert isinstance(entry["description"], str)
 
 
-def test_classify_source_builtin_takes_priority():
-    # Even when the path is under /skills/, a name in BUILTIN_SKILL_NAMES is built-in.
+@pytest.mark.django_db(transaction=True)
+async def test_classify_source_builtin_when_no_override_row():
+    # No GlobalSkill row for this name → built-in resolution wins.
     with patch("skills.services.BUILTIN_SKILL_NAMES", frozenset({"code-review"})):
-        assert _classify_source("code-review", "/skills/code-review/SKILL.md") == SkillInvocation.Source.BUILTIN
+        assert await _classify_source("code-review", "/skills/code-review/SKILL.md") == SkillInvocation.Source.BUILTIN
 
 
-def test_classify_source_global_when_path_under_global_skills_path():
+@pytest.mark.django_db(transaction=True)
+async def test_classify_source_global_overrides_builtin_when_row_exists():
+    """When a custom global skill shadows a built-in of the same name, the
+    invocation must be classified GLOBAL — that's the version the agent actually
+    ran. Classifying as BUILTIN here would split the counts and hide overrides
+    from telemetry."""
+    await GlobalSkill.objects.acreate(name="code-review", description="x", size_bytes=1, file_count=1, checksum="c")
+    with patch("skills.services.BUILTIN_SKILL_NAMES", frozenset({"code-review"})):
+        assert await _classify_source("code-review", "/skills/code-review/SKILL.md") == SkillInvocation.Source.GLOBAL
+
+
+@pytest.mark.django_db(transaction=True)
+async def test_classify_source_global_when_path_under_global_skills_path():
+    await GlobalSkill.objects.acreate(name="custom-thing", description="x", size_bytes=1, file_count=1, checksum="c")
     with patch("skills.services.BUILTIN_SKILL_NAMES", frozenset()):
-        assert _classify_source("custom-thing", "/skills/custom-thing/SKILL.md") == SkillInvocation.Source.GLOBAL
+        assert await _classify_source("custom-thing", "/skills/custom-thing/SKILL.md") == SkillInvocation.Source.GLOBAL
 
 
-def test_classify_source_repo_when_path_outside_global_skills_path():
-    with patch("skills.services.BUILTIN_SKILL_NAMES", frozenset()):
+@pytest.mark.django_db(transaction=True)
+async def test_classify_source_repo_when_path_outside_global_skills_path():
+    # Pin the invariant that GLOBAL_SKILLS_PATH is the only gate to BUILTIN —
+    # a per-repo skill whose name happens to match a built-in must still be
+    # classified REPO, so per-repo overrides aren't mis-attributed in telemetry.
+    with patch("skills.services.BUILTIN_SKILL_NAMES", frozenset({"repo-skill"})):
         assert (
-            _classify_source("repo-skill", "/workspace/repo/.agents/skills/repo-skill/SKILL.md")
+            await _classify_source("repo-skill", "/workspace/repo/.agents/skills/repo-skill/SKILL.md")
             == SkillInvocation.Source.REPO
         )
 

--- a/tests/unit_tests/skills/test_skill_package.py
+++ b/tests/unit_tests/skills/test_skill_package.py
@@ -149,12 +149,20 @@ def test_disallowed_suffix_rejected():
     assert exc.value.code == "disallowed_suffix"
 
 
-def test_forbidden_path_part_rejected():
-    data = _raw_zip([_valid_skill_md(), ("demo/__pycache__/foo.pyc", b"x")])
-    with pytest.raises(SkillValidationError) as exc:
-        SkillPackage.inspect(io.BytesIO(data))
-    # FORBIDDEN_PATH_PARTS is checked before suffix, so __pycache__ wins over .pyc
-    assert exc.value.code == "forbidden_path_part"
+def test_forbidden_path_part_skipped():
+    """``__pycache__`` and ``.pyc`` files are hygiene noise — silently dropped
+    instead of rejecting the whole zip. The remaining content must validate
+    normally and the file_count must exclude the dropped entries."""
+    data = _raw_zip([
+        _valid_skill_md(),
+        ("demo/scripts/foo.py", b"print('ok')\n"),
+        ("demo/scripts/__pycache__/foo.cpython-314.pyc", b"\x00bytecode"),
+        ("demo/scripts/bar.pyc", b"\x00bytecode"),
+    ])
+    pkg = SkillPackage.inspect(io.BytesIO(data))
+    assert pkg.name == "demo"
+    # SKILL.md + scripts/foo.py — the two noise entries dropped.
+    assert pkg.file_count == 2
 
 
 @pytest.mark.parametrize(

--- a/tests/unit_tests/skills/test_skill_storage.py
+++ b/tests/unit_tests/skills/test_skill_storage.py
@@ -10,7 +10,7 @@ from django.db import DatabaseError
 import pytest
 from skills.constants import TRASH_TTL_SECONDS
 from skills.models import GlobalSkill
-from skills.services import SkillPackage, SkillStorage, SkillStorageError
+from skills.services import SkillPackage, SkillStorage
 
 
 @pytest.fixture
@@ -24,6 +24,26 @@ def storage(tmp_path, monkeypatch):
     monkeypatch.setattr("skills.services.agent_settings.CUSTOM_SKILLS_PATH", custom)
     monkeypatch.setattr("skills.services.SKILLS_CACHE_PATH", cache)
     return SkillStorage()
+
+
+@pytest.mark.django_db
+def test_replace_skips_pycache_and_pyc_noise(storage, admin_user, build_skill_zip):
+    """``__pycache__`` and ``.pyc`` entries must be filtered from the unpacked
+    tree on disk — they ride along in the stored zip but never extracted."""
+    data = build_skill_zip(
+        skill_name="demo",
+        extra_files={
+            "scripts/foo.py": b"print('ok')\n",
+            "scripts/__pycache__/foo.cpython-314.pyc": b"\x00bc",
+            "scripts/bar.pyc": b"\x00bc",
+        },
+    )
+    storage.replace(SkillPackage.inspect(io.BytesIO(data)), uploaded_by=admin_user)
+
+    base = storage.root
+    assert (base / "demo" / "scripts" / "foo.py").exists()
+    assert not (base / "demo" / "scripts" / "__pycache__").exists()
+    assert not (base / "demo" / "scripts" / "bar.pyc").exists()
 
 
 @pytest.mark.django_db
@@ -163,23 +183,30 @@ def test_delete_moves_tree_and_zip_to_trash_and_removes_row(storage, admin_user,
 
 
 @pytest.mark.django_db
-def test_delete_refuses_builtin_name(storage, monkeypatch):
-    monkeypatch.setattr("skills.services.BUILTIN_SKILL_NAMES", frozenset({"plan", "init"}))
-    with pytest.raises(SkillStorageError, match="built-in"):
-        storage.delete("plan")
+def test_replace_allows_overriding_builtin(storage, admin_user, build_skill_zip, monkeypatch):
+    """A custom global skill is allowed to shadow a built-in: per-repo skills can already
+    override builtins at runtime, and the storage layer must not be stricter than the
+    middleware that actually serves skills to the agent."""
+    monkeypatch.setattr("skills.services.BUILTIN_SKILL_NAMES", frozenset({"demo"}))
+    data = build_skill_zip(skill_name="demo", description="override")
+    storage.replace(SkillPackage.inspect(io.BytesIO(data)), uploaded_by=admin_user)
+    assert (storage.root / "demo" / "SKILL.md").exists()
+    assert GlobalSkill.objects.get(name="demo").description == "override"
 
 
 @pytest.mark.django_db
-def test_replace_refuses_builtin_name(storage, admin_user, build_skill_zip, monkeypatch):
-    """Uploads must not be allowed to shadow a built-in skill (it would become un-deletable)."""
+def test_delete_allows_removing_override_of_builtin(storage, admin_user, build_skill_zip, monkeypatch):
+    """Deleting a custom override must remove only the custom row + tree;
+    the built-in underneath is untouched on disk (it lives at BUILTIN_SKILLS_PATH,
+    not under CUSTOM_SKILLS_PATH)."""
     monkeypatch.setattr("skills.services.BUILTIN_SKILL_NAMES", frozenset({"demo"}))
     data = build_skill_zip(skill_name="demo")
-    pkg = SkillPackage.inspect(io.BytesIO(data))
-    with pytest.raises(SkillStorageError, match="built-in"):
-        storage.replace(pkg, uploaded_by=admin_user)
-    # No tree, no zip, no DB row left behind.
+    storage.replace(SkillPackage.inspect(io.BytesIO(data)), uploaded_by=admin_user)
+    assert (storage.root / "demo").exists()
+
+    storage.delete("demo")
+
     assert not (storage.root / "demo").exists()
-    assert not (storage.root / ".zips" / "demo.zip").exists()
     assert not GlobalSkill.objects.filter(name="demo").exists()
 
 

--- a/tests/unit_tests/skills/test_views.py
+++ b/tests/unit_tests/skills/test_views.py
@@ -242,16 +242,19 @@ def test_download_404_when_zip_missing(client, admin_user, storage):
 
 
 @pytest.mark.django_db
-def test_upload_refuses_builtin_name(client, admin_user, storage, build_skill_zip, monkeypatch):
-    """Uploading a skill whose name collides with a built-in must be rejected with an inline error."""
+def test_upload_allows_overriding_builtin(client, admin_user, storage, build_skill_zip, monkeypatch):
+    """Uploading a skill with the same name as a built-in must succeed — the custom
+    upload shadows the built-in at runtime, matching how per-repo skills already
+    override builtins."""
     monkeypatch.setattr("skills.services.BUILTIN_SKILL_NAMES", frozenset({"demo"}))
+    monkeypatch.setattr("skills.views.BUILTIN_SKILL_NAMES", frozenset({"demo"}))
     client.force_login(admin_user)
-    data = build_skill_zip(skill_name="demo")
+    data = build_skill_zip(skill_name="demo", description="my override")
     uploaded = SimpleUploadedFile("demo.zip", data, content_type="application/zip")
     resp = client.post(reverse("skills:upload"), data={"zip": uploaded})
-    assert resp.status_code == 200
-    assert b"built-in" in resp.content.lower()
-    assert not GlobalSkill.objects.filter(name="demo").exists()
+    assert resp.status_code == 302
+    assert resp.url == reverse("skills:list")
+    assert GlobalSkill.objects.get(name="demo").description == "my override"
 
 
 @pytest.mark.django_db
@@ -472,6 +475,48 @@ def test_detail_view_builtin_missing_skill_md_logs_and_404s(admin_client, tmp_pa
     response = admin_client.get(reverse("skills:detail", args=["broken"]))
     assert response.status_code == 404
     assert any("missing SKILL.md" in rec.message for rec in caplog.records)
+
+
+@pytest.mark.django_db
+def test_detail_view_prefers_global_override_over_builtin(
+    admin_client, admin_user, storage, build_skill_zip, monkeypatch
+):
+    """When a custom global skill shadows a built-in, the detail page must render the
+    custom one — that's the skill the agent actually runs."""
+    monkeypatch.setattr("skills.services.BUILTIN_SKILL_NAMES", frozenset({"plan"}))
+    monkeypatch.setattr("skills.views.BUILTIN_SKILL_NAMES", frozenset({"plan"}))
+    data = build_skill_zip(skill_name="plan", description="my override")
+    storage.replace(SkillPackage.inspect(io.BytesIO(data)), uploaded_by=admin_user)
+
+    response = admin_client.get(reverse("skills:detail", args=["plan"]))
+    assert response.status_code == 200
+    assert response.context["source"] == "global"
+    assert response.context["skill"].description == "my override"
+
+
+@pytest.mark.django_db
+def test_list_hides_shadowed_builtin_and_marks_override(
+    admin_client, admin_user, storage, build_skill_zip, monkeypatch, request
+):
+    """A custom upload that shadows a built-in must (1) drop the built-in entry from
+    the built-in list so only the active skill is shown, and (2) flag the custom row
+    so the template can render an 'Overrides built-in' badge."""
+    from skills.services import list_builtins
+
+    list_builtins.cache_clear()
+    request.addfinalizer(list_builtins.cache_clear)
+    monkeypatch.setattr("skills.services.BUILTIN_SKILL_NAMES", frozenset({"plan"}))
+    monkeypatch.setattr("skills.views.BUILTIN_SKILL_NAMES", frozenset({"plan"}))
+
+    data = build_skill_zip(skill_name="plan", description="override")
+    storage.replace(SkillPackage.inspect(io.BytesIO(data)), uploaded_by=admin_user)
+
+    response = admin_client.get(reverse("skills:list"))
+    builtin_names = [entry["name"] for entry in response.context["builtin_skills"]]
+    assert "plan" not in builtin_names
+
+    custom_row = next(s for s in response.context["custom_skills"] if s.name == "plan")
+    assert custom_row.overrides_builtin is True
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Summary

- **Custom global skills can shadow built-ins of the same name.** The storage-layer guard refusing builtin-name collisions was inconsistent with the runtime middleware (per-repo skills already override builtins). `_classify_source` is now async + DB-aware so override invocations are recorded as `GLOBAL`, not `BUILTIN`. The detail view prefers the override; the list view filters shadowed builtins and surfaces a warning icon with an "Overrides built-in" tooltip on the custom card.
- **`__pycache__` / `.pyc` entries are silently dropped from uploaded zips** instead of rejecting the whole upload. They're hygiene noise (no security risk; the agent never reads bytecode). Both `SkillPackage.inspect` and `SkillStorage._stage_extract` apply the same filter so the noise rides along in the stored zip but never lands on disk.
- **Hardened telemetry error handling.** The outer catch in `_record_invocation` widens to `django.db.utils.Error` so the new DB call in `_classify_source` can't violate the docstring's "telemetry can never abort an invocation" guarantee on connection-level failures (`InterfaceError` is a sibling of `DatabaseError`, not a subclass).

## Test plan

- [x] `make lint-fix` clean
- [x] `uv run pytest tests/unit_tests/skills/ tests/unit_tests/automation/agent/middlewares/test_skills.py` — 129 passed
- [x] `make test` — 2735 passed
- [x] Upload a custom skill with the same name as a built-in via the admin UI, confirm the warning icon appears on the card and the detail page renders the override
- [x] Upload a zip containing `__pycache__/*.pyc`, confirm it succeeds and the unpacked tree on disk excludes those files
- [x] Delete the custom override, confirm the built-in is restored on the next agent run