### PR TITLE
feat(code-review): Add schema/contract and N+1 checks to scan

### DIFF
--- a/daiv/automation/agent/skills/code-review/SKILL.md
+++ b/daiv/automation/agent/skills/code-review/SKILL.md
@@ -2,7 +2,7 @@
 name: code-review
 description: This skill should be used when a user asks for a code review, feedback on a PR or MR, diff assessment, or says things like 'can you review my changes', 'look at this diff', 'is this ready to merge', 'check my code', 'review this branch', 'what do you think of these changes', or 'LGTM check'. Covers correctness, tests, performance, security, structural concerns, and questions of intent on pull/merge requests or raw diffs from any platform (GitHub, GitLab).
 metadata:
-  version: 2.1.0
+  version: 2.2.0
 ---
 
 # Code Review
@@ -38,10 +38,12 @@ Five patterns produce most of the value in human review — scan the diff for ea
 Beyond those, also check:
 
 - Correctness defects (compile/parse errors, clearly wrong logic).
+- Breaking changes to data schemas or public contracts (a removed/renamed column, field, or endpoint still read by deployed code or downstream consumers; a non-nullable column added without a default).
 - Input validation gaps at trust boundaries.
 - Security exposures (secrets in code, broken authz).
 - Concurrency hazards (locking missing on contested writes, races).
 - Unintended side effects (a hook now firing in paths it didn't before).
+- Repeated queries, remote calls, or lookups inside a loop where one batched call before the loop would do (N+1).
 
 Do **not** flag style, formatting, whitespace, or import ordering — tooling handles those. Don't flag naming unless the name materially misleads.
 


### PR DESCRIPTION
## What

Promotes the two highest-value detection categories from `references/principles.md` into the always-on **"What to look for"** checklist in the code-review SKILL.md, and bumps the skill to `2.2.0`.

- **Breaking changes to data schemas / public contracts** (principles #24, #25) — a removed/renamed column, field, or endpoint still read by deployed code or downstream consumers; a non-nullable column added without a default.
- **Repeated queries/calls/lookups in a loop (N+1)** (principle #17).

## Why

Analysis of 18 `/code-review` agent traces showed the agent **never** loads `references/principles.md` (a 26-category detection taxonomy) — it only scans against the ~10 categories baked into the always-on checklist. The missing categories included schema-removal safety, which was directly relevant to a real column-drop MR in the trace corpus, and N+1.

Rather than force-load the large reference files on every review (token cost + against the skill's progressive-disclosure design), this primes only the highest-value missing categories at ~0 extra cost and no new tool call.

## Deliberately excluded

Style/convention-level categories (e.g. principles #6 convention deviation, #8/#9 i18n/UI) are left out — #6 directly contradicts the skill's existing "do not flag style, formatting, whitespace, or import ordering" rule. The goal is to widen recall **without** eroding the skill's precision-first design. Each new category is still gated by the existing Signal filter.

## Validation

- `uv run pytest tests/unit_tests/skills/ tests/unit_tests/automation/agent/skills/ .../test_skills.py` → **156 passed**. No test snapshots the SKILL.md prose.
- Follow-up signal to watch on the next trace batch: schema/contract + N+1 findings posted **and** human accept/resolve rate — win condition is more accepted findings of these classes with no rise in dismissed comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)