### PR TITLE
feat(code-review): Add inline question archetype

### DIFF
--- a/daiv/automation/agent/skills/code-review/SKILL.md
+++ b/daiv/automation/agent/skills/code-review/SKILL.md
@@ -2,7 +2,7 @@
 name: code-review
 description: This skill should be used when a user asks for a code review, feedback on a PR or MR, diff assessment, or says things like 'can you review my changes', 'look at this diff', 'is this ready to merge', 'check my code', 'review this branch', 'what do you think of these changes', or 'LGTM check'. Covers correctness, tests, performance, security, structural concerns, and questions of intent on pull/merge requests or raw diffs from any platform (GitHub, GitLab).
 metadata:
-  version: 2.0.0
+  version: 2.1.0
 ---
 
 # Code Review
@@ -77,7 +77,7 @@ Fields:
 
 **Implementation.** `scripts/marker.py` is the canonical implementation of the marker contract — never compute anchors or assemble markers by hand. The script's `anchor`, `build`, and `parse-notes` subcommands are deterministic and version-stable; paraphrasing the rules into ad-hoc Python or prose silently breaks dedup across reruns. Run `scripts/marker.py <cmd> --help` for argument details.
 
-**Anchor target.** Inline findings anchor on **added or context** lines on the new side of the diff. A pure-deletion finding (no `new_line`) is not inline-eligible — demote it to the summary. For a single-line suggestion, the target line is `new_line` from the diff position. For a multi-line suggestion (`suggestion:-N+M` covering several lines), the target is the **first** new-side line of the replacement window. The model picks the line; the script computes the anchor.
+**Anchor target.** Inline findings anchor on **added or context** lines on the new side of the diff. A pure-deletion finding (no `new_line`) is not inline-eligible — demote it to the summary. For a single-line finding (suggestion or question), the target line is `new_line` from the diff position. For a multi-line finding — `suggestion:-N+M` covering several lines, or a question scoped to a contiguous block — the target is the **first** new-side line of the range. The model picks the line; the script computes the anchor.
 
 **Daiv-authored detection.** A note is treated as daiv-posted **iff** its body begins with the literal prefix `<!-- daiv-cr ` followed by a parseable JSON payload terminating in ` -->`. Author username is *not* used. `parse-notes` applies this rule; do not reimplement it.
 
@@ -138,20 +138,24 @@ After addressing all pending replies, continue to bucketing new findings. A repl
 
 ### Step 3 — Bucket findings
 
-For each candidate finding, classify the fix as one of these **inline-eligible** archetypes:
+Inline delivery comes in two shapes — both anchor on a single new-side line (or contiguous new-side range) and both dedup by `(inline, archetype, file, anchor)`.
+
+**Fix archetypes** — the finding ships a concrete code change expressible as a `suggestion` block replacing a contiguous range of new-side lines within a single hunk:
 
 - `remove_dead_lines`
 - `use_framework_idiom`
 - `replace_with_constant`
 - `swap_library_call`
 
-If the fix is one of those AND can be expressed as a `suggestion` block replacing a contiguous range of new-side lines within a single hunk, it's **inline**. The range may cover several lines (use `suggestion:-N+M`) — what matters is that it's one contiguous hunk replacement, not that only one line changes. Lines inside the range that don't change are restated verbatim in the suggestion. For example, a finding that the same expression is computed twice across a 4-line block is still inline: the suggestion replaces all 4 lines, restating the ones that stay.
+The range may cover several lines (use `suggestion:-N+M`) — what matters is that it's one contiguous hunk replacement, not that only one line changes. Lines inside the range that don't change are restated verbatim in the suggestion. For example, a finding that the same expression is computed twice across a 4-line block is still inline: the suggestion replaces all 4 lines, restating the ones that stay.
 
-Demote to **discussion-only** only when no clean inline patch exists: the change spans multiple files or non-adjacent hunks, requires prose to land (e.g., "this module needs restructuring"), is a question, or is a rename that propagates to call sites.
+**Question archetype** — `question`. A targeted question that anchors on a single new-side line or a contiguous new-side range within a single hunk, and poses a concrete hypothesis the author can answer yes/no. No `suggestion` block — just marker + one or two sentences ending in `?`. Use this for every finding that meets the Signal filter's *Question* bar; the reader sees the question on the exact line(s) in the diff view instead of hunting for it in the summary. When anchoring on a range, follow the same rule as multi-line suggestions: post the discussion against the full range, and compute the anchor on the **first** new-side line of the range. Pure-deletion questions (no new-side line) demote to summary, same rule as fix archetypes.
+
+Demote to **discussion-only** only when no clean inline shape exists: the finding spans multiple files or non-adjacent hunks, requires prose to land (e.g., "this module needs restructuring"), is a question with no single-line anchor (e.g., a cross-cutting concern about a refactor), is a question whose subject is a rename (the question is about call-site impact the anchor can't show), or is a rename that propagates to call sites.
 
 A rename is *not* inline-eligible: a `suggestion` block can only patch the declaration, not the call sites, so a rename-as-inline ships a half-truth. Renames go in the summary.
 
-If an inline finding's diff position cannot be constructed reliably (file renamed across the diff, line moved within a hunk, anchor ambiguous), **demote it to discussion-only**. Never post a misaligned suggestion.
+If an inline finding's diff position cannot be constructed reliably (file renamed across the diff, line moved within a hunk, anchor ambiguous), **demote it to discussion-only**. Never post a misaligned suggestion or a misanchored question.
 
 ### Step 4 — Apply dedup
 
@@ -164,10 +168,16 @@ For each surviving inline finding:
 1. Build the marker line with `scripts/marker.py build --kind inline --sha <head_sha> --archetype <X> --file <new_path> --line <new_line> --anchor <anchor>`. Capture the output verbatim — it is the first physical line of the note body.
 2. Post via `gitlab project-merge-request-discussion create` with `--position`. Follow the position-construction and suggestion-block guidance already documented on the `gitlab` tool — do not invent your own conventions.
 
-Body shape: marker line, then a short comment (one or two sentences), then — when the fix is a literal line replacement — a `suggestion` block. Keep bodies tight; the suggestion block IS the value, not the prose around it. Example marker line:
+Body shape depends on the archetype:
+
+- **Fix archetype** (`remove_dead_lines`, `use_framework_idiom`, `replace_with_constant`, `swap_library_call`): marker line, then a short comment (one or two sentences), then a `suggestion` block replacing the target range. The suggestion block IS the value.
+- **Question archetype** (`question`): marker line, then one or two sentences ending in `?`. No `suggestion` block. The question itself IS the value.
+
+Keep bodies tight; the prose around it is justification, not filler. Example marker lines:
 
 ```
 <!-- daiv-cr {"v":1,"kind":"inline","archetype":"remove_dead_lines","file":"services/api.py","line":42,"anchor":"a1b2c3d4","sha":"abc1234"} -->
+<!-- daiv-cr {"v":1,"kind":"inline","archetype":"question","file":"env_files/all/grafana.env","line":9,"anchor":"b2c3d4e5","sha":"abc1234"} -->
 ```
 
 ### Step 6 — Post or update the summary discussion
@@ -175,7 +185,7 @@ Body shape: marker line, then a short comment (one or two sentences), then — w
 Compose **one** top-level summary containing:
 
 - All discussion-only findings, grouped by severity (High / Medium / Low). Same shape as Interactive mode below: one-line summary + `<details>` block.
-- A short **Questions** section, if any.
+- A short **Questions** section for discussion-only questions (cross-file or un-anchored). Targeted questions go inline (see Step 3), not here.
 - A one-line index of the inline findings posted this run (filename + line + archetype), so a reviewer skimming the thread sees the full picture without expanding diffs.
 
 Build the marker with `scripts/marker.py build --kind summary --sha <head_sha>` and place its output as the first physical line of the body. Example:
@@ -189,6 +199,8 @@ If `summary` from Step 1 was non-null, **update the existing note in place** (`g
 If `summary` was null, create a fresh top-level discussion (`project-merge-request-discussion create --mr-iid <iid> --body "..."` with no `--position`).
 
 If there are zero discussion-only findings AND zero inline findings AND no prior summary, write **nothing** — don't post an empty summary.
+
+A question previously embedded in an older summary's *Questions* section has no `(inline, question, file, anchor)` fingerprint — only the summary's `kind=summary` fingerprint exists. So on re-review the agent posts the question inline (new fingerprint, not deduped) AND rewrites the summary in place to drop the prose copy. Both happen in one run; convergence is single-pass.
 
 ### Step 7 — Return status to the harness
 

--- a/daiv/automation/agent/skills/code-review/examples/example-review-output.md
+++ b/daiv/automation/agent/skills/code-review/examples/example-review-output.md
@@ -86,6 +86,18 @@ return strings.Join(parts, ":")
 
 ---
 
+## Delivery mode — inline body (example C: `question`, env file)
+
+A targeted question — anchored on one new-side line, no `suggestion` block, just a concrete hypothesis the author can answer yes/no.
+
+````markdown
+<!-- daiv-cr {"v":1,"kind":"inline","archetype":"question","file":"env_files/all/grafana.env","line":9,"anchor":"b2c3d4e5","sha":"abc1234"} -->
+
+The migration notes call for `fake|alloy` during cutover, but this default is `fake` only. Is `alloy` intentionally omitted here (environment-specific override), or should the default match the documented cutover list?
+````
+
+---
+
 ## Delivery mode — summary discussion body
 
 The summary collects every **discussion-only** finding plus a one-line index of the inline findings posted this run. On re-review, this exact body is updated in place — never appended.
@@ -119,25 +131,29 @@ Move the uniqueness check into the model's `validate()`.
 
 ## Questions
 
-**3. Does this hook fire on every product edit, or only on approval?** — `inbound/views.go:81`
+**3. Does the new ingestion pipeline preserve ordering across the three modules, or is reordering OK?** — multiple files
 
 <details>
 <summary>Details</summary>
 
-The new branch in `CanPublish` triggers `submitForReviewEmail` whenever `canSubmit()` is true. A seller editing the product description after approval would re-trigger the email. Intended, or should the trigger guard on a state transition?
+The refactor moves dedup into `ingest/wavecom.py` and removes the explicit sort step from two callers. The change spans more than one file, so it can't anchor on a single diff line. Is the looser ordering intentional, or did the dedup move accidentally drop the sort?
 
 </details>
 
-## Inline suggestions posted (2)
+## Inline findings posted (3)
 
 - `services/api.py:42` — drop explicit default `timeout=30` *(remove_dead_lines)*
 - `internal/cache/key.go:18` — use `strings.Join` instead of manual loop *(use_framework_idiom)*
+- `env_files/all/grafana.env:9` — is `alloy` intentionally omitted from the default tenant list? *(question)*
 ````
 
 ---
 
 ## What goes inline vs in the summary
 
-Inline body is for **one- or two-line fixes** that map cleanly to a `suggestion` block — fix archetypes `remove_dead_lines`, `use_framework_idiom`, `replace_with_constant`, `swap_library_call`. The body is the suggestion; the prose is one or two sentences of justification, no more.
+Two inline shapes:
 
-Everything else goes in the summary: findings spanning multiple lines or files, architectural / placement concerns, **renames** (a `suggestion` block can only patch the declaration, not the call sites), questions, anything that needs prose to land. If a finding's diff position can't be reliably constructed (renamed file, line moved, hunk anchor unclear), demote it to the summary — never post a misaligned inline suggestion.
+- **Fix archetypes** — one- or two-line fixes that map cleanly to a `suggestion` block: `remove_dead_lines`, `use_framework_idiom`, `replace_with_constant`, `swap_library_call`. The body is the suggestion; the prose is one or two sentences of justification, no more.
+- **Question archetype** — targeted questions anchored on a single new-side line or a contiguous new-side range within one hunk. No `suggestion` block — just marker + one or two sentences ending in `?`. The reader sees the question on the exact line(s) in the diff view. When the question is about a multi-line block, scope the position to the full range and compute the anchor on the first new-side line of that range.
+
+Everything else goes in the summary: findings spanning multiple lines or files, architectural / placement concerns, **renames** (a `suggestion` block can only patch the declaration, not the call sites), questions without a single-line anchor (cross-cutting concerns), anything that needs prose to land. If a finding's diff position can't be reliably constructed (renamed file, line moved, hunk anchor unclear), demote it to the summary — never post a misaligned inline suggestion or misanchored question.

--- a/daiv/automation/agent/skills/code-review/references/few-shot-examples.md
+++ b/daiv/automation/agent/skills/code-review/references/few-shot-examples.md
@@ -1,16 +1,21 @@
 # Code Review — Few-Shot Examples
 
-Each section shows one fix archetype rendered in three different languages.
-Treat these as *shape* references: the archetype generalizes; the syntax is
-language-specific. Use them to calibrate how short an inline review comment
-can be, what a suggestion block typically replaces, and how the same defect
-manifests across stacks. These are not templates to copy verbatim.
+Each section shows one archetype rendered in several languages — comment / fix
+pairs for fix archetypes, or comment-only snippets for the `question`
+archetype (which carries no fix). Treat these as *shape* references: the
+archetype generalizes; the syntax is language-specific. Use them to calibrate
+how short an inline review comment can be, what a suggestion block typically
+replaces, what a yes/no question looks like, and how the same defect manifests
+across stacks. These are not templates to copy verbatim.
 
-Inline-eligible archetypes (the skill posts these as inline suggestion blocks):
-`remove_dead_lines`, `use_framework_idiom`, `replace_with_constant`,
-`swap_library_call`. Everything else — including `rename`, which propagates to
-call sites that a single-line suggestion can't patch — goes in the summary
-discussion.
+Inline-eligible archetypes come in two shapes. **Fix archetypes** ship a
+`suggestion` block: `remove_dead_lines`, `use_framework_idiom`,
+`replace_with_constant`, `swap_library_call`. The **question archetype**
+(`question`) is also inline-eligible: it anchors on a specific new-side line
+but carries no `suggestion` block — just the question. Everything else —
+including `rename`, which propagates to call sites that a single-line
+suggestion can't patch, and cross-file or un-anchored questions — goes in
+the summary discussion.
 
 ---
 
@@ -521,6 +526,88 @@ function getTopScorers(players: Player[]): Player[] {
 
 renderLeaderboard(getTopScorers(roster));
 renderRoster(roster); // roster order is preserved
+```
+
+---
+
+## `question` (inline-eligible)
+
+A targeted question anchored on a single new-side line or a contiguous
+new-side range within one hunk. The reader needs the author's *intent*, not
+a fix — does the diff really do what it looks like it does, or is there a
+hidden constraint the comment doesn't capture? Inline delivery puts the
+question on the exact line(s) in the diff view, so the author can answer
+with context instead of hunting through a summary. The body is marker + one
+or two sentences ending in `?` — no `suggestion` block. When the question
+is about a multi-line block, scope the discussion position to the full range
+and compute the anchor on the first new-side line of that range.
+
+The bar is high: don't ask curiosity questions, don't paraphrase the code,
+don't ask things the diff itself already answers. The hypothesis must be
+concrete and yes/no-answerable.
+
+### Example A — config file
+
+**Reviewer comment:** `The migration notes call for "fake|alloy" during cutover, but this default is "fake" only. Is "alloy" intentionally omitted here (environment-specific override), or should the default match the documented cutover list?`
+
+**Code:**
+
+```bash
+# env_files/all/grafana.env
+GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET__FILE=/run/secrets/keycloak_client_secret
+
+# Pipe-joined list of Loki tenant ids the single Loki datasource is allowed
+# to query (see configs/all/grafana/provisioning/datasources/loki.yml).
+LOKI_TENANT_IDS=fake
+```
+
+### Example B — Python
+
+**Reviewer comment:** `signal.connect with weak=False is called on every form __init__ — does this leak a handler per form instance, or is the signal expected to be re-registered on each request?`
+
+**Code:**
+
+```python
+class OrderForm(forms.ModelForm):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        post_save.connect(self._update_inventory, sender=Order, weak=False)
+```
+
+### Example C — Go
+
+**Reviewer comment:** `ctx is constructed with context.Background() inside the goroutine — should this inherit from the request context so cancellation propagates, or is the goroutine intentionally detached from the caller's lifetime?`
+
+**Code:**
+
+```go
+func (h *Handler) Submit(w http.ResponseWriter, r *http.Request) {
+    go func() {
+        ctx := context.Background()
+        if err := h.processor.Enqueue(ctx, payload); err != nil {
+            log.Error(err)
+        }
+    }()
+    w.WriteHeader(http.StatusAccepted)
+}
+```
+
+### Example D — multi-line block (TypeScript)
+
+The question is about the block as a whole, not a single line. Scope the discussion position to the contiguous range; the anchor is computed on the first new-side line of the range (`try {` here).
+
+**Reviewer comment:** `This catch swallows network errors, parse errors, and validation errors under one branch and returns the same fallback. Is collapsing all three intentional, or should at least validation errors surface to the caller?`
+
+**Code (lines 24–31, single hunk):**
+
+```typescript
+try {
+    const resp = await fetch(url);
+    const json = await resp.json();
+    return schema.parse(json);
+} catch {
+    return DEFAULT_CONFIG;
+}
 ```
 
 ---


### PR DESCRIPTION
## Summary

Adds a `question` inline-eligible archetype to the code-review skill so targeted questions land on the relevant diff line instead of being buried in the summary's *Questions* section.

- New archetype `question` — anchors on a single new-side line OR a contiguous new-side range within one hunk. No `suggestion` block; just marker + one or two sentences ending in `?`.
- Cross-file, un-anchored, pure-deletion, and rename-subject questions still demote to summary.
- Dedup fingerprint `(inline, question, file, anchor)` follows the existing rule; `scripts/marker.py` doesn't whitelist archetypes, so no code change required.
- Convergence on re-review: a question previously embedded in an older summary has no inline fingerprint, so the agent posts it inline AND rewrites the summary in one run.

### Motivation

Trace `019e6ee6-374b-7090-9027-2b9aa58fc8fb` shows the agent producing a perfectly targeted question anchored at `env_files/all/grafana.env:9` ("Is `alloy` intentionally omitted from the default tenant list?"), but the spec forced it into the MR summary. Posting inline puts the question where the reader can answer it with context.

### Files

- `daiv/automation/agent/skills/code-review/SKILL.md` — version bump 2.0.0 → 2.1.0; Step 3 bucketing, Step 5 body shape, Step 6 summary-convergence note, Anchor target rule generalised.
- `daiv/automation/agent/skills/code-review/examples/example-review-output.md` — new inline Example C (env file question); summary's *Questions* now shows a cross-file question.
- `daiv/automation/agent/skills/code-review/references/few-shot-examples.md` — new `question` section with four examples, including a multi-line block case.

## Test plan

- [x] `uv run pytest tests/unit_tests/automation/agent/skills/code_review/` — 23/23 marker tests pass.
- [ ] Manual: re-run code-review against an MR with a previously summary-embedded question and verify the question moves to inline + the summary's Questions section drops it in a single run.