### PR TITLE
fix(slash-commands): Drop in-memory history when /clear runs

### DIFF
--- a/daiv/automation/agent/middlewares/skills.py
+++ b/daiv/automation/agent/middlewares/skills.py
@@ -10,8 +10,9 @@ from deepagents.middleware.skills import SkillsMiddleware as DeepAgentsSkillsMid
 from langchain.agents.middleware import hook_config
 from langchain.agents.middleware.types import PrivateStateAttr
 from langchain.tools import ToolRuntime, tool  # noqa: TC002
-from langchain_core.messages import AIMessage, AnyMessage, HumanMessage, ToolMessage
+from langchain_core.messages import AIMessage, AnyMessage, HumanMessage, RemoveMessage, ToolMessage
 from langchain_core.prompts import PromptTemplate
+from langgraph.graph.message import REMOVE_ALL_MESSAGES
 from langgraph.runtime import Runtime  # noqa: TC002
 from langgraph.types import Command
 from skills.services import _record_invocation
@@ -362,10 +363,18 @@ class SkillsMiddleware(DeepAgentsSkillsMiddleware):
             )
         except Exception:
             logger.exception("[%s] Failed to execute `%s` slash command", self.name, slash_command.raw)
+            # Intentionally do not honor ``resets_thread`` here: if ``execute_for_agent`` raised,
+            # any checkpointer-side wipe (e.g. ``/clear``'s ``delete_thread``) may not have run,
+            # so keeping in-memory history avoids diverging state from the still-populated Redis
+            # checkpoint.
             return {"messages": [AIMessage(content=f"Failed to execute `{slash_command.raw}`.")], "jump_to": "end"}
         else:
             logger.info("[%s] `%s` slash command completed", self.name, slash_command.raw)
-            return {"messages": [AIMessage(content=result)], "jump_to": "end"}
+            # ``resets_thread`` commands (e.g. ``/clear``) must drop the in-memory history;
+            # otherwise the final checkpoint write of this turn re-persists every prior message
+            # under the same ``thread_id``, resurrecting messages the command just deleted.
+            reset_prefix: list = [RemoveMessage(id=REMOVE_ALL_MESSAGES)] if command.resets_thread else []
+            return {"messages": [*reset_prefix, AIMessage(content=result)], "jump_to": "end"}
 
     def _extract_slash_command(self, messages: list[AnyMessage], bot_username: str) -> SlashCommandCommand | None:
         """

--- a/daiv/slash_commands/actions/clear.py
+++ b/daiv/slash_commands/actions/clear.py
@@ -19,6 +19,7 @@ class ClearSlashCommand(SlashCommand):
     """
 
     description: str = "Clear the conversation context and start fresh."
+    resets_thread = True
 
     async def execute_for_agent(
         self, *, args: str, issue_iid: int | None = None, merge_request_id: int | None = None, **kwargs

--- a/daiv/slash_commands/base.py
+++ b/daiv/slash_commands/base.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from typing import ClassVar
 
 from codebase.base import Scope
 
@@ -13,6 +14,11 @@ class SlashCommand(ABC):
     command: str
     scopes: list[Scope]
     description: str
+
+    resets_thread: ClassVar[bool] = False
+    """When ``True``, the middleware will drop the conversation history from agent state on
+    return — required because deleting the Redis checkpoint alone is undone when the same
+    turn writes its final checkpoint back under the same ``thread_id``."""
 
     def __init__(self, *, scope: Scope, repo_id: str, bot_username: str | None = None):
         self.scope = scope

--- a/tests/unit_tests/automation/agent/middlewares/test_skills.py
+++ b/tests/unit_tests/automation/agent/middlewares/test_skills.py
@@ -5,7 +5,8 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from langchain.agents.middleware.types import ToolCallRequest
-from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+from langchain_core.messages import AIMessage, HumanMessage, RemoveMessage, ToolMessage
+from langgraph.graph.message import REMOVE_ALL_MESSAGES
 from langgraph.types import Command
 
 from automation.agent.constants import AGENTS_SKILLS_PATH, CLAUDE_CODE_SKILLS_PATH, CURSOR_SKILLS_PATH, SKILLS_SOURCES
@@ -303,6 +304,51 @@ class TestSkillsMiddleware:
         assert result["jump_to"] == "end"
         assert isinstance(result["messages"][0], AIMessage)
         assert result["messages"][0].content == "arg1|101|202|skill-one"
+
+    async def test_apply_builtin_slash_commands_drops_history_when_command_resets_thread(self):
+        """Commands flagged ``resets_thread`` must emit ``RemoveMessage(REMOVE_ALL_MESSAGES)``
+        ahead of the result so the turn-final checkpoint write doesn't re-persist prior
+        messages under the same thread_id (regression for /clear)."""
+
+        class ResettingSlashCommand(SlashCommand):
+            description = "reset"
+            resets_thread = True
+
+            async def execute_for_agent(
+                self,
+                *,
+                args: str,
+                issue_iid: int | None = None,
+                merge_request_id: int | None = None,
+                available_skills: list | None = None,
+                available_subagents: list | None = None,
+            ) -> str:
+                return "done"
+
+        registry = SlashCommandRegistry()
+        registry.register(ResettingSlashCommand, "reset", [Scope.GLOBAL])
+
+        middleware = SkillsMiddleware(backend=Mock(), sources=["/skills"])
+        context = Mock()
+        context.bot_username = "daiv"
+        context.scope = Scope.GLOBAL
+        context.repository = Mock(slug="repo-1")
+        context.issue = None
+        context.merge_request = None
+
+        with patch("automation.agent.middlewares.skills.slash_command_registry", registry):
+            result = await middleware._apply_builtin_slash_commands(
+                [HumanMessage(content="/reset"), AIMessage(content="prior"), HumanMessage(content="/reset")],
+                context,
+                [],
+            )
+
+        assert result is not None
+        assert result["jump_to"] == "end"
+        assert isinstance(result["messages"][0], RemoveMessage)
+        assert result["messages"][0].id == REMOVE_ALL_MESSAGES
+        assert isinstance(result["messages"][1], AIMessage)
+        assert result["messages"][1].content == "done"
 
     async def test_apply_builtin_slash_commands_returns_error_message_on_failure(self):
         class FailingSlashCommand(SlashCommand):

--- a/tests/unit_tests/slash_commands/actions/test_clear.py
+++ b/tests/unit_tests/slash_commands/actions/test_clear.py
@@ -32,6 +32,9 @@ def test_clear_command_has_correct_attributes():
     assert Scope.ISSUE in ClearSlashCommand.scopes
     assert Scope.MERGE_REQUEST in ClearSlashCommand.scopes
     assert Scope.GLOBAL not in ClearSlashCommand.scopes
+    # The middleware relies on this flag to drop in-memory messages on /clear; otherwise the
+    # turn-final checkpoint write re-persists the prior history under the same thread_id.
+    assert ClearSlashCommand.resets_thread is True
 
 
 @override_settings(DJANGO_REDIS_CHECKPOINT_URL="redis://localhost:6379")


### PR DESCRIPTION
## Summary

- `/clear` was deleting the Redis checkpoint mid-turn but the same LangGraph turn's final checkpoint write re-persisted every prior message under the same `thread_id` — the in-memory `messages` channel (with the `add_messages` reducer) still held the full history, so the command had no observable effect.
- Add `resets_thread: ClassVar[bool] = False` on `SlashCommand`; `ClearSlashCommand` sets it to `True`.
- In `SkillsMiddleware._apply_builtin_slash_commands`, the success branch now prepends `RemoveMessage(id=REMOVE_ALL_MESSAGES)` when the command resets the thread, so the in-memory state is wiped before LangGraph writes the final checkpoint. The failure branch intentionally skips this to keep state consistent with the (possibly still-populated) Redis checkpoint when `delete_thread` may not have run.

## Test plan

- [x] `uv run pytest tests/unit_tests/slash_commands/actions/test_clear.py tests/unit_tests/automation/agent/middlewares/test_skills.py` — 46 passed
- [x] `make lint-fix` — clean
- [x] `make lint-typing` — 357 diagnostics, unchanged from baseline (no new type errors introduced)
- [ ] Manual: send `/clear` on a real GitLab/GitHub issue with prior conversation; confirm follow-up message starts fresh