### PR TITLE
feat(skills): Anchor injected skill body to its virtual root

### DIFF
--- a/daiv/automation/agent/middlewares/skills.py
+++ b/daiv/automation/agent/middlewares/skills.py
@@ -446,6 +446,14 @@ class SkillsMiddleware(DeepAgentsSkillsMiddleware):
                     else f"{body}\n\n{SKILL_ARGUMENTS_PLACEHOLDER}: {arg_str}"
                 )
 
+            # Skill names can collide between the global tree and per-repo .agents/skills/,
+            # so inject the resolved root for relative references inside SKILL.md.
+            skill_root = str(Path(loaded_skill["path"]).parent)
+            body = (
+                f"<skill_root>{skill_root}</skill_root>\n"
+                f"Relative paths in this skill resolve under the skill root above.\n\n{body}"
+            )
+
             skill_mode = loaded_skill.get("metadata", {}).get("mode")
             update: dict = {
                 "messages": [

--- a/tests/unit_tests/automation/agent/middlewares/test_skills.py
+++ b/tests/unit_tests/automation/agent/middlewares/test_skills.py
@@ -472,7 +472,45 @@ class TestSkillsMiddleware:
         assert isinstance(messages[0], ToolMessage)
         assert messages[0].content == "Launching skill 'demo'..."
         assert isinstance(messages[1], HumanMessage)
-        assert messages[1].content == "First alpha, second beta, all: alpha beta"
+        assert messages[1].content.endswith("First alpha, second beta, all: alpha beta")
+
+    async def test_skill_tool_anchors_body_to_skill_root(self):
+        backend = Mock()
+        backend.adownload_files = AsyncMock(
+            return_value=[Mock(error=None, content=b"---\nname: demo\ndescription: Demo\n---\nRun this.")]
+        )
+        middleware = SkillsMiddleware(backend=backend, sources=["/skills"])
+        tool = middleware._skill_tool_generator()
+
+        runtime = Mock()
+        runtime.state = {"skills_metadata": [{"name": "demo", "path": "/skills/demo/SKILL.md"}]}
+        runtime.tool_call_id = "call_1"
+
+        with patch("automation.agent.middlewares.skills._record_invocation", new_callable=AsyncMock):
+            result = await tool.coroutine(skill="demo", runtime=runtime)
+
+        assert result.update["messages"][1].content == (
+            "<skill_root>/skills/demo</skill_root>\n"
+            "Relative paths in this skill resolve under the skill root above.\n\n"
+            "Run this."
+        )
+
+    async def test_skill_tool_anchors_per_repo_skill_to_its_source_root(self):
+        backend = Mock()
+        backend.adownload_files = AsyncMock(
+            return_value=[Mock(error=None, content=b"---\nname: demo\ndescription: Demo\n---\nBody.")]
+        )
+        middleware = SkillsMiddleware(backend=backend, sources=["/skills", "/myrepo/.agents/skills"])
+        tool = middleware._skill_tool_generator()
+
+        runtime = Mock()
+        runtime.state = {"skills_metadata": [{"name": "demo", "path": "/myrepo/.agents/skills/demo/SKILL.md"}]}
+        runtime.tool_call_id = "call_1"
+
+        with patch("automation.agent.middlewares.skills._record_invocation", new_callable=AsyncMock):
+            result = await tool.coroutine(skill="demo", runtime=runtime)
+
+        assert result.update["messages"][1].content.startswith("<skill_root>/myrepo/.agents/skills/demo</skill_root>\n")
 
     async def test_skill_tool_appends_named_arguments_when_missing_placeholder(self):
         backend = Mock()


### PR DESCRIPTION
## Summary
- When the `skill` tool injects a skill's SKILL.md body as a `HumanMessage`, the body now carries an explicit `<skill_root>{virtual_path}</skill_root>` anchor derived from the skill's backend path.
- Without the anchor, relative references inside SKILL.md (e.g. `scripts/foo.py`) were unresolvable: the system prompt's `<available_skills>` list intentionally strips paths, and a skill name can exist in both the global tree and per-repo `.agents/skills/` — the agent had to guess which source root it came from.
- Added focused unit tests covering the global path, a per-repo source path, and asserting the prefix shape independently of `$ARGUMENTS` substitution.

## Test plan
- [x] `uv run pytest tests/unit_tests/automation/agent/middlewares/test_skills.py` — 43 passed
- [ ] Manual: invoke a per-repo skill in a repo that has `.agents/skills/<name>/` and confirm the agent can resolve relative asset paths under the correct root