### PR TITLE
feat(agent): redirect gitlab/gh tool output to a file on the sandbox FS

### DIFF
--- a/daiv/automation/agent/constants.py
+++ b/daiv/automation/agent/constants.py
@@ -7,9 +7,11 @@ from daiv.settings.components import PROJECT_DIR
 # Path where the builtin skills are stored in the filesystem to be copied to the repository.
 BUILTIN_SKILLS_PATH = PROJECT_DIR / "automation" / "agent" / "skills"
 
-# Virtual path the composite backend serves global skills from. Mounted onto
-# ``SKILLS_CACHE_PATH`` on disk so per-turn skill uploads are idempotent and writes
-# under ``/skills/`` don't round-trip through the agent's state.
+# Virtual path the disk-backed (non-sandbox) composite backend serves global skills from.
+# Mounted onto ``SKILLS_CACHE_PATH`` on disk so per-turn skill uploads are idempotent and
+# writes under ``/skills/`` don't round-trip through the agent's state. Sandbox runs do NOT
+# use this route: they address skills by their sandbox-absolute path ``SKILLS_PATH``
+# (``/workspace/skills``) directly, since the backend is a pass-through.
 GLOBAL_SKILLS_PATH = "/skills"
 GLOBAL_SKILLS_ROUTE = f"{GLOBAL_SKILLS_PATH}/"
 

--- a/daiv/automation/agent/graph.py
+++ b/daiv/automation/agent/graph.py
@@ -21,9 +21,9 @@ from automation.agent.constants import (
     GLOBAL_SKILLS_ROUTE,
     REPO_PATH,
     SKILLS_CACHE_PATH,
+    SKILLS_PATH,
     SKILLS_SOURCES,
     SUBAGENTS_SOURCES,
-    WORKSPACE_PATH,
     ModelName,
 )
 from automation.agent.deferred.conf import settings as deferred_settings
@@ -42,6 +42,7 @@ from automation.agent.middlewares.logging import ToolCallLoggingMiddleware
 from automation.agent.middlewares.prompt_cache import AnthropicPromptCachingMiddleware
 from automation.agent.middlewares.sandbox import BASH_TOOL_NAME, SandboxMiddleware
 from automation.agent.middlewares.skills import SkillsMiddleware
+from automation.agent.middlewares.slash_commands import SlashCommandMiddleware
 from automation.agent.middlewares.web_fetch import WebFetchMiddleware
 from automation.agent.middlewares.web_search import WebSearchMiddleware
 from automation.agent.prompts import DAIV_SYSTEM_PROMPT, REPO_RELATIVE_SYSTEM_REMINDER, WRITE_TODOS_SYSTEM_PROMPT
@@ -215,17 +216,19 @@ async def create_daiv_agent(
     if _sandbox_enabled:
         # Sandbox-authoritative: one backend serves all of /workspace (repo at
         # /workspace/repo, seeded skills at /workspace/skills, scratchpad at
-        # /workspace/tmp). The global skills route (/skills) resolves under
-        # /workspace/skills via this same backend. Bound to the live client+session
-        # by SandboxMiddleware.abefore_agent once the session exists.
+        # /workspace/tmp). The agent uses these sandbox-absolute paths directly, so the
+        # backend is a pass-through, bound to the live client+session by
+        # SandboxMiddleware.abefore_agent once the session exists.
         agent_root = REPO_PATH
-        backend: BackendProtocol = SandboxFileBackend(root=WORKSPACE_PATH)
+        global_skills_source = SKILLS_PATH
+        backend: BackendProtocol = SandboxFileBackend()
     else:
-        # Sandbox-disabled runs have no sandbox to be authoritative: keep the disk-backed
-        # composite (repo files from disk; ``/skills/`` from the shared SKILLS_CACHE_PATH so
-        # per-turn skill uploads become a no-op once primed). Preserves repoless/no-sandbox flows.
+        # Sandbox-disabled runs keep the disk-backed composite: repo files from disk;
+        # ``/skills/`` from the shared SKILLS_CACHE_PATH so per-turn skill uploads become a
+        # no-op once primed. Preserves repoless/no-sandbox flows.
         agent_path = Path(ctx.gitrepo.working_dir)
         agent_root = f"/{agent_path.name}"
+        global_skills_source = GLOBAL_SKILLS_PATH
         repo_backend = DAIVFilesystemBackend(root_dir=agent_path.parent, virtual_mode=True)
         skills_backend = DAIVFilesystemBackend(root_dir=SKILLS_CACHE_PATH, virtual_mode=True)
         backend = DAIVCompositeBackend(default=repo_backend, routes={GLOBAL_SKILLS_ROUTE: skills_backend})
@@ -259,12 +262,13 @@ async def create_daiv_agent(
 
     user_middleware: list[AgentMiddleware[Any, Any, Any]] = [
         TodoListMiddleware(system_prompt=dynamic_write_todos_system_prompt(bash_tool_enabled=_sandbox_enabled)),
+        SlashCommandMiddleware(subagents=subagents),
+        *([SandboxMiddleware(backend=backend, agent_root=agent_root)] if _sandbox_enabled else []),
         SkillsMiddleware(
             backend=backend,
-            sources=[(GLOBAL_SKILLS_PATH, "Global"), *[f"{agent_root}/{source}" for source in SKILLS_SOURCES]],
-            subagents=subagents,
+            sources=[(global_skills_source, "Global"), *[f"{agent_root}/{source}" for source in SKILLS_SOURCES]],
+            sandbox_enabled=_sandbox_enabled,
         ),
-        *([SandboxMiddleware(backend=backend, agent_root=agent_root)] if _sandbox_enabled else []),
         *([WebSearchMiddleware()] if _web_search_enabled else []),
         *([WebFetchMiddleware()] if _web_fetch_enabled else []),
         *([ModelFallbackMiddleware(fallback_models[0], *fallback_models[1:])] if fallback_models else []),

--- a/daiv/automation/agent/middlewares/file_system.py
+++ b/daiv/automation/agent/middlewares/file_system.py
@@ -204,13 +204,13 @@ class DAIVCompositeBackend(CompositeBackend):
 
 
 class SandboxFileBackend(BackendProtocol):
-    """Deepagents backend whose files live in a sandbox workspace rooted at ``root``.
+    """Deepagents backend whose files live in a sandbox workspace.
 
-    The backend maps agent-visible route-relative paths (``/<rel>``) to the
-    sandbox-absolute ``<root>/<rel>`` and back. As the single ``/workspace`` backend,
-    ``root`` is ``/workspace`` and the agent sees ``/repo/<rel>``, ``/skills/<rel>``,
-    ``/tmp/<rel>`` resolved under it. Every op is one RPC over ``DAIVSandboxClient``;
-    there is no local copy, so no rollback/desync machinery (the sandbox is authoritative).
+    The agent addresses files by their sandbox-absolute path (``/workspace/repo``,
+    ``/workspace/skills``, ``/workspace/tmp``); the backend is a thin pass-through to
+    ``DAIVSandboxClient`` — the sandbox is authoritative, so there is no path translation
+    or local mirror. Every op is one RPC over ``DAIVSandboxClient``; there is no local
+    copy, so no rollback/desync machinery.
 
     The backend is constructed at graph-build time (before the per-run session exists)
     and **bound** to a live client+session via :meth:`bind` once
@@ -229,8 +229,7 @@ class SandboxFileBackend(BackendProtocol):
     edits in place and leaves the existing file's mode untouched.
     """
 
-    def __init__(self, *, root: str, client: DAIVSandboxClient | None = None, session_id: str | None = None) -> None:
-        self._root = root.rstrip("/")
+    def __init__(self, *, client: DAIVSandboxClient | None = None, session_id: str | None = None) -> None:
         self._client = client
         self._session_id = session_id
 
@@ -257,16 +256,16 @@ class SandboxFileBackend(BackendProtocol):
             raise RuntimeError("SandboxFileBackend is not bound to a sandbox session")
         return self._client, self._session_id
 
-    # -- path mapping --------------------------------------------------------
+    # -- path mapping (identity) --------------------------------------------
+    # The sandbox is authoritative and the agent addresses files by their
+    # sandbox-absolute path (/workspace/repo, /workspace/skills, /workspace/tmp).
+    # There is no translation: paths pass straight through. Kept as helpers so the
+    # async methods below need no change and an empty path normalises to "/".
     def _abs(self, backend_path: str) -> str:
-        bp = backend_path or "/"
-        if bp == "/":
-            return self._root
-        return f"{self._root}{bp}" if bp.startswith("/") else f"{self._root}/{bp}"
+        return backend_path or "/"
 
     def _rel(self, abs_path: str) -> str:
-        # Strip the root prefix; the bare root and any empty remainder map to "/".
-        return abs_path[len(self._root) :] or "/"
+        return abs_path or "/"
 
     # -- async protocol methods ---------------------------------------------
     # The Fs*Response list types carry an ``error`` field (populated, with an empty list,

--- a/daiv/automation/agent/middlewares/git_platform.py
+++ b/daiv/automation/agent/middlewares/git_platform.py
@@ -768,7 +768,10 @@ async def gitlab_tool(
 
     output = stdout.decode("utf-8").strip()
     if not output:
-        return "(empty result — command succeeded with no output, e.g. an empty list or no matches)"
+        empty = "(empty result — command succeeded with no output, e.g. an empty list or no matches)"
+        if output_file is not None:
+            empty += f"\n(note: output_file '{output_file}' was not written — the command produced no output.)"
+        return empty
 
     keep: Literal["head", "tail"] = "head"
     if resource == "project-job" and action == "trace":
@@ -934,6 +937,8 @@ async def github_tool(
     output = stdout.decode("utf-8").strip()
     if not output:
         final_output = "(empty result — command succeeded with no output, e.g. an empty list or no matches)"
+        if output_file is not None:
+            final_output += f"\n(note: output_file '{output_file}' was not written — the command produced no output.)"
     else:
         keep: Literal["head", "tail"] = "head"
         if resource == "run" and action == "view" and "--log" in splitted_subcommand:

--- a/daiv/automation/agent/middlewares/git_platform.py
+++ b/daiv/automation/agent/middlewares/git_platform.py
@@ -670,6 +670,15 @@ async def gitlab_tool(
         "Use 'simplified' for listing/discovery and 'detailed' for inspecting a specific resource or reading logs. "
         "Default: 'simplified'.",
     ] = "simplified",
+    output_file: Annotated[
+        str | None,
+        "Optional absolute path under /workspace to write the FULL, untruncated result to. "
+        "When set, the result is written to the sandbox filesystem as JSON (output_mode is ignored) "
+        "and the tool returns a compact confirmation (path + size + a short preview) instead of the "
+        "content, so you can then process the file with bash (jq, scripts, grep). "
+        "Prefer /workspace/tmp for transient dumps; a /workspace/repo target becomes a commit "
+        "candidate. Overwrites the file if it exists.",
+    ] = None,
 ) -> str:
     """
     Tool to interact with GitLab API using the `python-gitlab` command line interface.
@@ -704,6 +713,9 @@ async def gitlab_tool(
     if _gitlab_has_disallowed_cli_flags(splitted_subcommand[2:]):
         return "error: The project ID and output format are automatically set."
 
+    if output_file is not None and (path_error := _validate_workspace_path(output_file)):
+        return path_error
+
     # Inline MR diff discussion: bypass CLI because python-gitlab cannot encode nested
     # hash params (position[base_sha], position[position_type], …) via the CLI.
     if resource == "project-merge-request-discussion" and action == "create":
@@ -723,7 +735,11 @@ async def gitlab_tool(
 
     args = ["gitlab"]
 
-    if output_mode == "detailed":
+    if output_file is not None:
+        # output_mode (detailed/simplified) only shapes the inline text format for token economy;
+        # it is moot for a JSON file dump that never enters context, so force JSON on redirect.
+        args += ["--output", "json"]
+    elif output_mode == "detailed":
         args.append("--verbose")
 
     args += splitted_subcommand
@@ -754,12 +770,18 @@ async def gitlab_tool(
     if not output:
         return "(empty result — command succeeded with no output, e.g. an empty list or no matches)"
 
-    if resource == "project-job" and splitted_subcommand[1] == "trace":
-        # TODO: evict the output to the file system if it's too long
+    keep: Literal["head", "tail"] = "head"
+    if resource == "project-job" and action == "trace":
         output = clean_job_logs(output, runtime.context.git_platform)
-        return _truncate_cli_output(output, keep="tail")
+        keep = "tail"
 
-    return _truncate_cli_output(output, keep="head")
+    if output_file is not None:
+        return await _handle_output_redirect(
+            output=output, output_file=output_file, runtime=runtime, keep=keep, tool_name=GITLAB_TOOL_NAME
+        )
+    return await _finalize_inline_output(
+        output=output, runtime=runtime, resource=resource, action=action, keep=keep, tool_name=GITLAB_TOOL_NAME
+    )
 
 
 def _get_cached_github_cli_token(runtime: ToolRuntime[RuntimeCtx]) -> tuple[str, dict[str, str | float] | None]:

--- a/daiv/automation/agent/middlewares/git_platform.py
+++ b/daiv/automation/agent/middlewares/git_platform.py
@@ -7,6 +7,7 @@ import logging
 import os
 import posixpath
 import shlex
+import uuid
 from typing import TYPE_CHECKING, Annotated, Literal, NotRequired
 
 from django.core.cache import cache
@@ -20,7 +21,7 @@ from langchain_core.messages import ToolMessage
 from langchain_core.prompts import SystemMessagePromptTemplate
 from langgraph.types import Command
 
-from automation.agent.constants import WORKSPACE_PATH
+from automation.agent.constants import SCRATCH_PATH, WORKSPACE_PATH
 from codebase.base import GitPlatform
 from codebase.clients import RepoClient
 from codebase.clients.github.utils import get_github_integration
@@ -119,6 +120,70 @@ async def _write_output_to_sandbox(content: str, path: str, session_id: str) -> 
     if not response.ok:
         raise RuntimeError(response.error or "sandbox returned ok=false")
     return len(data), len(content.splitlines())
+
+
+async def _handle_output_redirect(
+    *, output: str, output_file: str, runtime: ToolRuntime[RuntimeCtx], keep: Literal["head", "tail"], tool_name: str
+) -> str:
+    """Write the full output to ``output_file`` and return a confirmation.
+
+    Assumes ``output_file`` already passed ``_validate_workspace_path``. Degrades to inline
+    (truncated) output with a note when the sandbox is not active for this run.
+    """
+    session_id = runtime.state.get("session_id")
+    if not session_id:
+        note = (
+            "(note: output_file was ignored — file redirect needs the sandbox, which is not active "
+            "for this run. Returning inline output instead.)\n\n"
+        )
+        return note + _truncate_cli_output(output, keep=keep)
+
+    try:
+        byte_count, line_count = await _write_output_to_sandbox(output, output_file, session_id)
+    except Exception as exc:
+        logger.exception("[%s] Failed to write output_file %s", tool_name, output_file)
+        return f"error: Failed to write output to {output_file}. Details: {exc}"
+
+    return _redirect_confirmation(output_file, byte_count, line_count, output)
+
+
+async def _auto_evict(output: str, session_id: str, resource: str, action: str, tool_name: str) -> str | None:
+    """Spill oversized inline output verbatim to a scratch file under /workspace/tmp.
+
+    Returns a confirmation + note, or ``None`` if the write failed (caller falls back to
+    inline truncation).
+    """
+    path = posixpath.join(SCRATCH_PATH, f"{tool_name}-{resource}-{action}-{uuid.uuid4().hex[:8]}.txt")
+    try:
+        byte_count, line_count = await _write_output_to_sandbox(output, path, session_id)
+    except Exception:
+        logger.exception("[%s] Auto-eviction failed for oversized output", tool_name)
+        return None
+    confirmation = _redirect_confirmation(path, byte_count, line_count, output)
+    return (
+        confirmation + "\n\n(note: output exceeded the inline limit and was written verbatim to the scratch file "
+        "above instead of being truncated. To structure-query it as JSON, re-run with output_file=<path>.)"
+    )
+
+
+async def _finalize_inline_output(
+    *,
+    output: str,
+    runtime: ToolRuntime[RuntimeCtx],
+    resource: str,
+    action: str,
+    keep: Literal["head", "tail"],
+    tool_name: str,
+) -> str:
+    """Return inline output, auto-evicting to a scratch file when it exceeds the inline cap."""
+    if not _exceeds_output_cap(output):
+        return _truncate_cli_output(output, keep=keep)
+    session_id = runtime.state.get("session_id")
+    if session_id:
+        evicted = await _auto_evict(output, session_id, resource, action, tool_name)
+        if evicted is not None:
+            return evicted
+    return _truncate_cli_output(output, keep=keep)
 
 
 GITLAB_REQUESTS_TIMEOUT = 15

--- a/daiv/automation/agent/middlewares/git_platform.py
+++ b/daiv/automation/agent/middlewares/git_platform.py
@@ -61,6 +61,10 @@ def _truncate_cli_output(output: str, *, keep: Literal["head", "tail"]) -> str:
     return "".join(lines[:DEFAULT_MAX_OUTPUT_LINES]) + sentinel
 
 
+_PREVIEW_MAX_LINES = 25
+_PREVIEW_MAX_CHARS = 1024
+
+
 def _validate_workspace_path(path: str) -> str | None:
     """Return an ``error: ...`` string when ``path`` is not a clean absolute path under
     ``/workspace``, else ``None``. ``..`` is collapsed first so traversal out of the workspace
@@ -73,6 +77,26 @@ def _validate_workspace_path(path: str) -> str | None:
     if normalized == WORKSPACE_PATH:
         return f"error: output_file must be a file path, not the {WORKSPACE_PATH} directory itself."
     return None
+
+
+def _exceeds_output_cap(output: str) -> bool:
+    """True when ``output`` is long enough that ``_truncate_cli_output`` would trim it.
+
+    Mirrors ``_truncate_cli_output``'s own cheap-then-exact line check so eviction triggers
+    exactly when inline truncation would.
+    """
+    if output.count("\n") < DEFAULT_MAX_OUTPUT_LINES:
+        return False
+    return len(output.splitlines(keepends=True)) > DEFAULT_MAX_OUTPUT_LINES
+
+
+def _redirect_confirmation(path: str, byte_count: int, line_count: int, output: str) -> str:
+    """Compact confirmation returned in place of redirected content: path, size, head preview."""
+    preview = "\n".join(output.splitlines()[:_PREVIEW_MAX_LINES])
+    if len(preview) > _PREVIEW_MAX_CHARS:
+        preview = preview[:_PREVIEW_MAX_CHARS] + "\n… (preview truncated)"
+    shown = min(line_count, _PREVIEW_MAX_LINES)
+    return f"Wrote {byte_count} bytes ({line_count} lines) to {path}\nPreview (first {shown} lines):\n{preview}"
 
 
 GITLAB_REQUESTS_TIMEOUT = 15

--- a/daiv/automation/agent/middlewares/git_platform.py
+++ b/daiv/automation/agent/middlewares/git_platform.py
@@ -112,8 +112,8 @@ async def _write_output_to_sandbox(content: str, path: str, session_id: str) -> 
     """
     data = content.encode("utf-8")
     client = DAIVSandboxClient()
-    await client.open()
     try:
+        await client.open()
         response = await client.fs_write(session_id, FsWriteRequest(path=path, content=base64.b64encode(data)))
     finally:
         await client.close()
@@ -132,6 +132,7 @@ async def _handle_output_redirect(
     """
     session_id = runtime.state.get("session_id")
     if not session_id:
+        logger.warning("[%s] output_file requested but no sandbox session; returning inline output", tool_name)
         note = (
             "(note: output_file was ignored — file redirect needs the sandbox, which is not active "
             "for this run. Returning inline output instead.)\n\n"
@@ -141,7 +142,7 @@ async def _handle_output_redirect(
     try:
         byte_count, line_count = await _write_output_to_sandbox(output, output_file, session_id)
     except Exception as exc:
-        logger.exception("[%s] Failed to write output_file %s", tool_name, output_file)
+        logger.exception("[%s] Failed to write output_file %s (session=%s)", tool_name, output_file, session_id)
         return f"error: Failed to write output to {output_file}. Details: {exc}"
 
     return _redirect_confirmation(output_file, byte_count, line_count, output)
@@ -157,12 +158,13 @@ async def _auto_evict(output: str, session_id: str, resource: str, action: str, 
     try:
         byte_count, line_count = await _write_output_to_sandbox(output, path, session_id)
     except Exception:
-        logger.exception("[%s] Auto-eviction failed for oversized output", tool_name)
+        logger.exception("[%s] Auto-eviction failed (session=%s, path=%s)", tool_name, session_id, path)
         return None
     confirmation = _redirect_confirmation(path, byte_count, line_count, output)
     return (
         confirmation + "\n\n(note: output exceeded the inline limit and was written verbatim to the scratch file "
-        "above instead of being truncated. To structure-query it as JSON, re-run with output_file=<path>.)"
+        "above instead of being truncated. To get the full result, re-run with output_file=<path> "
+        "(GitLab writes JSON automatically; for GitHub add --json <fields> to the subcommand).)"
     )
 
 
@@ -183,6 +185,10 @@ async def _finalize_inline_output(
         evicted = await _auto_evict(output, session_id, resource, action, tool_name)
         if evicted is not None:
             return evicted
+        return _truncate_cli_output(output, keep=keep) + (
+            "\n\n(note: output exceeded the inline cap and writing it to a sandbox scratch file failed, "
+            "so it is truncated here. Re-run with output_file=<path> for the full result.)"
+        )
     return _truncate_cli_output(output, keep=keep)
 
 
@@ -204,12 +210,12 @@ This tool is best for retrieving the current state of:
 **Inputs:**
 - `subcommand`: a single CLI-like subcommand string in the form `<object> <action> <arguments...>`
 - `output_mode`: either `simplified` or `detailed`
-- `output_file`: optional absolute path under `/workspace` to write the FULL result to as JSON (`output_mode` is ignored). Returns a compact confirmation instead of the content.
+- `output_file`: optional absolute path under `/workspace` to write the FULL result to as JSON (`output_mode` is ignored); project-job trace is written as raw log text, not JSON. Returns a compact confirmation instead of the content.
 
 **Hard rules:**
 - Do NOT include the `gitlab` prefix in `subcommand`
 - Do NOT pass `--project-id` (the project is injected automatically)
-- Do NOT pass `--output` (it is set automatically from `output_mode`)
+- Do NOT pass `--output` (set automatically from `output_mode`, or forced to json when output_file is used)
 - Prefer IID-based lookup when available (for example `--iid` for issues and merge requests)
 
 **Default behavior:**
@@ -219,7 +225,7 @@ This tool is best for retrieving the current state of:
 - Output may be truncated bottom-up to {DEFAULT_MAX_OUTPUT_LINES} lines
 
 **Redirecting large output to a file (for jq/scripts):**
-- Set `output_file` to an absolute `/workspace` path to write the FULL, untruncated result there as JSON (using `--output json`), instead of returning it inline. Then process the file with `bash` (jq, scripts, grep).
+- Set `output_file` to an absolute `/workspace` path to write the FULL, untruncated result there as JSON (using `--output json`) (except project-job trace, which is written as raw log text), instead of returning it inline. Then process the file with `bash` (jq, scripts, grep).
 - This avoids re-typing tool output into a bash command and bypasses the inline line cap.
 - Pagination stays under your control: pair with `--get-all` or `--per-page` for complete list dumps.
 - Prefer `/workspace/tmp` for transient dumps; a `/workspace/repo` path becomes a commit candidate.
@@ -691,8 +697,9 @@ async def gitlab_tool(
     output_file: Annotated[
         str | None,
         "Optional absolute path under /workspace to write the FULL, untruncated result to. "
-        "When set, the result is written to the sandbox filesystem as JSON (output_mode is ignored) "
-        "and the tool returns a compact confirmation (path + size + a short preview) instead of the "
+        "When set, the result is written to the sandbox filesystem as JSON (output_mode is ignored); "
+        "project-job trace is written as raw log text. "
+        "The tool returns a compact confirmation (path + size + a short preview) instead of the "
         "content, so you can then process the file with bash (jq, scripts, grep). "
         "Prefer /workspace/tmp for transient dumps; a /workspace/repo target becomes a commit "
         "candidate. Overwrites the file if it exists.",

--- a/daiv/automation/agent/middlewares/git_platform.py
+++ b/daiv/automation/agent/middlewares/git_platform.py
@@ -753,9 +753,11 @@ async def gitlab_tool(
 
     args = ["gitlab"]
 
-    if output_file is not None:
+    is_job_trace = resource == "project-job" and action == "trace"
+    if output_file is not None and not is_job_trace:
         # output_mode (detailed/simplified) only shapes the inline text format for token economy;
         # it is moot for a JSON file dump that never enters context, so force JSON on redirect.
+        # Job traces are raw streamed log text, not a serializable object — leave them as-is.
         args += ["--output", "json"]
     elif output_mode == "detailed":
         args.append("--verbose")

--- a/daiv/automation/agent/middlewares/git_platform.py
+++ b/daiv/automation/agent/middlewares/git_platform.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 import logging
 import os
+import posixpath
 import shlex
 from typing import TYPE_CHECKING, Annotated, Literal, NotRequired
 
@@ -18,6 +19,7 @@ from langchain_core.messages import ToolMessage
 from langchain_core.prompts import SystemMessagePromptTemplate
 from langgraph.types import Command
 
+from automation.agent.constants import WORKSPACE_PATH
 from codebase.base import GitPlatform
 from codebase.clients import RepoClient
 from codebase.clients.github.utils import get_github_integration
@@ -57,6 +59,20 @@ def _truncate_cli_output(output: str, *, keep: Literal["head", "tail"]) -> str:
     if keep == "tail":
         return sentinel + "".join(lines[-DEFAULT_MAX_OUTPUT_LINES:])
     return "".join(lines[:DEFAULT_MAX_OUTPUT_LINES]) + sentinel
+
+
+def _validate_workspace_path(path: str) -> str | None:
+    """Return an ``error: ...`` string when ``path`` is not a clean absolute path under
+    ``/workspace``, else ``None``. ``..`` is collapsed first so traversal out of the workspace
+    is rejected, and the bare workspace directory is not accepted as a file target."""
+    if not path or not path.startswith("/"):
+        return f"error: output_file must be an absolute path under {WORKSPACE_PATH} (got '{path}')."
+    normalized = posixpath.normpath(path)
+    if normalized != WORKSPACE_PATH and not normalized.startswith(WORKSPACE_PATH + "/"):
+        return f"error: output_file must resolve to a path under {WORKSPACE_PATH} (got '{path}')."
+    if normalized == WORKSPACE_PATH:
+        return f"error: output_file must be a file path, not the {WORKSPACE_PATH} directory itself."
+    return None
 
 
 GITLAB_REQUESTS_TIMEOUT = 15

--- a/daiv/automation/agent/middlewares/git_platform.py
+++ b/daiv/automation/agent/middlewares/git_platform.py
@@ -204,6 +204,7 @@ This tool is best for retrieving the current state of:
 **Inputs:**
 - `subcommand`: a single CLI-like subcommand string in the form `<object> <action> <arguments...>`
 - `output_mode`: either `simplified` or `detailed`
+- `output_file`: optional absolute path under `/workspace` to write the FULL result to as JSON (`output_mode` is ignored). Returns a compact confirmation instead of the content.
 
 **Hard rules:**
 - Do NOT include the `gitlab` prefix in `subcommand`
@@ -216,6 +217,14 @@ This tool is best for retrieving the current state of:
 - Results are ordered from most recent to oldest by default
 - List subcommands return the first 5 items by default unless you paginate with `--page`
 - Output may be truncated bottom-up to {DEFAULT_MAX_OUTPUT_LINES} lines
+
+**Redirecting large output to a file (for jq/scripts):**
+- Set `output_file` to an absolute `/workspace` path to write the FULL, untruncated result there as JSON (using `--output json`), instead of returning it inline. Then process the file with `bash` (jq, scripts, grep).
+- This avoids re-typing tool output into a bash command and bypasses the inline line cap.
+- Pagination stays under your control: pair with `--get-all` or `--per-page` for complete list dumps.
+- Prefer `/workspace/tmp` for transient dumps; a `/workspace/repo` path becomes a commit candidate.
+- If output exceeds the inline cap and you did NOT set `output_file`, it is auto-written to a `/workspace/tmp` file and that path is returned.
+- Example: `project-merge-request list --state opened --get-all` with `output_file="/workspace/tmp/mrs.json"`, then `bash`: `jq '[.[].labels[]] | group_by(.) | map({{label: .[0], count: length}})' /workspace/tmp/mrs.json`.
 
 **How to use it well:**
 - Use `output_mode="simplified"` ONLY for broad `list` discovery where you just need IDs (e.g. `project-merge-request list --state opened`).
@@ -285,6 +294,7 @@ This tool is best for retrieving the current state of:
 
 **Inputs:**
 - `subcommand`: a single CLI-like subcommand string in the form `<object> <action> [arguments...]>`
+- `output_file`: optional absolute path under `/workspace` to write the FULL stdout to (verbatim). Returns a compact confirmation instead of the content.
 
 **Hard rules:**
 - Do NOT include the `gh` prefix in `subcommand`
@@ -296,6 +306,14 @@ This tool is best for retrieving the current state of:
 - List subcommands are limited to the first 30 items by default
 - Results are ordered from most recent to oldest when supported by the underlying subcommand
 - Output may be truncated bottom-up to {DEFAULT_MAX_OUTPUT_LINES} lines
+
+**Redirecting large output to a file (for jq/scripts):**
+- Set `output_file` to an absolute `/workspace` path to write the FULL, untruncated stdout there, instead of returning it inline. Then process the file with `bash` (jq, scripts, grep).
+- gh has no global JSON flag — for jq-able output, include gh's own `--json <fields> [--jq ...]` in the subcommand; otherwise the file holds gh's text output.
+- Pagination stays under your control: use `--limit` for complete list dumps.
+- Prefer `/workspace/tmp` for transient dumps; a `/workspace/repo` path becomes a commit candidate.
+- If output exceeds the inline cap and you did NOT set `output_file`, it is auto-written to a `/workspace/tmp` file and that path is returned.
+- Example: `pr list --state open --json number,title,labels --limit 200` with `output_file="/workspace/tmp/prs.json"`, then `bash`: `jq '.[] | select(.labels | length == 0) | .number' /workspace/tmp/prs.json`.
 
 **How to use it well:**
 - Start with the smallest subcommand that identifies the exact target

--- a/daiv/automation/agent/middlewares/git_platform.py
+++ b/daiv/automation/agent/middlewares/git_platform.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import base64
 import json
 import logging
 import os
@@ -26,6 +27,8 @@ from codebase.clients.github.utils import get_github_integration
 from codebase.clients.utils import clean_job_logs
 from codebase.conf import settings
 from codebase.context import RuntimeCtx  # noqa: TC001
+from core.sandbox.client import DAIVSandboxClient
+from core.sandbox.schemas import FsWriteRequest
 from daiv import USER_AGENT
 
 if TYPE_CHECKING:
@@ -97,6 +100,25 @@ def _redirect_confirmation(path: str, byte_count: int, line_count: int, output: 
         preview = preview[:_PREVIEW_MAX_CHARS] + "\n… (preview truncated)"
     shown = min(line_count, _PREVIEW_MAX_LINES)
     return f"Wrote {byte_count} bytes ({line_count} lines) to {path}\nPreview (first {shown} lines):\n{preview}"
+
+
+async def _write_output_to_sandbox(content: str, path: str, session_id: str) -> tuple[int, int]:
+    """Write ``content`` to ``path`` under /workspace via a short-lived sandbox client.
+
+    Mirrors the short-lived-client pattern of ``open_git_manager``: open one client against the
+    live session, write, close in a ``finally``. ``content`` is base64-encoded for the
+    ``Base64Bytes`` wire field. Returns ``(byte_count, line_count)``; raises on a failed write.
+    """
+    data = content.encode("utf-8")
+    client = DAIVSandboxClient()
+    await client.open()
+    try:
+        response = await client.fs_write(session_id, FsWriteRequest(path=path, content=base64.b64encode(data)))
+    finally:
+        await client.close()
+    if not response.ok:
+        raise RuntimeError(response.error or "sandbox returned ok=false")
+    return len(data), len(content.splitlines())
 
 
 GITLAB_REQUESTS_TIMEOUT = 15

--- a/daiv/automation/agent/middlewares/git_platform.py
+++ b/daiv/automation/agent/middlewares/git_platform.py
@@ -133,11 +133,10 @@ async def _handle_output_redirect(
     session_id = runtime.state.get("session_id")
     if not session_id:
         logger.warning("[%s] output_file requested but no sandbox session; returning inline output", tool_name)
-        note = (
+        return (
             "(note: output_file was ignored — file redirect needs the sandbox, which is not active "
             "for this run. Returning inline output instead.)\n\n"
-        )
-        return note + _truncate_cli_output(output, keep=keep)
+        ) + _truncate_cli_output(output, keep=keep)
 
     try:
         byte_count, line_count = await _write_output_to_sandbox(output, output_file, session_id)
@@ -160,9 +159,9 @@ async def _auto_evict(output: str, session_id: str, resource: str, action: str, 
     except Exception:
         logger.exception("[%s] Auto-eviction failed (session=%s, path=%s)", tool_name, session_id, path)
         return None
-    confirmation = _redirect_confirmation(path, byte_count, line_count, output)
     return (
-        confirmation + "\n\n(note: output exceeded the inline limit and was written verbatim to the scratch file "
+        _redirect_confirmation(path, byte_count, line_count, output)
+        + "\n\n(note: output exceeded the inline limit and was written verbatim to the scratch file "
         "above instead of being truncated. To get the full result, re-run with output_file=<path> "
         "(GitLab writes JSON automatically; for GitHub add --json <fields> to the subcommand).)"
     )
@@ -801,7 +800,7 @@ async def gitlab_tool(
         return empty
 
     keep: Literal["head", "tail"] = "head"
-    if resource == "project-job" and action == "trace":
+    if is_job_trace:
         output = clean_job_logs(output, runtime.context.git_platform)
         keep = "tail"
 

--- a/daiv/automation/agent/middlewares/git_platform.py
+++ b/daiv/automation/agent/middlewares/git_platform.py
@@ -842,6 +842,15 @@ async def github_tool(
         "Examples: 'issue view 42', 'pr list --state open'.",
     ],
     runtime: ToolRuntime[RuntimeCtx],
+    output_file: Annotated[
+        str | None,
+        "Optional absolute path under /workspace to write the FULL, untruncated result to. "
+        "When set, stdout is written verbatim to the sandbox filesystem and the tool returns a "
+        "compact confirmation instead of the content, so you can process the file with bash "
+        "(jq, scripts, grep). For jq-able output, include gh's own --json <fields> [--jq ...] in "
+        "the subcommand. Prefer /workspace/tmp for transient dumps; a /workspace/repo target "
+        "becomes a commit candidate. Overwrites the file if it exists.",
+    ] = None,
 ) -> str | Command:
     """
     Tool to interact with GitHub API using the `gh` command line interface.
@@ -875,6 +884,9 @@ async def github_tool(
 
     if _gh_has_disallowed_cli_flags(splitted_subcommand[2:]):
         return "error: The repository and hostname are automatically set. Do not pass --repo, -R, or --hostname."
+
+    if output_file is not None and (path_error := _validate_workspace_path(output_file)):
+        return path_error
 
     token, state_update = _get_cached_github_cli_token(runtime)
 
@@ -921,21 +933,29 @@ async def github_tool(
 
     output = stdout.decode("utf-8").strip()
     if not output:
-        output = "(empty result — command succeeded with no output, e.g. an empty list or no matches)"
-    elif resource == "run" and action == "view" and "--log" in splitted_subcommand:
-        # TODO: evict the output to the file system if it's too long
-        output = clean_job_logs(output, runtime.context.git_platform)
-        output = _truncate_cli_output(output, keep="tail")
+        final_output = "(empty result — command succeeded with no output, e.g. an empty list or no matches)"
     else:
-        output = _truncate_cli_output(output, keep="head")
+        keep: Literal["head", "tail"] = "head"
+        if resource == "run" and action == "view" and "--log" in splitted_subcommand:
+            output = clean_job_logs(output, runtime.context.git_platform)
+            keep = "tail"
+
+        if output_file is not None:
+            final_output = await _handle_output_redirect(
+                output=output, output_file=output_file, runtime=runtime, keep=keep, tool_name=GITHUB_TOOL_NAME
+            )
+        else:
+            final_output = await _finalize_inline_output(
+                output=output, runtime=runtime, resource=resource, action=action, keep=keep, tool_name=GITHUB_TOOL_NAME
+            )
 
     # Return Command with state update if token was cached/refreshed
     if state_update:
-        tool_message = ToolMessage(content=output, tool_call_id=runtime.tool_call_id)
+        tool_message = ToolMessage(content=final_output, tool_call_id=runtime.tool_call_id)
         state_update["messages"] = [tool_message]
         return Command(update=state_update)
 
-    return output
+    return final_output
 
 
 class GitPlatformState(AgentState):

--- a/daiv/automation/agent/middlewares/sandbox.py
+++ b/daiv/automation/agent/middlewares/sandbox.py
@@ -15,10 +15,10 @@ from langchain.tools import ToolRuntime  # noqa: TC002
 from langchain_core.tools import BaseTool, tool
 from langgraph.typing import StateT  # noqa: TC002
 
-from automation.agent.constants import SKILLS_CACHE_PATH
+from automation.agent.conf import settings as agent_settings
+from automation.agent.constants import BUILTIN_SKILLS_PATH
 from automation.agent.middlewares.file_system import SandboxFileBackend
 from codebase.context import RuntimeCtx  # noqa: TC001
-from codebase.utils import files_changed_from_patch
 from core.conf import settings
 from core.sandbox.client import DAIVSandboxClient
 from core.sandbox.command_parser import CommandParseError, parse_command
@@ -49,9 +49,8 @@ Session behavior:
   <bad-example>cd /workspace/repo/tests && pytest</bad-example>
 
 Result format:
-- On success, returns a JSON object `{"commands": [...], "files_changed": [...]}`.
+- On success, returns a JSON object `{"commands": [...]}`.
   - `commands` is a list of per-command result objects including at least `command`, `output`, and `exit_code`.
-  - `files_changed` is a list of workspace modifications made by these commands (`{"path", "op"}` with op in `modified`/`added`/`deleted`/`renamed`; renames also carry `from_path`). Empty array when nothing changed.
 - You MUST inspect each command's `exit_code` and treat non-zero values or tracebacks in `output` as failures, not as successful verification.
 - On infrastructure failure, the tool may return a plain string starting with `error:` instead of JSON. Treat that as a tool failure, not as a test result.
 
@@ -117,7 +116,7 @@ Use dedicated tools when available:
 - Use `ls`, `glob`, `grep`, `read_file`, `edit_file`, `write_file` instead of doing file listing/search/read/edit/write in bash.
 
 Result interpretation:
-- Successful calls return a JSON object with `commands` (per-command results: `command`, `output`, `exit_code`) and `files_changed` (workspace mutations: path + op).
+- Successful calls return a JSON object with `commands` (per-command results: `command`, `output`, `exit_code`).
 - Always check each `exit_code` and treat non-zero codes or Python tracebacks in `output` as failures that require investigation or fixes.
 - If the tool returns a plain string starting with `error:` instead of JSON, treat it as a sandbox/tool failure, not as a passing check.
 
@@ -250,28 +249,43 @@ def _make_repo_archive(working_dir: str) -> bytes:
     return buf.getvalue()
 
 
-def _make_skills_archive(skills_dir: Path) -> bytes | None:
-    """Tar the contents of ``skills_dir`` (members relative to it). Return ``None`` if missing/empty."""
-    if not skills_dir.is_dir():
+def _make_global_skills_archive() -> bytes | None:
+    """Tar builtin + custom global skills (members relative to their skill dir).
+
+    These are the only-disk sources for global skills; seeding them into the sandbox's
+    ``/workspace/skills`` is the single provisioning step (one RPC), replacing per-file
+    uploads. Custom skills are added after builtins so a same-named custom skill overrides.
+    Returns ``None`` if there is nothing to pack.
+    """
+    roots: list[Path] = [BUILTIN_SKILLS_PATH]
+    custom = agent_settings.CUSTOM_SKILLS_PATH
+    if custom is not None and custom.is_dir():
+        roots.append(custom)
+
+    members: dict[str, Path] = {}
+    for root in roots:
+        if not root.is_dir():
+            continue
+        try:
+            children = list(root.iterdir())
+        except OSError:
+            logger.warning("Could not read skills root '%s'; skipping for seed archive", root, exc_info=True)
+            continue
+        for child in children:
+            if child.is_dir() and (child.name.startswith(".") or child.name == "__pycache__"):
+                continue
+            members[child.name] = child  # later root (custom) overrides builtin
+
+    if not members:
         return None
-    try:
-        children = list(skills_dir.iterdir())
-    except OSError:
-        logger.warning(
-            "Could not read skills directory '%s'; seeding without skills archive", skills_dir, exc_info=True
-        )
-        return None
-    if not children:
-        return None
+
     buf = io.BytesIO()
     try:
         with tarfile.open(fileobj=buf, mode="w:gz") as tf:
-            for child in children:
-                tf.add(child, arcname=child.name)
+            for name, path in members.items():
+                tf.add(path, arcname=name)
     except OSError, tarfile.TarError:
-        logger.warning(
-            "Failed to build skills archive from '%s'; seeding without skills archive", skills_dir, exc_info=True
-        )
+        logger.warning("Failed to build global skills archive; seeding without skills", exc_info=True)
         return None
     return buf.getvalue()
 
@@ -372,13 +386,8 @@ class SandboxMiddleware(AgentMiddleware):
                 )
 
             # The sandbox is authoritative: bash mutations already live in /workspace/repo,
-            # so there is no local repo to apply the patch to. ``files_changed_from_patch`` is
-            # display-only here (chat rail) and is retired once "files_changed" reads from
-            # ``git status`` in the sandbox (follow-on cleanup).
-            return json.dumps({
-                "commands": [result.model_dump(mode="json") for result in response.results],
-                "files_changed": files_changed_from_patch(response.patch),
-            })
+            # so there is no local repo to keep in sync here.
+            return json.dumps({"commands": [result.model_dump(mode="json") for result in response.results]})
 
         return bash_tool
 
@@ -424,7 +433,6 @@ class SandboxMiddleware(AgentMiddleware):
             session_id = await client.start_session(
                 StartSessionRequest(
                     base_image=sb.base_image,
-                    extract_patch=True,
                     network_enabled=sb.network_enabled,
                     memory_bytes=sb.memory_bytes,
                     cpus=sb.cpus,
@@ -435,7 +443,7 @@ class SandboxMiddleware(AgentMiddleware):
                 working_dir = Path(runtime.context.gitrepo.working_dir)
                 repo_archive, skills_archive = await asyncio.gather(
                     asyncio.to_thread(_make_repo_archive, str(working_dir)),
-                    asyncio.to_thread(_make_skills_archive, SKILLS_CACHE_PATH),
+                    asyncio.to_thread(_make_global_skills_archive),
                 )
                 await client.seed_session(session_id, repo_archive=repo_archive, skills_archive=skills_archive)
             except Exception:

--- a/daiv/automation/agent/middlewares/skills.py
+++ b/daiv/automation/agent/middlewares/skills.py
@@ -7,12 +7,10 @@ from typing import TYPE_CHECKING, Annotated, NotRequired, override
 
 from deepagents.middleware.skills import SkillMetadata, SkillsState, SkillsStateUpdate
 from deepagents.middleware.skills import SkillsMiddleware as DeepAgentsSkillsMiddleware
-from langchain.agents.middleware import hook_config
 from langchain.agents.middleware.types import PrivateStateAttr
 from langchain.tools import ToolRuntime, tool  # noqa: TC002
-from langchain_core.messages import AIMessage, AnyMessage, HumanMessage, RemoveMessage, ToolMessage
+from langchain_core.messages import AIMessage, AnyMessage, HumanMessage, ToolMessage
 from langchain_core.prompts import PromptTemplate
-from langgraph.graph.message import REMOVE_ALL_MESSAGES
 from langgraph.runtime import Runtime  # noqa: TC002
 from langgraph.types import Command
 from skills.services import _record_invocation
@@ -20,16 +18,12 @@ from skills.services import _record_invocation
 from automation.agent.conf import settings as agent_settings
 from automation.agent.constants import BUILTIN_SKILLS_PATH, GLOBAL_SKILLS_PATH, SKILLS_CACHE_PATH
 from automation.agent.middlewares.file_system import WRITE_TOOL_NAMES
-from automation.agent.utils import extract_body_from_frontmatter, extract_text_content
+from automation.agent.utils import extract_body_from_frontmatter
 from codebase.context import RuntimeCtx  # noqa: TC001
-from slash_commands.parser import SlashCommandCommand, parse_slash_command
-from slash_commands.registry import slash_command_registry
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable, Callable, Sequence
+    from collections.abc import Awaitable, Callable
 
-    from deepagents.graph import SubAgent
-    from deepagents.middleware.subagents import CompiledSubAgent
     from langchain.agents.middleware.types import ToolCallRequest
     from langchain_core.runnables import RunnableConfig
     from langchain_core.tools import BaseTool
@@ -109,58 +103,46 @@ AVAILABLE_SKILLS_TEMPLATE = PromptTemplate.from_template(
 
 class SkillsMiddleware(DeepAgentsSkillsMiddleware):
     """
-    Middleware to apply builtin slash commands early in the conversation and copy builtin skills to the project skills
-    directory to make them available to the agent even if the project skills directory is not set up.
+    Middleware that loads skill metadata and, in disk-backed (non-sandbox) mode, copies builtin
+    and custom global skills into the ``/skills`` cache so they are available even when the
+    project skills directory is not set up. In sandbox mode global skills are provisioned by the
+    sandbox seed (SandboxMiddleware), so no upload happens here.
     """
 
     state_schema = DAIVSkillsState
 
-    def __init__(self, *args, subagents: Sequence[SubAgent | CompiledSubAgent] | None = None, **kwargs):
+    def __init__(self, *args, sandbox_enabled: bool = False, **kwargs):
         super().__init__(*args, **kwargs)
         self.system_prompt_template = SKILLS_SYSTEM_PROMPT
         self.tools = [self._skill_tool_generator()]
-        self.subagents = subagents or []
+        self._sandbox_enabled = sandbox_enabled
 
-    @hook_config(can_jump_to=["end"])
     async def abefore_agent(
         self, state: DAIVSkillsState, runtime: Runtime[RuntimeCtx], config: RunnableConfig
     ) -> SkillsStateUpdate | dict | None:
         """
-        Apply builtin slash commands early in the conversation and copy builtin skills to the project skills directory
-        to make them available to the agent.
+        Load skill metadata and (disk-mode only) materialize global skills into the
+        ``/skills`` cache. In sandbox mode global skills are provisioned by the sandbox
+        seed (SandboxMiddleware), so no upload happens here; discovery reads the bound,
+        seeded sandbox via ``super().abefore_agent``.
 
-        ``skills_load_errors`` are captured once per session and persist through subsequent turns;
-        a misconfig fixed mid-session will continue surfacing in ``<skill_load_warnings>`` until restart.
+        ``skills_load_errors`` are captured once per session and persist through subsequent
+        turns; a misconfig fixed mid-session will keep surfacing until restart.
         """
         clear_skill_mode = state.get("active_skill_mode") is not None and self._has_user_followup(state["messages"])
         if clear_skill_mode:
             logger.info("[%s] Clearing active skill mode '%s' on user follow-up", self.name, state["active_skill_mode"])
 
-        # Skip the filesystem walk once skills_metadata is in state — upstream `abefore_agent` also
+        # Skip the filesystem walk once skills_metadata is in state — upstream also
         # short-circuits on the same condition, so re-walking is pure waste on turns 2+.
         local_load_errors: list[str] = []
-        if "skills_metadata" not in state:
+        if "skills_metadata" not in state and not self._sandbox_enabled:
             local_load_errors = await self._copy_global_skills()
 
         skills_update = await super().abefore_agent(state, runtime, config)
 
         if local_load_errors and skills_update is not None:
             skills_update.setdefault("skills_load_errors", []).extend(local_load_errors)
-
-        skills_metadata = skills_update["skills_metadata"] if skills_update else state["skills_metadata"]
-
-        builtin_slash_commands = None
-        if runtime.context.config.slash_commands.enabled:
-            builtin_slash_commands = await self._apply_builtin_slash_commands(
-                state["messages"], runtime.context, skills_metadata
-            )
-
-        if builtin_slash_commands:
-            if skills_update is not None and "skills_load_errors" in skills_update:
-                builtin_slash_commands["skills_load_errors"] = skills_update["skills_load_errors"]
-            if clear_skill_mode:
-                builtin_slash_commands["active_skill_mode"] = None
-            return builtin_slash_commands
 
         if clear_skill_mode:
             return {**(skills_update or {}), "active_skill_mode": None}
@@ -315,88 +297,6 @@ class SkillsMiddleware(DeepAgentsSkillsMiddleware):
                 break
 
         return False
-
-    async def _apply_builtin_slash_commands(
-        self, messages: list[AnyMessage], context: RuntimeCtx, skills: list[SkillMetadata]
-    ) -> SkillsStateUpdate | None:
-        """
-        Detect and execute builtin slash commands (not project skills) early in the conversation.
-
-        Args:
-            messages: The list of messages.
-            context: The runtime context.
-            skills: The list of skills.
-
-        Returns:
-            State update with messages injected, or None if no builtin slash command detected.
-        """
-        slash_command = self._extract_slash_command(messages, context.bot_username)
-        if not slash_command:
-            return None
-
-        command_classes = slash_command_registry.get_commands(scope=context.scope, command=slash_command.command)
-        if not command_classes:
-            return None
-
-        if len(command_classes) > 1:
-            logger.warning(
-                "[%s] Multiple `%s` slash commands found for scope '%s': %r",
-                self.name,
-                slash_command.command,
-                context.scope.value,
-                [c.command for c in command_classes],
-            )
-            return None
-
-        command = command_classes[0](
-            scope=context.scope, repo_id=context.repository.slug, bot_username=context.bot_username
-        )
-        logger.info("[%s] Executing `%s` slash command", self.name, slash_command.raw)
-
-        try:
-            result = await command.execute_for_agent(
-                args=" ".join(slash_command.args),
-                issue_iid=context.issue.iid if context.issue else None,
-                merge_request_id=context.merge_request.merge_request_id if context.merge_request else None,
-                available_skills=skills,
-                available_subagents=self.subagents,
-            )
-        except Exception:
-            logger.exception("[%s] Failed to execute `%s` slash command", self.name, slash_command.raw)
-            # Intentionally do not honor ``resets_thread`` here: if ``execute_for_agent`` raised,
-            # any checkpointer-side wipe (e.g. ``/clear``'s ``delete_thread``) may not have run,
-            # so keeping in-memory history avoids diverging state from the still-populated Redis
-            # checkpoint.
-            return {"messages": [AIMessage(content=f"Failed to execute `{slash_command.raw}`.")], "jump_to": "end"}
-        else:
-            logger.info("[%s] `%s` slash command completed", self.name, slash_command.raw)
-            # ``resets_thread`` commands (e.g. ``/clear``) must drop the in-memory history;
-            # otherwise the final checkpoint write of this turn re-persists every prior message
-            # under the same ``thread_id``, resurrecting messages the command just deleted.
-            reset_prefix: list = [RemoveMessage(id=REMOVE_ALL_MESSAGES)] if command.resets_thread else []
-            return {"messages": [*reset_prefix, AIMessage(content=result)], "jump_to": "end"}
-
-    def _extract_slash_command(self, messages: list[AnyMessage], bot_username: str) -> SlashCommandCommand | None:
-        """
-        Extract the slash command from the latest message.
-
-        Args:
-            messages: The list of messages.
-            bot_username: The username of the bot.
-
-        Returns:
-            The slash command command if found, otherwise None.
-        """
-        latest_message = messages[-1]
-
-        if not hasattr(latest_message, "type") or latest_message.type != "human":
-            return None
-
-        text_content = extract_text_content(latest_message.content)
-        if not text_content or not text_content.strip():
-            return None
-
-        return parse_slash_command(text_content, bot_username)
 
     def _skill_tool_generator(self) -> BaseTool:
         """Generate a skill tool."""

--- a/daiv/automation/agent/middlewares/slash_commands.py
+++ b/daiv/automation/agent/middlewares/slash_commands.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from deepagents.middleware.skills import SkillMetadata, _parse_skill_metadata
+from langchain.agents.middleware import AgentMiddleware, hook_config
+from langchain_core.messages import AIMessage, AnyMessage, RemoveMessage  # noqa: TC002
+from langgraph.graph.message import REMOVE_ALL_MESSAGES
+from langgraph.runtime import Runtime  # noqa: TC002
+
+from automation.agent.conf import settings as agent_settings
+from automation.agent.constants import BUILTIN_SKILLS_PATH
+from automation.agent.middlewares.skills import DAIVSkillsState
+from automation.agent.utils import extract_text_content
+from codebase.context import RuntimeCtx  # noqa: TC001
+from slash_commands.parser import SlashCommandCommand, parse_slash_command
+from slash_commands.registry import slash_command_registry
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+    from pathlib import Path
+
+    from deepagents.graph import SubAgent
+    from deepagents.middleware.subagents import CompiledSubAgent
+    from langchain_core.runnables import RunnableConfig
+
+logger = logging.getLogger("daiv.tools")
+
+
+def _load_global_skill_metadata() -> list[SkillMetadata]:
+    """Read builtin + custom *global* skill metadata from disk (name/description).
+
+    Used by :class:`SlashCommandMiddleware` for ``/help``, which runs before the sandbox
+    session exists — so it cannot read per-repo skills (those live in the sandbox). The
+    agent's ``<available_skills>`` system prompt still enumerates everything once the loop
+    runs; this is only the ``/help`` listing. Custom skills override builtins of the same
+    name (later source wins).
+    """
+    skills: dict[str, SkillMetadata] = {}
+    roots: list[Path] = [BUILTIN_SKILLS_PATH]
+    custom = agent_settings.CUSTOM_SKILLS_PATH
+    if custom is not None and custom.is_dir():
+        roots.append(custom)
+
+    for root in roots:
+        try:
+            children = sorted(root.iterdir())
+        except OSError:
+            logger.warning("Could not read global skills root '%s' for /help", root, exc_info=True)
+            continue
+        for skill_dir in children:
+            if not skill_dir.is_dir() or skill_dir.name.startswith(".") or skill_dir.name == "__pycache__":
+                continue
+            skill_md = skill_dir / "SKILL.md"
+            try:
+                content = skill_md.read_text(encoding="utf-8")
+            except OSError:
+                logger.warning("Could not read SKILL.md '%s' for /help; omitting from listing", skill_md, exc_info=True)
+                continue
+            meta = _parse_skill_metadata(content, str(skill_md), skill_dir.name)
+            if meta is not None:
+                skills[meta["name"]] = meta
+    return list(skills.values())
+
+
+class SlashCommandMiddleware(AgentMiddleware):
+    """Intercept builtin slash commands before the sandbox session starts.
+
+    Runs ahead of ``SandboxMiddleware`` so commands that reset/inspect the thread
+    (``/clear``, ``/help``, ``/agents``, ...) short-circuit the run without paying for a
+    sandbox session. Builtin commands need only static context (the configured subagents)
+    plus, for ``/help``, the builtin + custom *global* skill list — all read from disk, so
+    this hook never touches the sandbox backend.
+    """
+
+    # Declares the skills state channels so this middleware may reset ``active_skill_mode`` when a
+    # command wipes the thread (see ``_apply_builtin_slash_commands``); ``SkillsMiddleware`` owns it.
+    state_schema = DAIVSkillsState
+
+    def __init__(self, *, subagents: Sequence[SubAgent | CompiledSubAgent] | None = None) -> None:
+        super().__init__()
+        self.subagents = subagents or []
+
+    @hook_config(can_jump_to=["end"])
+    async def abefore_agent(self, state: dict, runtime: Runtime[RuntimeCtx], config: RunnableConfig) -> dict | None:
+        if not runtime.context.config.slash_commands.enabled:
+            return None
+        return await self._apply_builtin_slash_commands(state["messages"], runtime.context)
+
+    async def _apply_builtin_slash_commands(self, messages: list[AnyMessage], context: RuntimeCtx) -> dict | None:
+        slash_command = self._extract_slash_command(messages, context.bot_username)
+        if not slash_command:
+            return None
+
+        command_classes = slash_command_registry.get_commands(scope=context.scope, command=slash_command.command)
+        if not command_classes:
+            return None
+
+        if len(command_classes) > 1:
+            logger.warning(
+                "[%s] Multiple `%s` slash commands found for scope '%s': %r",
+                self.name,
+                slash_command.command,
+                context.scope.value,
+                [c.command for c in command_classes],
+            )
+            return None
+
+        command = command_classes[0](
+            scope=context.scope, repo_id=context.repository.slug, bot_username=context.bot_username
+        )
+        logger.info("[%s] Executing `%s` slash command", self.name, slash_command.raw)
+
+        try:
+            result = await command.execute_for_agent(
+                args=" ".join(slash_command.args),
+                issue_iid=context.issue.iid if context.issue else None,
+                merge_request_id=context.merge_request.merge_request_id if context.merge_request else None,
+                available_skills=_load_global_skill_metadata(),
+                available_subagents=self.subagents,
+            )
+        except Exception:
+            logger.exception("[%s] Failed to execute `%s` slash command", self.name, slash_command.raw)
+            # Do NOT honor resets_thread here: if execute_for_agent raised, any checkpointer-side wipe
+            # may not have run, so keeping in-memory history avoids diverging from the Redis checkpoint.
+            return {"messages": [AIMessage(content=f"Failed to execute `{slash_command.raw}`.")], "jump_to": "end"}
+        else:
+            logger.info("[%s] `%s` slash command completed", self.name, slash_command.raw)
+            # resets_thread commands (e.g. /clear) must drop in-memory history, else the final
+            # checkpoint write re-persists every prior message under the same thread_id.
+            reset_prefix: list = [RemoveMessage(id=REMOVE_ALL_MESSAGES)] if command.resets_thread else []
+            update: dict = {"messages": [*reset_prefix, AIMessage(content=result)], "jump_to": "end"}
+            if command.resets_thread:
+                # The wipe also clears private state: a read-only skill (e.g. /plan sets
+                # active_skill_mode="read-only") must not survive onto the fresh thread, where
+                # _has_user_followup (needs surviving history) could never clear it — every write
+                # tool would stay refused. SkillsMiddleware's clear-on-followup never runs here
+                # (we jump to end), so reset it explicitly.
+                update["active_skill_mode"] = None
+            return update
+
+    def _extract_slash_command(self, messages: list[AnyMessage], bot_username: str) -> SlashCommandCommand | None:
+        latest_message = messages[-1]
+        if not hasattr(latest_message, "type") or latest_message.type != "human":
+            return None
+        text_content = extract_text_content(latest_message.content)
+        if not text_content or not text_content.strip():
+            return None
+        return parse_slash_command(text_content, bot_username)

--- a/daiv/codebase/utils.py
+++ b/daiv/codebase/utils.py
@@ -10,7 +10,6 @@ from git import GitCommandError
 from langchain_core.messages import AIMessage, AnyMessage, HumanMessage
 from unidiff import PatchSet
 from unidiff.constants import LINE_TYPE_CONTEXT
-from unidiff.errors import UnidiffParseError
 from unidiff.patch import Line
 
 from core.constants import BOT_NAME
@@ -140,37 +139,6 @@ def redact_diff_content(
                     Line("[Diff content was intentionally excluded by the repository configuration]", LINE_TYPE_CONTEXT)
                 )
     return str(patch_set) if not as_patch_set else patch_set
-
-
-def files_changed_from_patch(patch: str | None) -> list[dict[str, str]]:
-    """Derive a ``{path, op[, from_path]}`` list from a unified diff.
-
-    The sandbox reports every workspace mutation regardless of how it happened
-    (bash ``rm``/``mv``, scripts, ``find -delete``, …), which is what lets the
-    chat rail surface them alongside ``edit_file``/``write_file`` tool calls.
-    """
-    if not patch or not patch.strip():
-        return []
-    try:
-        patch_set = PatchSet.from_string(patch)
-    except UnidiffParseError:
-        logger.warning("Failed to parse patch for files_changed", exc_info=True)
-        return []
-
-    files: list[dict[str, str]] = []
-    for patched_file in patch_set:
-        entry: dict[str, str] = {"path": patched_file.path}
-        if patched_file.is_added_file:
-            entry["op"] = "added"
-        elif patched_file.is_removed_file:
-            entry["op"] = "deleted"
-        elif patched_file.is_rename:
-            entry["op"] = "renamed"
-            entry["from_path"] = patched_file.source_file.removeprefix("a/").removeprefix("b/")
-        else:
-            entry["op"] = "modified"
-        files.append(entry)
-    return files
 
 
 _SHELL_SAFE_ARG = re.compile(r"^[A-Za-z0-9_./@=:,+-]+$")

--- a/daiv/core/sandbox/command_policy.py
+++ b/daiv/core/sandbox/command_policy.py
@@ -162,8 +162,8 @@ def _argv_matches_rule(argv: tuple[str, ...], rule: tuple[str, ...]) -> bool:
     subsequence, with the executable name (argv[0]) matched exactly.
 
     This handles global flags that appear between the executable name and the
-    subcommand, e.g. ``git -C /repo commit`` is matched by rule
-    ``("git", "commit")`` even though ``-C /repo`` intervenes.
+    subcommand, e.g. ``git -C /workspace/repo commit`` is matched by rule
+    ``("git", "commit")`` even though ``-C /workspace/repo`` intervenes.
 
     Comparison is case-insensitive and performs short-flag normalization for
     bundled short options. Example: ``-rf`` and ``-fr`` are considered equal.

--- a/daiv/core/sandbox/schemas.dump.json
+++ b/daiv/core/sandbox/schemas.dump.json
@@ -734,18 +734,6 @@
       }
     },
     "properties": {
-      "patch": {
-        "anyOf": [
-          {
-            "type": "string"
-          },
-          {
-            "type": "null"
-          }
-        ],
-        "description": "Base64-encoded patch with the changes.",
-        "title": "Patch"
-      },
       "results": {
         "description": "List of results of each command.",
         "items": {
@@ -756,8 +744,7 @@
       }
     },
     "required": [
-      "results",
-      "patch"
+      "results"
     ],
     "title": "RunResponse",
     "type": "object"
@@ -829,12 +816,6 @@
         "default": null,
         "description": "Environment variables to set in the container at startup.",
         "title": "Environment"
-      },
-      "extract_patch": {
-        "default": false,
-        "description": "Whether to extract a patch with the changes made by the executed commands.",
-        "title": "Extract Patch",
-        "type": "boolean"
       },
       "memory_bytes": {
         "anyOf": [

--- a/daiv/core/sandbox/schemas.py
+++ b/daiv/core/sandbox/schemas.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Literal
 
-from pydantic import Base64Bytes, Base64Str, BaseModel, Field, field_validator, model_validator
+from pydantic import Base64Bytes, BaseModel, Field, field_validator, model_validator
 
 MAX_OUTPUT_LENGTH = 2000
 
@@ -10,7 +10,6 @@ MAX_OUTPUT_LENGTH = 2000
 class StartSessionRequest(BaseModel):
     base_image: str | None = Field(default=None, description="The base image to start the session with.")
     dockerfile: str | None = Field(default=None, description="The Dockerfile to use to build the base image.")
-    extract_patch: bool = Field(default=True, description="Whether to extract the patch of the changed files.")
     network_enabled: bool = Field(default=False, description="Whether to enable the network for the session.")
     memory_bytes: int | None = Field(default=None, description="Memory in bytes to be used for the session.")
     cpus: float | None = Field(default=None, description="CPUs to be used for the session.")
@@ -52,7 +51,6 @@ class RunCommandsResponse(BaseModel):
     """
 
     results: list[RunCommandResult]
-    patch: Base64Str | None
 
 
 class PutMutation(BaseModel):

--- a/tests/unit_tests/automation/agent/middlewares/test_git_platform.py
+++ b/tests/unit_tests/automation/agent/middlewares/test_git_platform.py
@@ -9,6 +9,8 @@ from langchain.tools import ToolRuntime
 from langgraph.types import Command
 
 from automation.agent.middlewares.git_platform import (
+    GITHUB_TOOL_DESCRIPTION,
+    GITLAB_TOOL_DESCRIPTION,
     _exceeds_output_cap,
     _finalize_inline_output,
     _handle_output_redirect,
@@ -651,3 +653,12 @@ async def test_gitlab_empty_output_with_output_file_notes_file_not_written():
     assert "empty result" in result
     assert "not written" in result
     client_cls.assert_not_called()
+
+
+def test_tool_descriptions_document_output_file():
+    for desc in (GITLAB_TOOL_DESCRIPTION, GITHUB_TOOL_DESCRIPTION):
+        assert "output_file" in desc
+        assert "/workspace" in desc
+        assert "/workspace/tmp" in desc  # transient-dump guidance
+    assert "--output json" in GITLAB_TOOL_DESCRIPTION  # gitlab forces JSON on redirect
+    assert "--json" in GITHUB_TOOL_DESCRIPTION  # gh opts into JSON via its own flag

--- a/tests/unit_tests/automation/agent/middlewares/test_git_platform.py
+++ b/tests/unit_tests/automation/agent/middlewares/test_git_platform.py
@@ -8,7 +8,13 @@ import pytest
 from langchain.tools import ToolRuntime
 from langgraph.types import Command
 
-from automation.agent.middlewares.git_platform import _validate_workspace_path, github_tool, gitlab_tool
+from automation.agent.middlewares.git_platform import (
+    _exceeds_output_cap,
+    _redirect_confirmation,
+    _validate_workspace_path,
+    github_tool,
+    gitlab_tool,
+)
 from codebase.base import GitPlatform
 from core.sandbox.schemas import FsWriteResponse
 
@@ -339,3 +345,25 @@ def test_validate_workspace_path_rejects(path):
     err = _validate_workspace_path(path)
     assert err is not None
     assert err.startswith("error:")
+
+
+def test_exceeds_output_cap_thresholds():
+    assert _exceeds_output_cap("\n".join(str(i) for i in range(2100))) is True  # 2100 lines
+    assert _exceeds_output_cap("\n".join(str(i) for i in range(100))) is False  # 100 lines
+    assert _exceeds_output_cap("\n".join(str(i) for i in range(2000))) is False  # exactly 2000 lines
+
+
+def test_redirect_confirmation_shape():
+    output = "line1\nline2\nline3"
+    msg = _redirect_confirmation("/workspace/tmp/x.json", 17, 3, output)
+    assert "/workspace/tmp/x.json" in msg
+    assert "17 bytes" in msg
+    assert "3 lines" in msg
+    assert "line1" in msg  # head preview included
+
+
+def test_redirect_confirmation_caps_preview_to_25_lines():
+    output = "\n".join(f"line{i}" for i in range(100))
+    msg = _redirect_confirmation("/workspace/tmp/x.json", 999, 100, output)
+    assert "line24" in msg  # 25th line (0-indexed) is shown
+    assert "line25" not in msg  # 26th line is not

--- a/tests/unit_tests/automation/agent/middlewares/test_git_platform.py
+++ b/tests/unit_tests/automation/agent/middlewares/test_git_platform.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from contextlib import contextmanager
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
@@ -9,6 +10,18 @@ from langgraph.types import Command
 
 from automation.agent.middlewares.git_platform import github_tool, gitlab_tool
 from codebase.base import GitPlatform
+from core.sandbox.schemas import FsWriteResponse
+
+
+@contextmanager
+def _mock_sandbox_client(*, ok: bool = True, error: str | None = None):
+    """Patch DAIVSandboxClient with an async mock; yield the client mock for assertions."""
+    client = Mock()
+    client.open = AsyncMock()
+    client.close = AsyncMock()
+    client.fs_write = AsyncMock(return_value=FsWriteResponse(ok=ok, error=error))
+    with patch("automation.agent.middlewares.git_platform.DAIVSandboxClient", return_value=client):
+        yield client
 
 
 @patch("automation.agent.middlewares.git_platform.cache.lock", new=MagicMock())

--- a/tests/unit_tests/automation/agent/middlewares/test_git_platform.py
+++ b/tests/unit_tests/automation/agent/middlewares/test_git_platform.py
@@ -515,6 +515,30 @@ async def test_gitlab_output_file_forces_json_writes_and_confirms():
     assert '"iid": 1' in result  # head preview
 
 
+async def test_gitlab_output_file_does_not_force_json_for_job_trace():
+    runtime = _make_gitlab_runtime()
+    runtime.state["session_id"] = "sess-1"
+    mock_settings = Mock()
+    mock_settings.GITLAB_AUTH_TOKEN.get_secret_value.return_value = "test-token"  # noqa: S106
+    mock_settings.GITLAB_URL.encoded_string.return_value = "https://gitlab.com"
+    with (
+        patch("automation.agent.middlewares.git_platform.asyncio.create_subprocess_exec") as create_proc,
+        patch("automation.agent.middlewares.git_platform.settings", mock_settings),
+        _mock_sandbox_client() as client,
+    ):
+        proc = Mock()
+        proc.communicate = AsyncMock(return_value=(b"log line 1\nlog line 2\n", b""))
+        proc.returncode = 0
+        create_proc.return_value = proc
+        result = await gitlab_tool.coroutine(
+            subcommand="project-job trace --id 55", runtime=runtime, output_file="/workspace/tmp/trace.txt"
+        )
+    argv = list(create_proc.call_args.args)
+    assert "--output" not in argv  # traces are raw log text; JSON would be degenerate
+    assert client.fs_write.call_args.args[1].path == "/workspace/tmp/trace.txt"
+    assert result.startswith("Wrote ")
+
+
 async def test_gitlab_invalid_output_file_errors_before_running_cli():
     runtime = _make_gitlab_runtime()
     runtime.state["session_id"] = "sess-1"

--- a/tests/unit_tests/automation/agent/middlewares/test_git_platform.py
+++ b/tests/unit_tests/automation/agent/middlewares/test_git_platform.py
@@ -10,6 +10,8 @@ from langgraph.types import Command
 
 from automation.agent.middlewares.git_platform import (
     _exceeds_output_cap,
+    _finalize_inline_output,
+    _handle_output_redirect,
     _redirect_confirmation,
     _validate_workspace_path,
     _write_output_to_sandbox,
@@ -387,3 +389,74 @@ async def test_write_output_to_sandbox_raises_on_not_ok_and_still_closes():
     with _mock_sandbox_client(ok=False, error="disk full") as client, pytest.raises(RuntimeError, match="disk full"):
         await _write_output_to_sandbox("x", "/workspace/tmp/x.txt", "s")
     client.close.assert_awaited_once()
+
+
+async def test_handle_redirect_degrades_inline_without_session():
+    runtime = _make_gitlab_runtime()  # state has no session_id
+    result = await _handle_output_redirect(
+        output="hello", output_file="/workspace/tmp/x.json", runtime=runtime, keep="head", tool_name="gitlab"
+    )
+    assert "output_file was ignored" in result
+    assert "hello" in result
+
+
+async def test_handle_redirect_writes_and_confirms_with_session():
+    runtime = _make_gitlab_runtime()
+    runtime.state["session_id"] = "sess-1"
+    with _mock_sandbox_client() as client:
+        result = await _handle_output_redirect(
+            output="payload-data", output_file="/workspace/tmp/x.json", runtime=runtime, keep="head", tool_name="gitlab"
+        )
+    assert client.fs_write.call_args.args[1].path == "/workspace/tmp/x.json"
+    assert result.startswith("Wrote ")
+
+
+async def test_handle_redirect_returns_error_on_write_failure():
+    runtime = _make_gitlab_runtime()
+    runtime.state["session_id"] = "sess-1"
+    with _mock_sandbox_client(ok=False, error="boom"):
+        result = await _handle_output_redirect(
+            output="x", output_file="/workspace/tmp/x.json", runtime=runtime, keep="head", tool_name="gitlab"
+        )
+    assert result.startswith("error:")
+    assert "/workspace/tmp/x.json" in result
+
+
+async def test_finalize_inline_returns_plain_output_when_small():
+    runtime = _make_gitlab_runtime()
+    with patch("automation.agent.middlewares.git_platform.DAIVSandboxClient") as cls:
+        result = await _finalize_inline_output(
+            output="small", runtime=runtime, resource="r", action="a", keep="head", tool_name="gitlab"
+        )
+        cls.assert_not_called()
+    assert result == "small"
+
+
+async def test_finalize_inline_auto_evicts_when_oversized_with_session():
+    runtime = _make_gitlab_runtime()
+    runtime.state["session_id"] = "sess-1"
+    big = "\n".join(str(i) for i in range(2100))
+    with _mock_sandbox_client() as client:
+        result = await _finalize_inline_output(
+            output=big,
+            runtime=runtime,
+            resource="project-merge-request",
+            action="list",
+            keep="head",
+            tool_name="gitlab",
+        )
+    path = client.fs_write.call_args.args[1].path
+    assert path.startswith("/workspace/tmp/gitlab-project-merge-request-list-")
+    assert path.endswith(".txt")
+    assert "written verbatim to the scratch file" in result
+
+
+async def test_finalize_inline_truncates_without_session_when_oversized():
+    runtime = _make_gitlab_runtime()  # no session
+    big = "\n".join(str(i) for i in range(2100))
+    with patch("automation.agent.middlewares.git_platform.DAIVSandboxClient") as cls:
+        result = await _finalize_inline_output(
+            output=big, runtime=runtime, resource="r", action="a", keep="head", tool_name="gitlab"
+        )
+        cls.assert_not_called()
+    assert "truncated" in result  # sentinel from _truncate_cli_output

--- a/tests/unit_tests/automation/agent/middlewares/test_git_platform.py
+++ b/tests/unit_tests/automation/agent/middlewares/test_git_platform.py
@@ -8,7 +8,7 @@ import pytest
 from langchain.tools import ToolRuntime
 from langgraph.types import Command
 
-from automation.agent.middlewares.git_platform import github_tool, gitlab_tool
+from automation.agent.middlewares.git_platform import _validate_workspace_path, github_tool, gitlab_tool
 from codebase.base import GitPlatform
 from core.sandbox.schemas import FsWriteResponse
 
@@ -327,3 +327,15 @@ class TestGitLabToolInlineDiscussionFallback:
 
         assert result.startswith("error:")
         assert "--mr-iid" in result
+
+
+@pytest.mark.parametrize("path", ["/workspace/tmp/x.json", "/workspace/repo/a/b.txt", "/workspace/out"])
+def test_validate_workspace_path_accepts_under_workspace(path):
+    assert _validate_workspace_path(path) is None
+
+
+@pytest.mark.parametrize("path", ["relative.json", "/etc/passwd", "/workspace/../etc/passwd", "/workspace", ""])
+def test_validate_workspace_path_rejects(path):
+    err = _validate_workspace_path(path)
+    assert err is not None
+    assert err.startswith("error:")

--- a/tests/unit_tests/automation/agent/middlewares/test_git_platform.py
+++ b/tests/unit_tests/automation/agent/middlewares/test_git_platform.py
@@ -460,3 +460,14 @@ async def test_finalize_inline_truncates_without_session_when_oversized():
         )
         cls.assert_not_called()
     assert "truncated" in result  # sentinel from _truncate_cli_output
+
+
+async def test_finalize_inline_falls_back_to_truncation_when_evict_fails():
+    runtime = _make_gitlab_runtime()
+    runtime.state["session_id"] = "sess-1"
+    big = "\n".join(str(i) for i in range(2100))
+    with _mock_sandbox_client(ok=False, error="disk full"):
+        result = await _finalize_inline_output(
+            output=big, runtime=runtime, resource="r", action="a", keep="head", tool_name="gitlab"
+        )
+    assert "truncated" in result  # fallback to _truncate_cli_output sentinel

--- a/tests/unit_tests/automation/agent/middlewares/test_git_platform.py
+++ b/tests/unit_tests/automation/agent/middlewares/test_git_platform.py
@@ -526,3 +526,69 @@ async def test_gitlab_invalid_output_file_errors_before_running_cli():
     assert result.startswith("error:")
     create_proc.assert_not_called()
     client_cls.assert_not_called()
+
+
+@patch("automation.agent.middlewares.git_platform.cache.lock", new=MagicMock())
+class TestGitHubToolOutputFile:
+    async def test_github_output_file_writes_verbatim_and_wraps_in_command(self):
+        runtime = ToolRuntime(
+            state={"session_id": "sess-1"},
+            context=Mock(repo_id="owner/repo", git_platform=GitPlatform.GITHUB),
+            config={"configurable": {"thread_id": "t-gh-of"}},
+            stream_writer=Mock(),
+            tool_call_id="c1",
+            store=None,
+        )
+        payload = b'{"number": 7}\n'
+
+        with (
+            patch("automation.agent.middlewares.git_platform.get_github_integration") as gi,
+            patch("automation.agent.middlewares.git_platform.asyncio.create_subprocess_exec") as create_proc,
+            _mock_sandbox_client() as client,
+        ):
+            gi.return_value.get_access_token.return_value = Mock(
+                token="tok",  # noqa: S106
+                expires_at=Mock(timestamp=Mock(return_value=9999999999.0)),
+            )
+            proc = Mock()
+            proc.communicate = AsyncMock(return_value=(payload, b""))
+            proc.returncode = 0
+            create_proc.return_value = proc
+
+            result = await github_tool.coroutine(
+                subcommand="pr view 7 --json number", runtime=runtime, output_file="/workspace/tmp/pr.json"
+            )
+
+        # gh is written verbatim — the tool never injects a global --output flag
+        argv = list(create_proc.call_args.args)
+        assert "--output" not in argv
+
+        req = client.fs_write.call_args.args[1]
+        assert req.path == "/workspace/tmp/pr.json"
+        assert req.content == b'{"number": 7}'
+
+        # token was refreshed → Command, and its ToolMessage carries the confirmation
+        assert isinstance(result, Command)
+        msg = result.update["messages"][0].content
+        assert msg.startswith("Wrote ")
+        assert "/workspace/tmp/pr.json" in msg
+
+    async def test_github_invalid_output_file_errors_before_running_cli(self):
+        runtime = ToolRuntime(
+            state={"session_id": "sess-1"},
+            context=Mock(repo_id="owner/repo", git_platform=GitPlatform.GITHUB),
+            config={"configurable": {"thread_id": "t-gh-bad"}},
+            stream_writer=Mock(),
+            tool_call_id="c2",
+            store=None,
+        )
+        with (
+            patch("automation.agent.middlewares.git_platform.asyncio.create_subprocess_exec") as create_proc,
+            patch("automation.agent.middlewares.git_platform.DAIVSandboxClient") as client_cls,
+        ):
+            result = await github_tool.coroutine(
+                subcommand="issue view 1", runtime=runtime, output_file="../escape.json"
+            )
+        assert result.startswith("error:")
+        create_proc.assert_not_called()
+        client_cls.assert_not_called()

--- a/tests/unit_tests/automation/agent/middlewares/test_git_platform.py
+++ b/tests/unit_tests/automation/agent/middlewares/test_git_platform.py
@@ -592,3 +592,62 @@ class TestGitHubToolOutputFile:
         assert result.startswith("error:")
         create_proc.assert_not_called()
         client_cls.assert_not_called()
+
+    async def test_github_empty_output_with_output_file_notes_file_not_written(self):
+        """When gh returns empty stdout and output_file is set, the result must contain
+        both the 'empty result' sentinel and a note that the file was not written."""
+        runtime = ToolRuntime(
+            state={"session_id": "sess-1", "github_token": "tok", "github_token_expires_at": 9999999999.0},
+            context=Mock(repo_id="owner/repo", git_platform=GitPlatform.GITHUB),
+            config={"configurable": {"thread_id": "t-gh-empty"}},
+            stream_writer=Mock(),
+            tool_call_id="c3",
+            store=None,
+        )
+        with (
+            patch("automation.agent.middlewares.git_platform.asyncio.create_subprocess_exec") as create_proc,
+            patch("automation.agent.middlewares.git_platform.DAIVSandboxClient") as client_cls,
+        ):
+            proc = Mock()
+            proc.communicate = AsyncMock(return_value=(b"", b""))
+            proc.returncode = 0
+            create_proc.return_value = proc
+
+            result = await github_tool.coroutine(
+                subcommand="issue list --state open", runtime=runtime, output_file="/workspace/tmp/issues.json"
+            )
+
+        # Token was already cached → plain string (no Command)
+        assert isinstance(result, str)
+        assert "empty result" in result
+        assert "not written" in result
+        client_cls.assert_not_called()
+
+
+async def test_gitlab_empty_output_with_output_file_notes_file_not_written():
+    """When the gitlab CLI returns empty stdout and output_file is set, the result must
+    contain both the 'empty result' sentinel and a note that the file was not written."""
+    runtime = _make_gitlab_runtime()
+    runtime.state["session_id"] = "sess-1"
+
+    mock_settings = Mock()
+    mock_settings.GITLAB_AUTH_TOKEN.get_secret_value.return_value = "test-token"  # noqa: S106
+    mock_settings.GITLAB_URL.encoded_string.return_value = "https://gitlab.com"
+
+    with (
+        patch("automation.agent.middlewares.git_platform.asyncio.create_subprocess_exec") as create_proc,
+        patch("automation.agent.middlewares.git_platform.settings", mock_settings),
+        patch("automation.agent.middlewares.git_platform.DAIVSandboxClient") as client_cls,
+    ):
+        proc = Mock()
+        proc.communicate = AsyncMock(return_value=(b"", b""))
+        proc.returncode = 0
+        create_proc.return_value = proc
+
+        result = await gitlab_tool.coroutine(
+            subcommand="project-issue list --state opened", runtime=runtime, output_file="/workspace/tmp/issues.json"
+        )
+
+    assert "empty result" in result
+    assert "not written" in result
+    client_cls.assert_not_called()

--- a/tests/unit_tests/automation/agent/middlewares/test_git_platform.py
+++ b/tests/unit_tests/automation/agent/middlewares/test_git_platform.py
@@ -451,6 +451,9 @@ async def test_finalize_inline_auto_evicts_when_oversized_with_session():
     assert path.startswith("/workspace/tmp/gitlab-project-merge-request-list-")
     assert path.endswith(".txt")
     assert "written verbatim to the scratch file" in result
+    # Note must be platform-neutral and guide both gitlab and gh users
+    assert "output_file=" in result
+    assert "--json" in result
 
 
 async def test_finalize_inline_truncates_without_session_when_oversized():
@@ -473,6 +476,7 @@ async def test_finalize_inline_falls_back_to_truncation_when_evict_fails():
             output=big, runtime=runtime, resource="r", action="a", keep="head", tool_name="gitlab"
         )
     assert "truncated" in result  # fallback to _truncate_cli_output sentinel
+    assert "writing it to a sandbox scratch file failed" in result  # eviction-failure note
 
 
 async def test_gitlab_output_file_forces_json_writes_and_confirms():
@@ -686,3 +690,81 @@ def test_tool_descriptions_document_output_file():
         assert "/workspace/tmp" in desc  # transient-dump guidance
     assert "--output json" in GITLAB_TOOL_DESCRIPTION  # gitlab forces JSON on redirect
     assert "--json" in GITHUB_TOOL_DESCRIPTION  # gh opts into JSON via its own flag
+
+
+def test_tool_descriptions_document_project_job_trace_raw_text():
+    """GITLAB_TOOL_DESCRIPTION must mention project-job trace together with raw log text."""
+    assert "project-job trace" in GITLAB_TOOL_DESCRIPTION
+    assert "raw log text" in GITLAB_TOOL_DESCRIPTION
+
+
+def test_redirect_confirmation_caps_preview_chars():
+    output = "x" * 5000  # single very long line
+    msg = _redirect_confirmation("/workspace/tmp/x.json", 5000, 1, output)
+    assert "(preview truncated)" in msg
+    assert len(msg) < 5000
+
+
+@patch("automation.agent.middlewares.git_platform.cache.lock", new=MagicMock())
+class TestGitHubToolOutputFileExtra:
+    async def test_github_run_view_log_redirect(self):
+        """gh run view --log redirect: clean_job_logs + keep='tail'; file written, confirmation returned."""
+        runtime = ToolRuntime(
+            state={"session_id": "sess-2", "github_token": "tok", "github_token_expires_at": 9999999999.0},
+            context=Mock(repo_id="owner/repo", git_platform=GitPlatform.GITHUB),
+            config={"configurable": {"thread_id": "t-gh-log"}},
+            stream_writer=Mock(),
+            tool_call_id="c-log",
+            store=None,
+        )
+        log_output = b"2024-01-01T00:00:00.000Z job1\tsome log line\n"
+
+        with (
+            patch("automation.agent.middlewares.git_platform.asyncio.create_subprocess_exec") as create_proc,
+            patch(
+                "automation.agent.middlewares.git_platform.clean_job_logs", return_value="some log line"
+            ) as mock_clean,
+            _mock_sandbox_client() as client,
+        ):
+            proc = Mock()
+            proc.communicate = AsyncMock(return_value=(log_output, b""))
+            proc.returncode = 0
+            create_proc.return_value = proc
+
+            result = await github_tool.coroutine(
+                subcommand="run view 123 --job 456 --log", runtime=runtime, output_file="/workspace/tmp/log.txt"
+            )
+
+        # Token was already cached → plain string (no Command)
+        assert isinstance(result, str)
+        assert result.startswith("Wrote ")
+        assert client.fs_write.call_args.args[1].path == "/workspace/tmp/log.txt"
+        mock_clean.assert_called_once()
+
+    async def test_github_output_file_cached_token_plain_string(self):
+        """gh output_file with a cached valid token returns a plain str (no Command)."""
+        runtime = ToolRuntime(
+            state={"session_id": "sess-3", "github_token": "tok", "github_token_expires_at": 9999999999.0},
+            context=Mock(repo_id="owner/repo", git_platform=GitPlatform.GITHUB),
+            config={"configurable": {"thread_id": "t-gh-cached"}},
+            stream_writer=Mock(),
+            tool_call_id="c-cached",
+            store=None,
+        )
+        payload = b'{"number": 7}\n'
+
+        with (
+            patch("automation.agent.middlewares.git_platform.asyncio.create_subprocess_exec") as create_proc,
+            _mock_sandbox_client(),
+        ):
+            proc = Mock()
+            proc.communicate = AsyncMock(return_value=(payload, b""))
+            proc.returncode = 0
+            create_proc.return_value = proc
+
+            result = await github_tool.coroutine(
+                subcommand="pr view 7 --json number", runtime=runtime, output_file="/workspace/tmp/pr.json"
+            )
+
+        assert isinstance(result, str)
+        assert result.startswith("Wrote ")

--- a/tests/unit_tests/automation/agent/middlewares/test_git_platform.py
+++ b/tests/unit_tests/automation/agent/middlewares/test_git_platform.py
@@ -12,6 +12,7 @@ from automation.agent.middlewares.git_platform import (
     _exceeds_output_cap,
     _redirect_confirmation,
     _validate_workspace_path,
+    _write_output_to_sandbox,
     github_tool,
     gitlab_tool,
 )
@@ -367,3 +368,22 @@ def test_redirect_confirmation_caps_preview_to_25_lines():
     msg = _redirect_confirmation("/workspace/tmp/x.json", 999, 100, output)
     assert "line24" in msg  # 25th line (0-indexed) is shown
     assert "line25" not in msg  # 26th line is not
+
+
+async def test_write_output_to_sandbox_writes_and_returns_counts():
+    with _mock_sandbox_client() as client:
+        byte_count, line_count = await _write_output_to_sandbox("a\nb\nc", "/workspace/tmp/x.txt", "sess-9")
+
+    assert client.fs_write.call_args.args[0] == "sess-9"
+    req = client.fs_write.call_args.args[1]
+    assert req.path == "/workspace/tmp/x.txt"
+    assert req.content == b"a\nb\nc"  # Base64Bytes stores decoded bytes after validation
+    assert (byte_count, line_count) == (5, 3)
+    client.open.assert_awaited_once()
+    client.close.assert_awaited_once()
+
+
+async def test_write_output_to_sandbox_raises_on_not_ok_and_still_closes():
+    with _mock_sandbox_client(ok=False, error="disk full") as client, pytest.raises(RuntimeError, match="disk full"):
+        await _write_output_to_sandbox("x", "/workspace/tmp/x.txt", "s")
+    client.close.assert_awaited_once()

--- a/tests/unit_tests/automation/agent/middlewares/test_git_platform.py
+++ b/tests/unit_tests/automation/agent/middlewares/test_git_platform.py
@@ -471,3 +471,58 @@ async def test_finalize_inline_falls_back_to_truncation_when_evict_fails():
             output=big, runtime=runtime, resource="r", action="a", keep="head", tool_name="gitlab"
         )
     assert "truncated" in result  # fallback to _truncate_cli_output sentinel
+
+
+async def test_gitlab_output_file_forces_json_writes_and_confirms():
+    runtime = _make_gitlab_runtime()
+    runtime.state["session_id"] = "sess-1"
+
+    mock_settings = Mock()
+    mock_settings.GITLAB_AUTH_TOKEN.get_secret_value.return_value = "test-token"  # noqa: S106
+    mock_settings.GITLAB_URL.encoded_string.return_value = "https://gitlab.com"
+
+    payload = b'[{"iid": 1}, {"iid": 2}]\n'
+
+    with (
+        patch("automation.agent.middlewares.git_platform.asyncio.create_subprocess_exec") as create_proc,
+        patch("automation.agent.middlewares.git_platform.settings", mock_settings),
+        _mock_sandbox_client() as client,
+    ):
+        proc = Mock()
+        proc.communicate = AsyncMock(return_value=(payload, b""))
+        proc.returncode = 0
+        create_proc.return_value = proc
+
+        result = await gitlab_tool.coroutine(
+            subcommand="project-merge-request list --state opened",
+            runtime=runtime,
+            output_mode="detailed",
+            output_file="/workspace/tmp/mrs.json",
+        )
+
+    argv = list(create_proc.call_args.args)
+    assert "--output" in argv and argv[argv.index("--output") + 1] == "json"
+    assert "--verbose" not in argv  # output_mode ignored on redirect
+
+    assert client.fs_write.call_args.args[0] == "sess-1"
+    req = client.fs_write.call_args.args[1]
+    assert req.path == "/workspace/tmp/mrs.json"
+    assert req.content == b'[{"iid": 1}, {"iid": 2}]'  # full, untruncated, decoded
+    assert result.startswith("Wrote ")
+    assert "/workspace/tmp/mrs.json" in result
+    assert '"iid": 1' in result  # head preview
+
+
+async def test_gitlab_invalid_output_file_errors_before_running_cli():
+    runtime = _make_gitlab_runtime()
+    runtime.state["session_id"] = "sess-1"
+    with (
+        patch("automation.agent.middlewares.git_platform.asyncio.create_subprocess_exec") as create_proc,
+        patch("automation.agent.middlewares.git_platform.DAIVSandboxClient") as client_cls,
+    ):
+        result = await gitlab_tool.coroutine(
+            subcommand="project-issue get --iid 1", runtime=runtime, output_file="/etc/passwd"
+        )
+    assert result.startswith("error:")
+    create_proc.assert_not_called()
+    client_cls.assert_not_called()

--- a/tests/unit_tests/automation/agent/middlewares/test_sandbox.py
+++ b/tests/unit_tests/automation/agent/middlewares/test_sandbox.py
@@ -1,16 +1,15 @@
-import base64
 import io
+import json
 import tarfile
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, Mock, patch
 
 from git import Repo
 
-from automation.agent.middlewares.file_system import DAIVFilesystemBackend
 from automation.agent.middlewares.sandbox import SANDBOX_SYSTEM_PROMPT, SandboxMiddleware, _run_bash_commands
 from core.conf import settings as core_settings
 from core.sandbox.client import DAIVSandboxClient
-from core.sandbox.schemas import RunCommandsResponse
+from core.sandbox.schemas import RunCommandResult, RunCommandsResponse
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -90,7 +89,7 @@ class TestBindBackend:
     def test_bind_backend_binds_sandbox_file_backend(self):
         from automation.agent.middlewares.file_system import SandboxFileBackend
 
-        backend = SandboxFileBackend(root="/workspace")
+        backend = SandboxFileBackend()
         mw = SandboxMiddleware(backend=backend, agent_root="/workspace/repo")
         mw._client = AsyncMock()
 
@@ -115,7 +114,7 @@ class TestBindBackend:
         not raise (the session, not the client, identifies the workspace)."""
         from automation.agent.middlewares.file_system import SandboxFileBackend
 
-        backend = SandboxFileBackend(root="/workspace")
+        backend = SandboxFileBackend()
         parent = SandboxMiddleware(backend=backend, agent_root="/workspace/repo")
         parent._client = AsyncMock()
         parent._bind_backend("sid")
@@ -129,54 +128,23 @@ class TestBindBackend:
 
 
 class TestBashTool:
-    async def test_bash_tool_returns_results_json_without_applying_patch(self, tmp_path: Path):
-        """The sandbox is authoritative: the bash tool reports ``files_changed`` derived from
-        the sandbox patch (display-only) but does NOT apply it to any local checkout."""
-        repo_dir = tmp_path / "repoX"
-        repo_dir.mkdir(parents=True)
-        repo = Repo.init(repo_dir)
+    async def test_bash_tool_returns_commands_json(self):
+        """The bash tool surfaces the sandbox's per-command results as ``{"commands": [...]}``.
 
-        # Configure git identity for commits
-        with repo.config_writer() as writer:
-            writer.set_value("user", "name", "Test User")
-            writer.set_value("user", "email", "test@example.com")
+        The sandbox is authoritative — there is no local checkout to keep in sync — so the
+        output carries only ``commands`` (no ``files_changed``)."""
+        response = RunCommandsResponse(results=[RunCommandResult(command="echo ok", output="ok", exit_code=0)])
 
-        file_path = repo_dir / "hello.txt"
-        file_path.write_text("old\n")
-        repo.git.add("-A")
-        repo.index.commit("init")
-
-        # Create a real patch via git diff, then restore the file so we can assert the
-        # bash tool does NOT apply it locally.
-        file_path.write_text("new\n")
-        patch_text = repo.git.diff("HEAD")
-        if patch_text and not patch_text.endswith("\n"):
-            patch_text += "\n"
-        repo.git.checkout("--", "hello.txt")
-
-        assert file_path.read_text() == "old\n"
-
-        response = RunCommandsResponse(results=[], patch=base64.b64encode(patch_text.encode("utf-8")).decode("utf-8"))
-
-        runtime = _make_bash_runtime(repo)
+        runtime = _make_bash_runtime(Mock())
         client = Mock()
         client.run_commands = AsyncMock(return_value=response)
-        middleware = SandboxMiddleware(
-            backend=Mock(spec=DAIVFilesystemBackend), agent_root=f"/{repo_dir.name}", close_session=True
-        )
-        middleware._client = client
-        bash_tool = middleware.tools[0]
+        bash_tool = _bash_tool_with_fake_client(client)
 
         output = await bash_tool.coroutine(command="echo ok", runtime=runtime)
 
-        # The patch is never applied to the local checkout — only the sandbox holds the changes.
-        assert file_path.read_text() == "old\n"
-        import json as _json
-
-        payload = _json.loads(output)
-        assert payload["commands"] == []
-        # The patch just edits hello.txt — nothing added/deleted/renamed.
-        assert payload["files_changed"] == [{"path": "hello.txt", "op": "modified"}]
+        payload = json.loads(output)
+        assert payload == {"commands": [{"command": "echo ok", "output": "ok", "exit_code": 0}]}
+        assert "files_changed" not in payload
         client.run_commands.assert_awaited_once()
 
     async def test_bash_tool_returns_error_when_sandbox_call_fails(self, tmp_path: Path):
@@ -228,7 +196,7 @@ class TestBashToolPolicyEnforcement:
         runtime.state["session_id"] = "sess_policy"
 
         client = Mock()
-        run_mock = AsyncMock(return_value=RunCommandsResponse(results=[], patch=None))
+        run_mock = AsyncMock(return_value=RunCommandsResponse(results=[]))
         client.run_commands = run_mock
         bash_tool = _bash_tool_with_fake_client(client)
 
@@ -361,7 +329,7 @@ class TestBashToolPolicyEnforcement:
 class TestRunBashCommands:
     async def test_run_bash_commands_no_archive_field(self):
         """_run_bash_commands no longer tarballs the working dir; archive is gone from RunCommandsRequest."""
-        run_commands_mock = AsyncMock(return_value=RunCommandsResponse(results=[], patch=None))
+        run_commands_mock = AsyncMock(return_value=RunCommandsResponse(results=[]))
         client = Mock()
         client.run_commands = run_commands_mock
 
@@ -392,10 +360,16 @@ class TestSandboxMiddleware:
         (repo_dir / "README.md").write_text("hello")
         runtime = _make_agent_runtime(repo_working_dir=str(repo_dir))
 
+        # No global skills available (empty builtin dir, no custom) -> skills_archive is None.
+        empty_builtin = tmp_path / "builtin-empty"
+        empty_builtin.mkdir()
+
         open_patch, close_patch = self._patch_client_lifecycle()
         with (
             open_patch,
             close_patch,
+            patch("automation.agent.middlewares.sandbox.BUILTIN_SKILLS_PATH", empty_builtin),
+            patch("automation.agent.middlewares.sandbox.agent_settings") as settings,
             patch(
                 "automation.agent.middlewares.sandbox.DAIVSandboxClient.start_session",
                 new=AsyncMock(return_value="sess_1"),
@@ -404,6 +378,7 @@ class TestSandboxMiddleware:
                 "automation.agent.middlewares.sandbox.DAIVSandboxClient.seed_session", new=AsyncMock(return_value=None)
             ) as seed_session_mock,
         ):
+            settings.CUSTOM_SKILLS_PATH = None
             middleware = _make_middleware(close_session=True)
             update = await middleware.abefore_agent({}, runtime)
 
@@ -570,9 +545,9 @@ class TestSandboxMiddleware:
         repo_dir.mkdir(parents=True)
         (repo_dir / "README.md").write_text("hello")
 
-        skills_dir = tmp_path / "skills"
-        (skills_dir / "skill-one").mkdir(parents=True)
-        (skills_dir / "skill-one" / "SKILL.md").write_text("hi")
+        builtin = tmp_path / "builtin"
+        (builtin / "skill-one").mkdir(parents=True)
+        (builtin / "skill-one" / "SKILL.md").write_text("hi")
 
         runtime = _make_agent_runtime(repo_working_dir=str(repo_dir))
 
@@ -580,7 +555,8 @@ class TestSandboxMiddleware:
         with (
             open_patch,
             close_patch,
-            patch("automation.agent.middlewares.sandbox.SKILLS_CACHE_PATH", skills_dir),
+            patch("automation.agent.middlewares.sandbox.BUILTIN_SKILLS_PATH", builtin),
+            patch("automation.agent.middlewares.sandbox.agent_settings") as settings,
             patch(
                 "automation.agent.middlewares.sandbox.DAIVSandboxClient.start_session",
                 new=AsyncMock(return_value="sess_skills"),
@@ -589,6 +565,7 @@ class TestSandboxMiddleware:
                 "automation.agent.middlewares.sandbox.DAIVSandboxClient.seed_session", new=AsyncMock(return_value=None)
             ) as seed_session_mock,
         ):
+            settings.CUSTOM_SKILLS_PATH = None
             middleware = SandboxMiddleware(backend=Mock(), agent_root=f"/{repo_dir.name}", close_session=True)
             update = await middleware.abefore_agent({}, runtime)
 
@@ -598,59 +575,81 @@ class TestSandboxMiddleware:
         assert isinstance(kwargs.get("repo_archive"), (bytes, bytearray))
         assert isinstance(kwargs.get("skills_archive"), (bytes, bytearray))
 
-    def test_make_skills_archive_returns_none_when_dir_missing(self, tmp_path: Path):
-        from automation.agent.middlewares.sandbox import _make_skills_archive
+    def test_make_global_skills_archive_packs_builtin_and_custom(self, tmp_path: Path):
+        from automation.agent.middlewares.sandbox import _make_global_skills_archive
 
-        assert _make_skills_archive(tmp_path / "nonexistent") is None
+        builtin = tmp_path / "builtin"
+        custom = tmp_path / "custom"
+        (builtin / "code-review").mkdir(parents=True)
+        (builtin / "code-review" / "SKILL.md").write_text("hi")
+        (custom / "deploy").mkdir(parents=True)
+        (custom / "deploy" / "SKILL.md").write_text("yo")
 
-    def test_make_skills_archive_returns_none_when_dir_empty(self, tmp_path: Path):
-        from automation.agent.middlewares.sandbox import _make_skills_archive
+        with (
+            patch("automation.agent.middlewares.sandbox.BUILTIN_SKILLS_PATH", builtin),
+            patch("automation.agent.middlewares.sandbox.agent_settings") as settings,
+        ):
+            settings.CUSTOM_SKILLS_PATH = custom
+            archive = _make_global_skills_archive()
 
-        empty = tmp_path / "skills"
-        empty.mkdir()
-        assert _make_skills_archive(empty) is None
-
-    def test_make_skills_archive_packs_children_relative_to_root(self, tmp_path: Path):
-        from automation.agent.middlewares.sandbox import _make_skills_archive
-
-        skills = tmp_path / "skills"
-        (skills / "skill-one").mkdir(parents=True)
-        (skills / "skill-one" / "SKILL.md").write_text("hello")
-        (skills / "skill-two").mkdir()
-        (skills / "skill-two" / "SKILL.md").write_text("world")
-
-        archive = _make_skills_archive(skills)
-        assert isinstance(archive, bytes)
-
+        assert isinstance(archive, (bytes, bytearray))
         with tarfile.open(fileobj=io.BytesIO(archive), mode="r:gz") as tf:
-            names = sorted(tf.getnames())
-        assert "skill-one/SKILL.md" in names
-        assert "skill-two/SKILL.md" in names
-        # No top-level wrapper directory.
-        assert not any(n.startswith("skills/") for n in names)
+            names = set(tf.getnames())
+        assert "code-review/SKILL.md" in names
+        assert "deploy/SKILL.md" in names
 
-    def test_make_skills_archive_returns_none_on_iterdir_oserror(self, tmp_path: Path):
-        from automation.agent.middlewares.sandbox import _make_skills_archive
+    def test_make_global_skills_archive_none_when_no_skills(self, tmp_path: Path):
+        from automation.agent.middlewares.sandbox import _make_global_skills_archive
 
-        skills = tmp_path / "skills"
-        skills.mkdir()
+        empty = tmp_path / "builtin-empty"
+        empty.mkdir()
+        with (
+            patch("automation.agent.middlewares.sandbox.BUILTIN_SKILLS_PATH", empty),
+            patch("automation.agent.middlewares.sandbox.agent_settings") as settings,
+        ):
+            settings.CUSTOM_SKILLS_PATH = None
+            assert _make_global_skills_archive() is None
 
-        with patch("automation.agent.middlewares.sandbox.Path.iterdir", side_effect=PermissionError("denied")):
-            result = _make_skills_archive(skills)
+    def test_make_global_skills_archive_skips_unreadable_root_and_still_packs_builtins(self, tmp_path: Path):
+        """An OSError reading one root (e.g. a bad-perms custom dir) must not abort the whole
+        archive — builtins still seed. (Multi-root behavior change vs the old single-root helper.)"""
+        from automation.agent.middlewares.sandbox import _make_global_skills_archive
 
-        assert result is None
+        builtin = tmp_path / "builtin"
+        (builtin / "code-review").mkdir(parents=True)
+        (builtin / "code-review" / "SKILL.md").write_text("hi")
 
-    def test_make_skills_archive_returns_none_on_tar_error(self, tmp_path: Path):
-        from automation.agent.middlewares.sandbox import _make_skills_archive
+        bad_custom = Mock()
+        bad_custom.is_dir.return_value = True
+        bad_custom.iterdir.side_effect = PermissionError("denied")
 
-        skills = tmp_path / "skills"
-        (skills / "skill-one").mkdir(parents=True)
-        (skills / "skill-one" / "SKILL.md").write_text("hello")
+        with (
+            patch("automation.agent.middlewares.sandbox.BUILTIN_SKILLS_PATH", builtin),
+            patch("automation.agent.middlewares.sandbox.agent_settings") as settings,
+        ):
+            settings.CUSTOM_SKILLS_PATH = bad_custom
+            archive = _make_global_skills_archive()
 
-        with patch("automation.agent.middlewares.sandbox.tarfile.open", side_effect=tarfile.TarError("boom")):
-            result = _make_skills_archive(skills)
+        assert isinstance(archive, (bytes, bytearray))
+        with tarfile.open(fileobj=io.BytesIO(archive), mode="r:gz") as tf:
+            names = set(tf.getnames())
+        assert "code-review/SKILL.md" in names
 
-        assert result is None
+    def test_make_global_skills_archive_returns_none_on_tar_error(self, tmp_path: Path):
+        """A TarError mid-build must not abort the whole sandbox seed — returns None (seed without skills)."""
+        from automation.agent.middlewares.sandbox import _make_global_skills_archive
+
+        builtin = tmp_path / "builtin"
+        (builtin / "code-review").mkdir(parents=True)
+        (builtin / "code-review" / "SKILL.md").write_text("hi")
+
+        with (
+            patch("automation.agent.middlewares.sandbox.BUILTIN_SKILLS_PATH", builtin),
+            patch("automation.agent.middlewares.sandbox.agent_settings") as settings,
+            patch("automation.agent.middlewares.sandbox.tarfile.open", side_effect=tarfile.TarError("boom")),
+        ):
+            settings.CUSTOM_SKILLS_PATH = None
+            assert _make_global_skills_archive() is None
 
     async def test_awrap_model_call_appends_sandbox_system_prompt(self, tmp_path: Path):
         from langchain.agents.middleware import ModelRequest, ModelResponse

--- a/tests/unit_tests/automation/agent/middlewares/test_sandbox_file_backend.py
+++ b/tests/unit_tests/automation/agent/middlewares/test_sandbox_file_backend.py
@@ -25,37 +25,35 @@ def client():
 
 @pytest.fixture
 def backend(client):
-    be = SandboxFileBackend(root="/workspace")
+    be = SandboxFileBackend()
     be.bind(client, "sid")
     return be
 
 
-def test_root_is_configurable():
-    be = SandboxFileBackend(root="/workspace")
-    assert be._abs("/repo/x.py") == "/workspace/repo/x.py"
-    assert be._abs("/") == "/workspace"
-    assert be._rel("/workspace/repo/x.py") == "/repo/x.py"
+def test_paths_pass_through_unchanged():
+    # The agent already addresses files by sandbox-absolute paths; the backend must NOT translate.
+    be = SandboxFileBackend()
+    assert be._abs("/workspace/repo/x.py") == "/workspace/repo/x.py"
+    assert be._abs("/") == "/"
+    assert be._abs("") == "/"
+    assert be._rel("/workspace/repo/x.py") == "/workspace/repo/x.py"
 
 
 async def test_calls_before_bind_raise():
-    be = SandboxFileBackend(root="/workspace")
+    be = SandboxFileBackend()
     with pytest.raises(RuntimeError, match="not bound"):
         await be.als("/")
 
 
 def test_rebind_same_session_is_noop(client):
-    # Re-binding the same session must be a no-op rather than an error.
-    be = SandboxFileBackend(root="/workspace")
+    be = SandboxFileBackend()
     be.bind(client, "sid")
     be.bind(client, "sid")  # must not raise
     assert be._session_id == "sid"
 
 
 def test_rebind_same_session_different_client_is_allowed():
-    # The real subagent topology: parent and subagent share one backend instance, but each
-    # SandboxMiddleware opens its OWN client and re-binds the SAME (parent's) session. The new
-    # client must replace the old one without raising — the session identifies the workspace.
-    be = SandboxFileBackend(root="/workspace")
+    be = SandboxFileBackend()
     parent_client, subagent_client = AsyncMock(), AsyncMock()
     be.bind(parent_client, "sid")
     be.bind(subagent_client, "sid")  # different client, same session -> allowed
@@ -64,36 +62,33 @@ def test_rebind_same_session_different_client_is_allowed():
 
 
 def test_rebind_different_session_raises(client):
-    be = SandboxFileBackend(root="/workspace")
+    be = SandboxFileBackend()
     be.bind(client, "sid")
     with pytest.raises(RuntimeError, match="already bound to session"):
         be.bind(client, "other-sid")
 
 
-async def test_bound_workspace_backend_resolves_repo_paths(client):
-    # Mirrors graph.py (constructs SandboxFileBackend(root=WORKSPACE_PATH) unbound) and
-    # SandboxMiddleware.abefore_agent (binds the live client+session). After binding, a
-    # read under the agent-visible /repo path must hit the absolute /workspace/repo path.
-    be = SandboxFileBackend(root="/workspace")
+async def test_bound_backend_sends_absolute_paths_unchanged(client):
+    be = SandboxFileBackend()
     be.bind(client, "sid")
     client.fs_read.return_value = FsReadResponse(content="x", encoding="utf-8")
-    await be.aread("/repo/pkg/mod.py")
+    await be.aread("/workspace/repo/pkg/mod.py")
     assert client.fs_read.call_args.args[0] == "sid"
     assert client.fs_read.call_args.args[1].path == "/workspace/repo/pkg/mod.py"
 
 
-async def test_awrite_maps_route_relative_to_scratch_abs(backend, client):
+async def test_awrite_sends_absolute_path(backend, client):
     client.fs_write.return_value = FsWriteResponse(ok=True)
-    result = await backend.awrite("/foo.txt", "hello\n")
+    result = await backend.awrite("/workspace/tmp/foo.txt", "hello\n")
     sent = client.fs_write.call_args.args[1]
-    assert sent.path == "/workspace/foo.txt"
+    assert sent.path == "/workspace/tmp/foo.txt"
     assert sent.content == b"hello\n"
-    assert result.error is None and result.path == "/foo.txt"
+    assert result.error is None and result.path == "/workspace/tmp/foo.txt"
 
 
 async def test_aread_returns_filedata(backend, client):
     client.fs_read.return_value = FsReadResponse(content="hi", encoding="utf-8")
-    result = await backend.aread("/foo.txt")
+    result = await backend.aread("/workspace/repo/foo.txt")
     assert result.error is None
     assert result.file_data["content"] == "hi"
     assert result.file_data["encoding"] == "utf-8"
@@ -101,112 +96,107 @@ async def test_aread_returns_filedata(backend, client):
 
 async def test_aread_maps_error(backend, client):
     client.fs_read.return_value = FsReadResponse(error="file_not_found")
-    result = await backend.aread("/missing.txt")
+    result = await backend.aread("/workspace/repo/missing.txt")
     assert result.file_data is None and "file_not_found" in result.error
 
 
-async def test_als_remaps_paths_to_route_relative(backend, client):
+async def test_als_returns_paths_unchanged(backend, client):
     client.fs_ls.return_value = FsLsResponse(
         entries=[FsEntry(path="/workspace/sub", is_dir=True), FsEntry(path="/workspace/f.py", is_dir=False)]
     )
-    result = await backend.als("/")
+    result = await backend.als("/workspace")
     paths = {(e["path"], e["is_dir"]) for e in result.entries}
-    assert ("/sub", True) in paths and ("/f.py", False) in paths
+    assert ("/workspace/sub", True) in paths and ("/workspace/f.py", False) in paths
     assert client.fs_ls.call_args.args[1].path == "/workspace"
 
 
-async def test_agrep_remaps_match_paths(backend, client):
+async def test_agrep_returns_match_paths_unchanged(backend, client):
     client.fs_grep.return_value = FsGrepResponse(matches=[FsGrepMatch(path="/workspace/a.py", line=2, text="x")])
-    result = await backend.agrep("x", path="/", glob=None)
-    assert result.matches[0]["path"] == "/a.py"
+    result = await backend.agrep("x", path="/workspace", glob=None)
+    assert result.matches[0]["path"] == "/workspace/a.py"
     assert result.matches[0]["line"] == 2
 
 
 async def test_aedit_success_and_error(backend, client):
     client.fs_edit.return_value = FsEditResponse(occurrences=2)
-    ok = await backend.aedit("/a.py", "old", "new", replace_all=True)
+    ok = await backend.aedit("/workspace/repo/a.py", "old", "new", replace_all=True)
     assert ok.error is None and ok.occurrences == 2
     client.fs_edit.return_value = FsEditResponse(error="string_not_found")
-    bad = await backend.aedit("/a.py", "nope", "x")
+    bad = await backend.aedit("/workspace/repo/a.py", "nope", "x")
     assert bad.error is not None
 
 
 async def test_delete_and_stat_mode(backend, client):
     client.fs_delete.return_value = FsDeleteResponse(ok=True)
-    assert await backend.delete("/a.py") is True
-    assert client.fs_delete.call_args.args[1].path == "/workspace/a.py"
-    assert await backend.stat_mode("/a.py") == 0o644
+    assert await backend.delete("/workspace/repo/a.py") is True
+    assert client.fs_delete.call_args.args[1].path == "/workspace/repo/a.py"
+    assert await backend.stat_mode("/workspace/repo/a.py") == 0o644
 
 
 async def test_delete_failure_logs_reason(backend, client, caplog):
     client.fs_delete.return_value = FsDeleteResponse(ok=False, error="permission_denied")
     with caplog.at_level("WARNING"):
-        assert await backend.delete("/a.py") is False
+        assert await backend.delete("/workspace/repo/a.py") is False
     assert "permission_denied" in caplog.text
-
-
-# -- error propagation: a soft sandbox failure (200 + error, empty list) must surface --
 
 
 async def test_als_propagates_error(backend, client):
     client.fs_ls.return_value = FsLsResponse(entries=[], error="permission_denied")
-    result = await backend.als("/")
+    result = await backend.als("/workspace")
     assert result.entries is None
     assert result.error is not None and "permission_denied" in result.error
 
 
 async def test_agrep_propagates_error(backend, client):
     client.fs_grep.return_value = FsGrepResponse(matches=[], error="grep_failed")
-    result = await backend.agrep("x", path="/", glob=None)
+    result = await backend.agrep("x", path="/workspace", glob=None)
     assert result.matches is None
     assert result.error is not None and "grep_failed" in result.error
 
 
-async def test_aglob_remaps_and_propagates_error(backend, client):
+async def test_aglob_returns_paths_and_propagates_error(backend, client):
     client.fs_glob.return_value = FsGlobResponse(matches=[FsEntry(path="/workspace/a.py", is_dir=False)])
-    ok = await backend.aglob("*.py", path="/")
+    ok = await backend.aglob("*.py", path="/workspace")
     assert ok.error is None
-    assert ok.matches[0]["path"] == "/a.py"
+    assert ok.matches[0]["path"] == "/workspace/a.py"
     assert client.fs_glob.call_args.args[1].path == "/workspace"
     client.fs_glob.return_value = FsGlobResponse(matches=[], error="bad_glob")
-    bad = await backend.aglob("[", path="/")
+    bad = await backend.aglob("[", path="/workspace")
     assert bad.matches is None and bad.error is not None and "bad_glob" in bad.error
 
 
 async def test_awrite_failure_maps_error(backend, client):
     client.fs_write.return_value = FsWriteResponse(ok=False, error="disk full")
-    r = await backend.awrite("/a.txt", "x")
+    r = await backend.awrite("/workspace/repo/a.txt", "x")
     assert r.path is None and "disk full" in r.error
-    # ok=False with no error string must not be reported as success
     client.fs_write.return_value = FsWriteResponse(ok=False)
-    r2 = await backend.awrite("/a.txt", "x")
+    r2 = await backend.awrite("/workspace/repo/a.txt", "x")
     assert r2.path is None and "unknown sandbox error" in r2.error
 
 
 async def test_aupload_files_ok_and_failure(backend, client):
     client.fs_write.return_value = FsWriteResponse(ok=True)
-    ok = await backend.aupload_files([("/a.txt", b"x")])
-    assert ok[0].path == "/a.txt" and ok[0].error is None
-    assert client.fs_write.call_args.args[1].path == "/workspace/a.txt"
-    # ok=False, error=None must still surface as an error (not silent success)
+    ok = await backend.aupload_files([("/workspace/skills/a.txt", b"x")])
+    assert ok[0].path == "/workspace/skills/a.txt" and ok[0].error is None
+    assert client.fs_write.call_args.args[1].path == "/workspace/skills/a.txt"
     client.fs_write.return_value = FsWriteResponse(ok=False)
-    bad = await backend.aupload_files([("/a.txt", b"x")])
+    bad = await backend.aupload_files([("/workspace/skills/a.txt", b"x")])
     assert bad[0].error == "unknown sandbox error"
 
 
 async def test_adownload_files_branches(backend, client):
     client.fs_read.return_value = FsReadResponse(content="hi", encoding="utf-8")
-    text = await backend.adownload_files(["/a.txt"])
+    text = await backend.adownload_files(["/workspace/repo/a.txt"])
     assert text[0].content == b"hi" and text[0].error is None
 
     client.fs_read.return_value = FsReadResponse(content=base64.b64encode(b"\x00\x01").decode(), encoding="base64")
-    binary = await backend.adownload_files(["/b.bin"])
+    binary = await backend.adownload_files(["/workspace/repo/b.bin"])
     assert binary[0].content == b"\x00\x01"
 
     client.fs_read.return_value = FsReadResponse(error="file_not_found")
-    missing = await backend.adownload_files(["/gone.txt"])
+    missing = await backend.adownload_files(["/workspace/repo/gone.txt"])
     assert missing[0].error == FILE_NOT_FOUND and missing[0].content is None
 
     client.fs_read.return_value = FsReadResponse(error="boom")
-    err = await backend.adownload_files(["/x.txt"])
+    err = await backend.adownload_files(["/workspace/repo/x.txt"])
     assert err[0].error == "boom" and err[0].content is None

--- a/tests/unit_tests/automation/agent/middlewares/test_skills.py
+++ b/tests/unit_tests/automation/agent/middlewares/test_skills.py
@@ -5,8 +5,7 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from langchain.agents.middleware.types import ToolCallRequest
-from langchain_core.messages import AIMessage, HumanMessage, RemoveMessage, ToolMessage
-from langgraph.graph.message import REMOVE_ALL_MESSAGES
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 from langgraph.types import Command
 
 from automation.agent.constants import AGENTS_SKILLS_PATH, CLAUDE_CODE_SKILLS_PATH, CURSOR_SKILLS_PATH, SKILLS_SOURCES
@@ -14,8 +13,6 @@ from automation.agent.middlewares.skills import SKILL_MODE_READ_ONLY, SkillsMidd
 from automation.agent.utils import extract_text_content
 from codebase.base import Scope
 from codebase.repo_config import RepositoryConfig, SlashCommands
-from slash_commands.base import SlashCommand
-from slash_commands.registry import SlashCommandRegistry
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -242,177 +239,40 @@ class TestSkillsMiddleware:
         formatted = middleware._format_skills_list([])
         assert formatted == "(No skills available yet. You can create skills in /skills or /extra/skills)"
 
-    def test_extract_slash_command_requires_human_message(self):
-        middleware = SkillsMiddleware(backend=Mock(), sources=["/skills"])
-        messages = [AIMessage(content="hello")]
-        assert middleware._extract_slash_command(messages, "daiv") is None
+    async def test_abefore_agent_skips_copy_global_skills_in_sandbox_mode(self):
+        """In sandbox mode SkillsMiddleware must NOT upload skills (the sandbox seed provisions them)."""
+        backend = Mock()
+        middleware = SkillsMiddleware(backend=backend, sources=[("/workspace/skills", "Global")], sandbox_enabled=True)
+        state = {"messages": [HumanMessage(content="hi")]}  # no skills_metadata yet
+        runtime = Mock()
 
-    def test_extract_slash_command_skips_blank_content(self):
-        middleware = SkillsMiddleware(backend=Mock(), sources=["/skills"])
-        messages = [HumanMessage(content="  \n\t ")]
-        assert middleware._extract_slash_command(messages, "daiv") is None
+        with (
+            patch.object(middleware, "_copy_global_skills", new_callable=AsyncMock) as mock_copy,
+            patch(
+                "deepagents.middleware.skills.SkillsMiddleware.abefore_agent",
+                new=AsyncMock(return_value={"skills_metadata": []}),
+            ),
+        ):
+            await middleware.abefore_agent(state, runtime, {})
 
-    def test_extract_slash_command_parses_multimodal_content(self):
-        middleware = SkillsMiddleware(backend=Mock(), sources=["/skills"])
-        messages = [
-            HumanMessage(
-                content=[
-                    {"type": "text", "text": "@daiv /help arg1"},
-                    {"type": "image_url", "image_url": {"url": "https://example.com/demo.png"}},
-                ]
-            )
-        ]
-        result = middleware._extract_slash_command(messages, "daiv")
-        assert result is not None
-        assert result.command == "help"
-        assert result.args == ["arg1"]
-        assert result.raw == "@daiv /help arg1"
+        mock_copy.assert_not_called()
 
-    async def test_apply_builtin_slash_commands_executes_command(self):
-        class DemoSlashCommand(SlashCommand):
-            description = "demo"
+    async def test_abefore_agent_runs_copy_global_skills_when_not_sandbox(self):
+        backend = Mock()
+        middleware = SkillsMiddleware(backend=backend, sources=[("/skills", "Global")], sandbox_enabled=False)
+        state = {"messages": [HumanMessage(content="hi")]}
+        runtime = Mock()
 
-            async def execute_for_agent(
-                self,
-                *,
-                args: str,
-                issue_iid: int | None = None,
-                merge_request_id: int | None = None,
-                available_skills: list | None = None,
-                available_subagents: list | None = None,
-            ) -> str:
-                skill_name = available_skills[0]["name"] if available_skills else "none"
-                return f"{args}|{issue_iid}|{merge_request_id}|{skill_name}"
+        with (
+            patch.object(middleware, "_copy_global_skills", new_callable=AsyncMock, return_value=[]) as mock_copy,
+            patch(
+                "deepagents.middleware.skills.SkillsMiddleware.abefore_agent",
+                new=AsyncMock(return_value={"skills_metadata": []}),
+            ),
+        ):
+            await middleware.abefore_agent(state, runtime, {})
 
-        registry = SlashCommandRegistry()
-        registry.register(DemoSlashCommand, "demo", [Scope.GLOBAL])
-
-        middleware = SkillsMiddleware(backend=Mock(), sources=["/skills"])
-        context = Mock()
-        context.bot_username = "daiv"
-        context.scope = Scope.GLOBAL
-        context.repository = Mock(slug="repo-1")
-        context.issue = Mock(iid=101)
-        context.merge_request = Mock(merge_request_id=202)
-
-        with patch("automation.agent.middlewares.skills.slash_command_registry", registry):
-            result = await middleware._apply_builtin_slash_commands(
-                [HumanMessage(content="/demo arg1")], context, [{"name": "skill-one"}]
-            )
-
-        assert result is not None
-        assert result["jump_to"] == "end"
-        assert isinstance(result["messages"][0], AIMessage)
-        assert result["messages"][0].content == "arg1|101|202|skill-one"
-
-    async def test_apply_builtin_slash_commands_drops_history_when_command_resets_thread(self):
-        """Commands flagged ``resets_thread`` must emit ``RemoveMessage(REMOVE_ALL_MESSAGES)``
-        ahead of the result so the turn-final checkpoint write doesn't re-persist prior
-        messages under the same thread_id (regression for /clear)."""
-
-        class ResettingSlashCommand(SlashCommand):
-            description = "reset"
-            resets_thread = True
-
-            async def execute_for_agent(
-                self,
-                *,
-                args: str,
-                issue_iid: int | None = None,
-                merge_request_id: int | None = None,
-                available_skills: list | None = None,
-                available_subagents: list | None = None,
-            ) -> str:
-                return "done"
-
-        registry = SlashCommandRegistry()
-        registry.register(ResettingSlashCommand, "reset", [Scope.GLOBAL])
-
-        middleware = SkillsMiddleware(backend=Mock(), sources=["/skills"])
-        context = Mock()
-        context.bot_username = "daiv"
-        context.scope = Scope.GLOBAL
-        context.repository = Mock(slug="repo-1")
-        context.issue = None
-        context.merge_request = None
-
-        with patch("automation.agent.middlewares.skills.slash_command_registry", registry):
-            result = await middleware._apply_builtin_slash_commands(
-                [HumanMessage(content="/reset"), AIMessage(content="prior"), HumanMessage(content="/reset")],
-                context,
-                [],
-            )
-
-        assert result is not None
-        assert result["jump_to"] == "end"
-        assert isinstance(result["messages"][0], RemoveMessage)
-        assert result["messages"][0].id == REMOVE_ALL_MESSAGES
-        assert isinstance(result["messages"][1], AIMessage)
-        assert result["messages"][1].content == "done"
-
-    async def test_apply_builtin_slash_commands_returns_error_message_on_failure(self):
-        class FailingSlashCommand(SlashCommand):
-            description = "fail"
-
-            async def execute_for_agent(
-                self,
-                *,
-                args: str,
-                issue_iid: int | None = None,
-                merge_request_id: int | None = None,
-                available_skills: list | None = None,
-                available_subagents: list | None = None,
-            ) -> str:
-                raise RuntimeError("boom")
-
-        registry = SlashCommandRegistry()
-        registry.register(FailingSlashCommand, "fail", [Scope.GLOBAL])
-
-        middleware = SkillsMiddleware(backend=Mock(), sources=["/skills"])
-        context = Mock()
-        context.bot_username = "daiv"
-        context.scope = Scope.GLOBAL
-        context.repository = Mock(slug="repo-1")
-        context.issue = None
-        context.merge_request = None
-
-        with patch("automation.agent.middlewares.skills.slash_command_registry", registry):
-            result = await middleware._apply_builtin_slash_commands(
-                [HumanMessage(content="/fail now")], context, [{"name": "skill-one"}]
-            )
-
-        assert result is not None
-        assert result["jump_to"] == "end"
-        assert isinstance(result["messages"][0], AIMessage)
-        assert result["messages"][0].content == "Failed to execute `/fail now`."
-
-    async def test_apply_builtin_slash_commands_returns_none_for_ambiguous_command(self):
-        class DemoSlashCommand(SlashCommand):
-            description = "demo"
-
-        class OtherSlashCommand(SlashCommand):
-            description = "other"
-
-        DemoSlashCommand.command = "demo"
-        OtherSlashCommand.command = "demo"
-
-        registry = Mock()
-        registry.get_commands.return_value = [DemoSlashCommand, OtherSlashCommand]
-
-        middleware = SkillsMiddleware(backend=Mock(), sources=["/skills"])
-        context = Mock()
-        context.bot_username = "daiv"
-        context.scope = Scope.GLOBAL
-        context.repository = Mock(slug="repo-1")
-        context.issue = None
-        context.merge_request = None
-
-        with patch("automation.agent.middlewares.skills.slash_command_registry", registry):
-            result = await middleware._apply_builtin_slash_commands(
-                [HumanMessage(content="/demo now")], context, [{"name": "skill-one"}]
-            )
-
-        assert result is None
+        mock_copy.assert_called_once()
 
     async def test_skill_tool_reports_missing_skill(self):
         backend = Mock()
@@ -491,27 +351,6 @@ class TestSkillsMiddleware:
         messages = result.update["messages"]
         assert messages[1].content.endswith("\n\n$ARGUMENTS: --flag=1")
 
-    async def test_abefore_agent_skips_slash_commands_when_disabled(self, tmp_path: Path):
-        from deepagents.backends.filesystem import FilesystemBackend
-
-        repo_name = "repoX"
-        builtin = tmp_path / "builtin_skills"
-        (builtin / "skill-one").mkdir(parents=True)
-        (builtin / "skill-one" / "SKILL.md").write_text(_make_skill_md(name="skill-one", description="does one"))
-
-        backend = FilesystemBackend(root_dir=tmp_path, virtual_mode=True)
-        middleware = SkillsMiddleware(backend=backend, sources=["/skills"])
-        runtime = _make_runtime(repo_working_dir=str(tmp_path / repo_name))
-        runtime.context.config = RepositoryConfig(slash_commands=SlashCommands(enabled=False))
-
-        with (
-            patch("automation.agent.middlewares.skills.BUILTIN_SKILLS_PATH", builtin),
-            patch.object(middleware, "_apply_builtin_slash_commands") as mock_apply,
-        ):
-            await middleware.abefore_agent({"messages": [HumanMessage(content="/help")]}, runtime, Mock())
-
-        mock_apply.assert_not_called()
-
     async def test_discovers_skills_from_multiple_sources(self, tmp_path: Path):
         from deepagents.backends.filesystem import FilesystemBackend
 
@@ -549,61 +388,6 @@ class TestSkillsMiddleware:
         assert skills["daiv-skill"]["description"] == "from daiv"
         assert skills["agents-skill"]["description"] == "from agents"
         assert skills["cursor-skill"]["description"] == "from cursor"
-
-    async def test_abefore_agent_forwards_skills_load_errors_through_slash_command_branch(self, tmp_path: Path):
-        """When a slash command short-circuits, skills_load_errors must still surface."""
-        from deepagents.backends.filesystem import FilesystemBackend
-
-        repo_name = "repoX"
-        builtin = tmp_path / "builtin_skills"
-        (builtin / "skill-one").mkdir(parents=True)
-        (builtin / "skill-one" / "SKILL.md").write_text(_make_skill_md(name="skill-one", description="ok"))
-
-        class DemoSlashCommand(SlashCommand):
-            description = "demo"
-
-            async def execute_for_agent(
-                self,
-                *,
-                args: str,
-                issue_iid: int | None = None,
-                merge_request_id: int | None = None,
-                available_skills: list | None = None,
-                available_subagents: list | None = None,
-            ) -> str:
-                return "ran"
-
-        registry = SlashCommandRegistry()
-        registry.register(DemoSlashCommand, "demo", [Scope.GLOBAL])
-
-        backend = FilesystemBackend(root_dir=tmp_path, virtual_mode=True)
-        middleware = SkillsMiddleware(backend=backend, sources=["/skills", f"/{repo_name}/.agents/skills"])
-        runtime = _make_runtime(repo_working_dir=str(tmp_path / repo_name))
-        runtime.context.config = RepositoryConfig()
-
-        upstream_update = {
-            "skills_metadata": [],
-            "skills_load_errors": [f"Cannot load skills from '/{repo_name}/.agents/skills': permission_denied"],
-        }
-
-        with (
-            patch("automation.agent.middlewares.skills.BUILTIN_SKILLS_PATH", builtin),
-            patch("automation.agent.middlewares.skills.slash_command_registry", registry),
-            patch(
-                "automation.agent.middlewares.skills.DeepAgentsSkillsMiddleware.abefore_agent",
-                AsyncMock(return_value=upstream_update),
-            ),
-        ):
-            result = await middleware.abefore_agent(
-                {"messages": [HumanMessage(content="@daiv-bot /demo")]}, runtime, Mock()
-            )
-
-        assert result is not None
-        assert result["jump_to"] == "end"
-        # Errors from the missing source must be carried through.
-        assert "skills_load_errors" in result
-        assert result["skills_load_errors"]
-        assert any(".agents/skills" in err for err in result["skills_load_errors"])
 
     async def test_abefore_agent_forwards_skills_load_errors_through_clear_skill_mode_branch(self, tmp_path: Path):
         """When clear-skill-mode merges into the return, skills_load_errors must survive."""
@@ -648,68 +432,6 @@ class TestSkillsMiddleware:
         assert result.get("active_skill_mode") is None
         assert "skills_load_errors" in result
         assert result["skills_load_errors"]
-        assert any(".agents/skills" in err for err in result["skills_load_errors"])
-
-    async def test_abefore_agent_forwards_skills_load_errors_with_clear_mode_and_slash_command(self, tmp_path: Path):
-        """All three signals must merge: slash-command short-circuit, clear-skill-mode, AND load errors."""
-        from deepagents.backends.filesystem import FilesystemBackend
-
-        repo_name = "repoX"
-        builtin = tmp_path / "builtin_skills"
-        (builtin / "skill-one").mkdir(parents=True)
-        (builtin / "skill-one" / "SKILL.md").write_text(_make_skill_md(name="skill-one", description="ok"))
-
-        class DemoSlashCommand(SlashCommand):
-            description = "demo"
-
-            async def execute_for_agent(
-                self,
-                *,
-                args: str,
-                issue_iid: int | None = None,
-                merge_request_id: int | None = None,
-                available_skills: list | None = None,
-                available_subagents: list | None = None,
-            ) -> str:
-                return "ran"
-
-        registry = SlashCommandRegistry()
-        registry.register(DemoSlashCommand, "demo", [Scope.GLOBAL])
-
-        backend = FilesystemBackend(root_dir=tmp_path, virtual_mode=True)
-        middleware = SkillsMiddleware(backend=backend, sources=["/skills", f"/{repo_name}/.agents/skills"])
-        runtime = _make_runtime(repo_working_dir=str(tmp_path / repo_name))
-        runtime.context.config = RepositoryConfig()
-
-        # Active read-only mode plus a user follow-up message that also invokes a slash command.
-        state = {
-            "active_skill_mode": SKILL_MODE_READ_ONLY,
-            "messages": [
-                HumanMessage(content="run /plan"),
-                AIMessage(content="planned"),
-                HumanMessage(content="@daiv-bot /demo proceed"),
-            ],
-        }
-        upstream_update = {
-            "skills_metadata": [],
-            "skills_load_errors": [f"Cannot load skills from '/{repo_name}/.agents/skills': permission_denied"],
-        }
-
-        with (
-            patch("automation.agent.middlewares.skills.BUILTIN_SKILLS_PATH", builtin),
-            patch("automation.agent.middlewares.skills.slash_command_registry", registry),
-            patch(
-                "automation.agent.middlewares.skills.DeepAgentsSkillsMiddleware.abefore_agent",
-                AsyncMock(return_value=upstream_update),
-            ),
-        ):
-            result = await middleware.abefore_agent(state, runtime, Mock())
-
-        assert result is not None
-        assert result["jump_to"] == "end"
-        # Both the clear-mode signal AND the load errors must survive through the slash-command return.
-        assert result.get("active_skill_mode") is None
-        assert "skills_load_errors" in result
         assert any(".agents/skills" in err for err in result["skills_load_errors"])
 
     def test_system_prompt_renders_skills_load_warnings(self):

--- a/tests/unit_tests/automation/agent/middlewares/test_slash_commands.py
+++ b/tests/unit_tests/automation/agent/middlewares/test_slash_commands.py
@@ -1,0 +1,232 @@
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from langchain_core.messages import AIMessage, HumanMessage
+from langgraph.graph.message import REMOVE_ALL_MESSAGES
+
+from automation.agent.middlewares.slash_commands import SlashCommandMiddleware, _load_global_skill_metadata
+from codebase.base import Scope
+from slash_commands.parser import SlashCommandCommand
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _write_skill(root: Path, name: str, description: str) -> None:
+    d = root / name
+    d.mkdir(parents=True)
+    (d / "SKILL.md").write_text(f"---\nname: {name}\ndescription: {description}\n---\n\nbody\n", encoding="utf-8")
+
+
+def test_load_global_skill_metadata_reads_builtin_and_custom(tmp_path: Path):
+    builtin = tmp_path / "builtin"
+    custom = tmp_path / "custom"
+    _write_skill(builtin, "code-review", "Review a diff")
+    _write_skill(custom, "deploy", "Deploy the app")
+
+    with (
+        patch("automation.agent.middlewares.slash_commands.BUILTIN_SKILLS_PATH", builtin),
+        patch("automation.agent.middlewares.slash_commands.agent_settings") as settings,
+    ):
+        settings.CUSTOM_SKILLS_PATH = custom
+        skills = _load_global_skill_metadata()
+
+    by_name = {s["name"]: s["description"] for s in skills}
+    assert by_name["code-review"] == "Review a diff"
+    assert by_name["deploy"] == "Deploy the app"
+
+
+def test_load_global_skill_metadata_custom_overrides_builtin(tmp_path: Path):
+    builtin = tmp_path / "builtin"
+    custom = tmp_path / "custom"
+    _write_skill(builtin, "shared", "builtin version")
+    _write_skill(custom, "shared", "custom version")
+
+    with (
+        patch("automation.agent.middlewares.slash_commands.BUILTIN_SKILLS_PATH", builtin),
+        patch("automation.agent.middlewares.slash_commands.agent_settings") as settings,
+    ):
+        settings.CUSTOM_SKILLS_PATH = custom
+        skills = _load_global_skill_metadata()
+
+    by_name = {s["name"]: s["description"] for s in skills}
+    assert by_name["shared"] == "custom version"
+
+
+def test_load_global_skill_metadata_skips_missing_custom_dir(tmp_path: Path):
+    builtin = tmp_path / "builtin"
+    _write_skill(builtin, "only-builtin", "x")
+
+    with (
+        patch("automation.agent.middlewares.slash_commands.BUILTIN_SKILLS_PATH", builtin),
+        patch("automation.agent.middlewares.slash_commands.agent_settings") as settings,
+    ):
+        settings.CUSTOM_SKILLS_PATH = tmp_path / "does-not-exist"
+        skills = _load_global_skill_metadata()
+
+    assert [s["name"] for s in skills] == ["only-builtin"]
+
+
+def _runtime(*, scope=Scope.GLOBAL, bot_username="daiv", slash_enabled=True):
+    rt = MagicMock()
+    rt.context.config.slash_commands.enabled = slash_enabled
+    rt.context.scope = scope
+    rt.context.bot_username = bot_username
+    rt.context.repository.slug = "group/repo"
+    rt.context.issue = None
+    rt.context.merge_request = None
+    return rt
+
+
+async def test_no_slash_command_returns_none():
+    mw = SlashCommandMiddleware(subagents=[])
+    state = {"messages": [HumanMessage(content="just a question")]}
+    assert await mw.abefore_agent(state, _runtime(), {}) is None
+
+
+async def test_disabled_slash_commands_short_circuits():
+    mw = SlashCommandMiddleware(subagents=[])
+    state = {"messages": [HumanMessage(content="/help")]}
+    assert await mw.abefore_agent(state, _runtime(slash_enabled=False), {}) is None
+
+
+async def test_executes_builtin_command_and_jumps_to_end():
+    mw = SlashCommandMiddleware(subagents=[])
+    command = MagicMock()
+    command.resets_thread = False
+    command.execute_for_agent = AsyncMock(return_value="help text")
+    command_cls = MagicMock(return_value=command)
+
+    state = {"messages": [HumanMessage(content="/help")]}
+    with (
+        patch.object(
+            mw, "_extract_slash_command", return_value=SlashCommandCommand(raw="/help", command="help", args=[])
+        ),
+        patch("automation.agent.middlewares.slash_commands.slash_command_registry") as registry,
+        patch(
+            "automation.agent.middlewares.slash_commands._load_global_skill_metadata",
+            return_value=[{"name": "x", "description": "d"}],
+        ),
+    ):
+        registry.get_commands.return_value = [command_cls]
+        result = await mw.abefore_agent(state, _runtime(), {})
+
+    assert result["jump_to"] == "end"
+    assert isinstance(result["messages"][-1], AIMessage)
+    assert result["messages"][-1].content == "help text"
+    # A non-resetting command must NOT touch active_skill_mode (SkillsMiddleware clears it on follow-up).
+    assert "active_skill_mode" not in result
+    # /help got the disk-loaded global skills
+    assert command.execute_for_agent.await_args.kwargs["available_skills"] == [{"name": "x", "description": "d"}]
+    assert command.execute_for_agent.await_args.kwargs["available_subagents"] == []
+
+
+async def test_resets_thread_prepends_remove_all():
+    mw = SlashCommandMiddleware(subagents=[])
+    command = MagicMock()
+    command.resets_thread = True
+    command.execute_for_agent = AsyncMock(return_value="cleared")
+    command_cls = MagicMock(return_value=command)
+
+    state = {"messages": [HumanMessage(content="/clear")]}
+    with (
+        patch.object(
+            mw, "_extract_slash_command", return_value=SlashCommandCommand(raw="/clear", command="clear", args=[])
+        ),
+        patch("automation.agent.middlewares.slash_commands.slash_command_registry") as registry,
+        patch("automation.agent.middlewares.slash_commands._load_global_skill_metadata", return_value=[]),
+    ):
+        registry.get_commands.return_value = [command_cls]
+        result = await mw.abefore_agent(state, _runtime(scope=Scope.ISSUE), {})
+
+    assert result["jump_to"] == "end"
+    assert getattr(result["messages"][0], "id", None) == REMOVE_ALL_MESSAGES
+    # A thread reset must also clear active_skill_mode, else a read-only skill stays stuck on the
+    # fresh thread (history is wiped, so SkillsMiddleware's clear-on-followup can never fire).
+    assert result["active_skill_mode"] is None
+
+
+async def test_command_failure_jumps_to_end_with_error_message():
+    mw = SlashCommandMiddleware(subagents=[])
+    command = MagicMock()
+    command.execute_for_agent = AsyncMock(side_effect=RuntimeError("boom"))
+    command_cls = MagicMock(return_value=command)
+
+    state = {"messages": [HumanMessage(content="/help")]}
+    with (
+        patch.object(
+            mw, "_extract_slash_command", return_value=SlashCommandCommand(raw="/help", command="help", args=[])
+        ),
+        patch("automation.agent.middlewares.slash_commands.slash_command_registry") as registry,
+        patch("automation.agent.middlewares.slash_commands._load_global_skill_metadata", return_value=[]),
+    ):
+        registry.get_commands.return_value = [command_cls]
+        result = await mw.abefore_agent(state, _runtime(), {})
+
+    assert result["jump_to"] == "end"
+    assert "Failed to execute `/help`." in result["messages"][-1].content
+
+
+async def test_unknown_command_falls_through_without_jump():
+    """An unregistered command must NOT short-circuit — it falls through so the agent handles it."""
+    mw = SlashCommandMiddleware(subagents=[])
+    command = MagicMock()
+    command.execute_for_agent = AsyncMock()
+    state = {"messages": [HumanMessage(content="/nope")]}
+    with (
+        patch.object(
+            mw, "_extract_slash_command", return_value=SlashCommandCommand(raw="/nope", command="nope", args=[])
+        ),
+        patch("automation.agent.middlewares.slash_commands.slash_command_registry") as registry,
+    ):
+        registry.get_commands.return_value = []
+        result = await mw.abefore_agent(state, _runtime(), {})
+
+    assert result is None
+    command.execute_for_agent.assert_not_awaited()
+
+
+async def test_ambiguous_command_falls_through_without_executing():
+    """More than one command for the same name is ambiguous — fall through, do not execute either."""
+    mw = SlashCommandMiddleware(subagents=[])
+    command = MagicMock()
+    command.execute_for_agent = AsyncMock()
+    state = {"messages": [HumanMessage(content="/demo")]}
+    with (
+        patch.object(
+            mw, "_extract_slash_command", return_value=SlashCommandCommand(raw="/demo", command="demo", args=[])
+        ),
+        patch("automation.agent.middlewares.slash_commands.slash_command_registry") as registry,
+    ):
+        registry.get_commands.return_value = [MagicMock(command="demo"), MagicMock(command="demo")]
+        result = await mw.abefore_agent(state, _runtime(), {})
+
+    assert result is None
+    command.execute_for_agent.assert_not_awaited()
+
+
+def test_extract_slash_command_requires_human_message():
+    mw = SlashCommandMiddleware(subagents=[])
+    assert mw._extract_slash_command([AIMessage(content="hello")], "daiv") is None
+
+
+def test_extract_slash_command_skips_blank_content():
+    mw = SlashCommandMiddleware(subagents=[])
+    assert mw._extract_slash_command([HumanMessage(content="  \n\t ")], "daiv") is None
+
+
+def test_extract_slash_command_parses_multimodal_content():
+    mw = SlashCommandMiddleware(subagents=[])
+    messages = [
+        HumanMessage(
+            content=[
+                {"type": "text", "text": "@daiv /help arg1"},
+                {"type": "image_url", "image_url": {"url": "https://example.com/demo.png"}},
+            ]
+        )
+    ]
+    result = mw._extract_slash_command(messages, "daiv")
+    assert result is not None
+    assert result.command == "help"
+    assert result.args == ["arg1"]
+    assert result.raw == "@daiv /help arg1"

--- a/tests/unit_tests/automation/agent/test_graph_construction.py
+++ b/tests/unit_tests/automation/agent/test_graph_construction.py
@@ -40,3 +40,57 @@ def test_graph_uses_fallback_thinking_level_standalone():
     assert "site_settings.agent_fallback_thinking_level or" not in src, (
         "graph.py must NOT coalesce agent_fallback_thinking_level to another value"
     )
+
+
+def test_graph_constructs_sandbox_backend_without_root():
+    src = inspect.getsource(graph_module)
+    assert "SandboxFileBackend()" in src, (
+        "graph.py must construct SandboxFileBackend() with no root — the agent uses sandbox-absolute paths"
+    )
+    assert "SandboxFileBackend(root=" not in src, "graph.py must NOT pass a root to SandboxFileBackend (pass-through)"
+
+
+def test_graph_sandbox_global_skills_source_is_workspace_skills():
+    src = inspect.getsource(graph_module)
+    # In sandbox mode the global-skills discovery source must be the real sandbox dir,
+    # not the route-relative "/skills" used by the disk-backed composite.
+    assert "global_skills_source = SKILLS_PATH" in src, (
+        "graph.py sandbox branch must use SKILLS_PATH (/workspace/skills) as the global-skills source"
+    )
+    assert "global_skills_source = GLOBAL_SKILLS_PATH" in src, (
+        "graph.py non-sandbox branch must keep GLOBAL_SKILLS_PATH (/skills) as the global-skills source"
+    )
+
+
+def test_middleware_order_slash_then_sandbox_then_skills():
+    src = inspect.getsource(graph_module)
+    # SlashCommandMiddleware must run before SandboxMiddleware (so /clear etc. don't start a sandbox),
+    # and SkillsMiddleware must run AFTER SandboxMiddleware (so the backend is bound + seeded before
+    # discovery reads it).
+    slash = src.index("SlashCommandMiddleware(")
+    sandbox = src.index("SandboxMiddleware(backend=backend, agent_root=agent_root)")
+    skills = src.index("SkillsMiddleware(")
+    assert slash < sandbox < skills, "order must be SlashCommandMiddleware -> SandboxMiddleware -> SkillsMiddleware"
+
+
+def _balanced_call_args(src: str, callee: str) -> str:
+    """Return the argument text inside ``callee(...)`` via balanced-paren matching."""
+    start = src.index(callee) + len(callee)
+    depth, i = 1, start
+    while i < len(src) and depth > 0:
+        depth += {"(": 1, ")": -1}.get(src[i], 0)
+        i += 1
+    return src[start : i - 1]
+
+
+def test_skills_middleware_receives_sandbox_enabled_flag():
+    src = inspect.getsource(graph_module)
+    # Assert the flag is passed INSIDE the SkillsMiddleware(...) call, not just somewhere in the
+    # file (it also appears on the subagent factory calls), so this guards the real wiring.
+    skills_call = _balanced_call_args(src, "SkillsMiddleware(")
+    assert "sandbox_enabled=_sandbox_enabled" in skills_call, "SkillsMiddleware must receive the sandbox_enabled flag"
+
+
+def test_slash_command_middleware_receives_subagents():
+    src = inspect.getsource(graph_module)
+    assert "SlashCommandMiddleware(subagents=subagents)" in src

--- a/tests/unit_tests/automation/agent/tools/test_git_publish.py
+++ b/tests/unit_tests/automation/agent/tools/test_git_publish.py
@@ -32,7 +32,7 @@ class _FakeClient:
             if needle in command:
                 code, out = c, o
                 break
-        return RunCommandsResponse(results=[RunCommandResult(command=command, output=out, exit_code=code)], patch=None)
+        return RunCommandsResponse(results=[RunCommandResult(command=command, output=out, exit_code=code)])
 
     def ran(self, needle: str) -> bool:
         return any(needle in command for command in self.commands)

--- a/tests/unit_tests/codebase/test_git_manager.py
+++ b/tests/unit_tests/codebase/test_git_manager.py
@@ -77,9 +77,7 @@ class FakeSandboxClient:
             if needle in command:
                 exit_code, output = code, out
                 break
-        return RunCommandsResponse(
-            results=[RunCommandResult(command=command, output=output, exit_code=exit_code)], patch=None
-        )
+        return RunCommandsResponse(results=[RunCommandResult(command=command, output=output, exit_code=exit_code)])
 
     def ran(self, needle: str) -> bool:
         return any(needle in command for command in self.commands)
@@ -427,7 +425,7 @@ async def test_local_git_check_raises_on_nonzero_exit(tmp_path: Path) -> None:
 async def test_sandbox_empty_results_raises_runtime_error() -> None:
     class _EmptyClient:
         async def run_commands(self, session_id, request) -> RunCommandsResponse:  # noqa: ARG002
-            return RunCommandsResponse(results=[], patch=None)
+            return RunCommandsResponse(results=[])
 
     gm = GitManager(client=_EmptyClient(), session_id="sid")  # type: ignore[arg-type]
     with pytest.raises(RuntimeError, match="no result"):

--- a/tests/unit_tests/codebase/test_utils.py
+++ b/tests/unit_tests/codebase/test_utils.py
@@ -2,13 +2,7 @@ import pytest
 from langchain_core.messages import AIMessage, HumanMessage
 
 from codebase.base import Discussion, Note, NoteableType, Scope, User
-from codebase.utils import (
-    compute_thread_id,
-    discussion_has_daiv_mentions,
-    files_changed_from_patch,
-    note_mentions_daiv,
-    notes_to_messages,
-)
+from codebase.utils import compute_thread_id, discussion_has_daiv_mentions, note_mentions_daiv, notes_to_messages
 from core.constants import BOT_NAME
 
 
@@ -261,47 +255,6 @@ class TestDiscussionHasDAIVMentions:
 
         discussion = Discussion(id="discussion_1", notes=notes)
         assert discussion_has_daiv_mentions(discussion, current_user) is True
-
-
-class TestFilesChangedFromPatch:
-    """Patch-parsing covers every op the rail needs to surface for bash edits."""
-
-    def test_empty_or_none_returns_empty_list(self):
-        assert files_changed_from_patch(None) == []
-        assert files_changed_from_patch("") == []
-        assert files_changed_from_patch("   \n") == []
-
-    def test_modified_file(self):
-        patch = (
-            "diff --git a/daiv/foo.py b/daiv/foo.py\n"
-            "index 1111111..2222222 100644\n"
-            "--- a/daiv/foo.py\n"
-            "+++ b/daiv/foo.py\n"
-            "@@ -1 +1 @@\n-old\n+new\n"
-        )
-        assert files_changed_from_patch(patch) == [{"path": "daiv/foo.py", "op": "modified"}]
-
-    def test_added_and_deleted(self):
-        patch = (
-            "diff --git a/new.txt b/new.txt\n"
-            "new file mode 100644\n"
-            "--- /dev/null\n"
-            "+++ b/new.txt\n"
-            "@@ -0,0 +1 @@\n+hi\n"
-            "diff --git a/old.txt b/old.txt\n"
-            "deleted file mode 100644\n"
-            "--- a/old.txt\n"
-            "+++ /dev/null\n"
-            "@@ -1 +0,0 @@\n-bye\n"
-        )
-        assert files_changed_from_patch(patch) == [
-            {"path": "new.txt", "op": "added"},
-            {"path": "old.txt", "op": "deleted"},
-        ]
-
-    def test_rename_carries_from_path(self):
-        patch = "diff --git a/src/a.py b/src/b.py\nsimilarity index 100%\nrename from src/a.py\nrename to src/b.py\n"
-        assert files_changed_from_patch(patch) == [{"path": "src/b.py", "op": "renamed", "from_path": "src/a.py"}]
 
 
 class TestComputeThreadId:

--- a/tests/unit_tests/core/sandbox/test_schemas.py
+++ b/tests/unit_tests/core/sandbox/test_schemas.py
@@ -23,3 +23,15 @@ def test_start_session_request_no_ephemeral():
     from core.sandbox.schemas import StartSessionRequest
 
     assert "ephemeral" not in StartSessionRequest.model_fields
+
+
+def test_start_session_request_no_extract_patch():
+    from core.sandbox.schemas import StartSessionRequest
+
+    assert "extract_patch" not in StartSessionRequest.model_fields
+
+
+def test_run_commands_response_no_patch():
+    from core.sandbox.schemas import RunCommandsResponse
+
+    assert "patch" not in RunCommandsResponse.model_fields


### PR DESCRIPTION
## Summary

Adds an `output_file` redirect to the agent's `gitlab` and `gh` tools so the **full** result of a platform tool call can be written to the sandbox filesystem (`/workspace`) and then piped to `jq`/scripts via `bash` — instead of the agent transcribing tool output token-by-token into a command (wasteful, error-prone, capped at 2000 lines).

- **`output_file` param** on both tools: writes the full untruncated output to a validated `/workspace` path and returns a compact confirmation (path + byte/line counts + ≤25-line preview) instead of the content. Written via a short-lived `DAIVSandboxClient.fs_write`, mirroring the `open_git_manager` pattern.
- **Format:** gitlab forces `--output json` on redirect (`output_mode` becomes moot) so the file is `jq`-ready — **except** `project-job trace`, which stays raw log text. gh writes verbatim; the agent adds `--json <fields>` itself for structured output.
- **Auto-eviction fallback:** when no `output_file` is given but output exceeds the 2000-line inline cap, the full output is spilled verbatim to `/workspace/tmp/<tool>-<resource>-<action>-<uuid>.txt` (with an agent-facing note) instead of being truncated into context.
- **Graceful degradation:** when the sandbox is disabled (no session), `output_file` falls back to inline output + a note; auto-eviction no-ops to truncation. Write failures surface to the agent (explicit redirect) or fall back to truncation with a note (auto-evict).
- **Pagination** stays agent-controlled (`--get-all`/`--per-page`/`--limit`), documented in the tool descriptions alongside worked `jq` examples.

Design spec and plan were produced via brainstorming/writing-plans (local, gitignored under `docs/superpowers/`).

## Test Plan

- [x] `uv run pytest tests/unit_tests/automation/agent/middlewares/test_git_platform.py` — 44 passing (custom logic only; `fs_write` mocked)
- [x] `make test` — full unit suite green (2836 passed), no regressions
- [x] `make lint` clean; `make lint-typing` introduces no new diagnostics vs base
- [ ] Manual: agent runs e.g. `gitlab("project-merge-request list --get-all", output_file="/workspace/tmp/mrs.json")` then `bash` `jq` over the file

## Review notes

Built batch-by-batch with two-stage review (spec + code quality) per batch, a final whole-feature review, and a 4-aspect pr-review-toolkit pass (code/tests/comments/errors) + simplify — all findings addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)