### PR TITLE
fix(skills): Rematerialize global skills on every turn

### DIFF
--- a/daiv/automation/agent/middlewares/skills.py
+++ b/daiv/automation/agent/middlewares/skills.py
@@ -136,11 +136,13 @@ class SkillsMiddleware(DeepAgentsSkillsMiddleware):
         if clear_skill_mode:
             logger.info("[%s] Clearing active skill mode '%s' on user follow-up", self.name, state["active_skill_mode"])
 
-        # Skip the filesystem walk once skills_metadata is in state — upstream `abefore_agent` also
-        # short-circuits on the same condition, so re-walking is pure waste on turns 2+.
-        local_load_errors: list[str] = []
-        if "skills_metadata" not in state:
-            local_load_errors = await self._copy_global_skills()
+        # Materialize on every turn, not just when ``skills_metadata`` is unset: ``SKILLS_CACHE_PATH``
+        # is per-container (``/tmp``) while ``skills_metadata`` is persisted in the Redis checkpoint,
+        # so a turn that resumes on a fresh worker (rolling deploy, scale-up, pod restart) would
+        # otherwise hit ``file_not_found`` when the ``skill`` tool downloads ``SKILL.md`` from disk.
+        # ``_collect_skill_files`` is idempotent via a per-file existence check, so warm containers
+        # only pay an ``iterdir`` + per-file ``stat``.
+        local_load_errors = await self._copy_global_skills()
 
         skills_update = await super().abefore_agent(state, runtime, config)
 

--- a/tests/unit_tests/automation/agent/middlewares/test_skills.py
+++ b/tests/unit_tests/automation/agent/middlewares/test_skills.py
@@ -81,8 +81,10 @@ class TestSkillsMiddleware:
         assert skills["skill-one"]["path"] == "/skills/skill-one/SKILL.md"
         assert skills["skill-two"]["path"] == "/skills/skill-two/SKILL.md"
 
-    async def test_skips_copy_global_skills_when_metadata_already_cached(self, tmp_path: Path):
-        """Once skills_metadata is in state, abefore_agent must not re-walk the filesystem."""
+    async def test_recopies_global_skills_when_metadata_already_cached(self, tmp_path: Path):
+        """``_copy_global_skills`` must run every turn so a resume on a fresh worker (Redis
+        checkpoint carries ``skills_metadata``, but ``/tmp/daiv-skills`` is empty on this
+        container) rematerializes SKILL.md files the ``skill`` tool needs to read from disk."""
         from deepagents.backends.filesystem import FilesystemBackend
 
         builtin = tmp_path / "builtin_skills"
@@ -103,11 +105,11 @@ class TestSkillsMiddleware:
 
         with (
             patch("automation.agent.middlewares.skills.BUILTIN_SKILLS_PATH", builtin),
-            patch.object(middleware, "_copy_global_skills", new_callable=AsyncMock) as mock_copy,
+            patch.object(middleware, "_copy_global_skills", new_callable=AsyncMock, return_value=[]) as mock_copy,
         ):
             await middleware.abefore_agent(state, runtime, Mock())
 
-        mock_copy.assert_not_called()
+        mock_copy.assert_awaited_once()
 
     async def test_preserves_user_supplied_metadata(self, tmp_path: Path):
         from deepagents.backends.filesystem import FilesystemBackend


### PR DESCRIPTION
## Summary

- `_copy_global_skills` now runs on every turn instead of being gated on `"skills_metadata" not in state`. The gate (added in 8ab4b7d2) assumed `SKILLS_CACHE_PATH` (`/tmp/daiv-skills`) survived for the session, but it's per-container while `skills_metadata` is persisted in the Redis checkpoint — so a turn that resumes on a different worker (rolling deploy, scale-up, pod restart) loaded the metadata but hit an empty cache, and the `skill` tool returned `file_not_found` when reading `SKILL.md` from disk.
- Observed in production: a `/code-review` turn following a `/clear` failed with `Failed to launch skill 'code-review': file_not_found.` The earlier `/clear` regression on `main` (since-fixed) kept `skills_metadata` across the cleared turn, and the next turn happened to land on a fresh container.
- `_collect_skill_files` is idempotent via a per-file `exists()` check, so warm containers only pay an `iterdir` + per-file `stat` — the perf cost the original commit was avoiding is small relative to the correctness loss.
- Inverted the test that locked in the broken invariant into `test_recopies_global_skills_when_metadata_already_cached` to pin the restored behavior.

## Test plan

- [x] `uv run pytest tests/unit_tests/automation/agent/middlewares/test_skills.py` — 41 passed
- [x] `make lint-fix` — clean
- [ ] Production: confirm `/code-review` succeeds on a `/clear`-then-resume sequence that lands on a fresh worker