### PR TITLE
refactor(sandbox): make the bound file backend the run's single session handle

### DIFF
--- a/daiv/automation/agent/git_manager.py
+++ b/daiv/automation/agent/git_manager.py
@@ -10,12 +10,11 @@ from typing import TYPE_CHECKING
 from git import GitCommandError
 
 from automation.agent.constants import REPO_PATH
-from core.sandbox.schemas import RunCommandsRequest
 
 if TYPE_CHECKING:
     from git import Repo
 
-    from core.sandbox.client import DAIVSandboxClient
+    from automation.agent.middlewares.file_system import SandboxFileBackend
 
 logger = logging.getLogger("daiv.tools")
 
@@ -56,9 +55,9 @@ class RepoStatus:
 class GitManager:
     """Run git operations against a repository in one of two mutually-exclusive modes:
 
-    - **Sandbox mode** (``client`` + ``session_id``): git runs *in the sandbox* via
-      ``run_commands`` in ``repo_path`` (``/workspace/repo``). Used for sandbox-enabled
-      runs, where the agent's changes are sandbox-authoritative (no local copy).
+    - **Sandbox mode** (``sandbox_backend``): git runs *in the sandbox* via the bound
+      backend's ``run_commands`` in ``repo_path`` (``/workspace/repo``). Used for
+      sandbox-enabled runs, where the agent's changes are sandbox-authoritative (no local copy).
     - **Local mode** (``repo``): git runs as a subprocess against a GitPython clone's
       working tree. Used for sandbox-disabled / repoless runs, where changes live on disk.
 
@@ -67,8 +66,7 @@ class GitManager:
 
     Args:
         repo: GitPython repo for local mode.
-        client: Sandbox client for sandbox mode.
-        session_id: Sandbox session id (required with ``client``).
+        sandbox_backend: The run's bound :class:`SandboxFileBackend` for sandbox mode.
         repo_path: Repo path inside the sandbox (defaults to ``REPO_PATH``).
     """
 
@@ -78,19 +76,15 @@ class GitManager:
         self,
         repo: Repo | None = None,
         *,
-        client: DAIVSandboxClient | None = None,
-        session_id: str | None = None,
+        sandbox_backend: SandboxFileBackend | None = None,
         repo_path: str | None = None,
     ) -> None:
-        if (repo is None) == (client is None):
-            raise ValueError("GitManager requires exactly one of `repo` (local) or `client` (sandbox).")
-        if client is not None and not session_id:
-            raise ValueError("GitManager sandbox mode requires a non-empty session_id.")
+        if (repo is None) == (sandbox_backend is None):
+            raise ValueError("GitManager requires exactly one of `repo` (local) or `sandbox_backend` (sandbox).")
         if repo_path is None:
             repo_path = REPO_PATH
         self.repo = repo
-        self._client = client
-        self._session_id = session_id
+        self._sandbox_backend = sandbox_backend
         self._repo_path = repo_path
 
     @classmethod
@@ -103,30 +97,31 @@ class GitManager:
         return cls(repo=repo)
 
     @classmethod
-    def for_sandbox(cls, client: DAIVSandboxClient, session_id: str, *, repo_path: str | None = None) -> GitManager:
+    def for_sandbox(cls, sandbox_backend: SandboxFileBackend, *, repo_path: str | None = None) -> GitManager:
         """Sandbox-mode manager that runs git in the session's ``repo_path`` (``/workspace/repo``).
 
-        Preferred over ``GitManager(client=..., session_id=...)``: the required ``session_id`` is
-        positional, so a sandbox manager can't be built without one.
+        Takes the run's already-bound :class:`SandboxFileBackend` — the single session handle.
+        The backend's ``_require_bound`` guard surfaces an unbound-session programming error on
+        the first command, so no session id is threaded here.
         """
-        return cls(client=client, session_id=session_id, repo_path=repo_path)
+        return cls(sandbox_backend=sandbox_backend, repo_path=repo_path)
 
     # -- git invocation ------------------------------------------------------
     async def _git(self, *args: str, check: bool = True) -> _GitResult:
         """Run one git command in the repo. Raises ``GitCommandError`` on a non-zero
         exit when ``check`` is True; otherwise returns the result for the caller to inspect.
         """
-        result = await (self._git_sandbox(args) if self._client is not None else self._git_local(args))
+        result = await (self._git_sandbox(args) if self._sandbox_backend is not None else self._git_local(args))
         if check and result.exit_code != 0:
             raise GitCommandError(["git", *args], result.exit_code, result.output)
         return result
 
     async def _git_sandbox(self, args: tuple[str, ...]) -> _GitResult:
-        client, session_id = self._client, self._session_id
-        if client is None or session_id is None:  # pragma: no cover - guaranteed by __init__
+        backend = self._sandbox_backend
+        if backend is None:  # pragma: no cover - guaranteed by __init__
             raise RuntimeError("GitManager is not in sandbox mode")
         command = " ".join(_shell_quote(token) for token in ("git", "-C", self._repo_path, *args))
-        response = await client.run_commands(session_id, RunCommandsRequest(commands=[command], fail_fast=True))
+        response = await backend.run_commands([command], fail_fast=True)
         if not response.results:
             # The sandbox always returns one result per command; an empty list is a wire-level
             # anomaly. Fail with context rather than a bare IndexError on ``results[0]``.
@@ -159,14 +154,11 @@ class GitManager:
         """
         if not commands:
             return []
-        if self._client is not None:
-            client, session_id = self._client, self._session_id
-            if session_id is None:  # pragma: no cover - guaranteed by __init__
-                raise RuntimeError("GitManager is not in sandbox mode")
+        if self._sandbox_backend is not None:
             cmd_strs = [
                 " ".join(_shell_quote(tok) for tok in ("git", "-C", self._repo_path, *args)) for args in commands
             ]
-            response = await client.run_commands(session_id, RunCommandsRequest(commands=cmd_strs, fail_fast=False))
+            response = await self._sandbox_backend.run_commands(cmd_strs, fail_fast=False)
             if len(response.results) != len(commands):
                 raise RuntimeError(f"Sandbox returned {len(response.results)} results for {len(commands)} git commands")
             return [_GitResult(exit_code=r.exit_code, output=r.output) for r in response.results]

--- a/daiv/automation/agent/git_utils.py
+++ b/daiv/automation/agent/git_utils.py
@@ -10,24 +10,21 @@ if TYPE_CHECKING:
 
     from git import Repo
 
-    from core.sandbox.client import DAIVSandboxClient
+    from automation.agent.middlewares.file_system import SandboxFileBackend
 
 
 @asynccontextmanager
 async def open_git_manager(
-    *, client: DAIVSandboxClient | None = None, session_id: str | None, gitrepo: Repo | None
+    *, sandbox_backend: SandboxFileBackend | None, gitrepo: Repo | None
 ) -> AsyncIterator[GitManager]:
     """Yield a :class:`GitManager` matched to the run's mode.
 
-    Sandbox-enabled runs (a ``session_id`` is present) get a **sandbox-mode** manager bound to the
-    injected run-scoped ``client`` — git runs in ``/workspace/repo`` where the agent's changes are
-    authoritative. The transport is borrowed, not owned: no open/close here, and no per-call
-    fallback — a session id without a client is a wiring error. Sandbox-disabled / repoless runs
-    (no session) get a **local-mode** manager over the GitPython clone.
+    Sandbox-enabled runs pass the run's bound :class:`SandboxFileBackend` — git runs in
+    ``/workspace/repo`` where the agent's changes are authoritative. Sandbox-disabled /
+    repoless runs pass ``sandbox_backend=None`` and get a local-mode manager over the
+    GitPython clone.
     """
-    if session_id:
-        if client is None:
-            raise RuntimeError("open_git_manager: sandbox session given but no sandbox client injected.")
-        yield GitManager.for_sandbox(client, session_id)
+    if sandbox_backend is not None:
+        yield GitManager.for_sandbox(sandbox_backend)
     else:
         yield GitManager.for_local(cast("Repo", gitrepo))

--- a/daiv/automation/agent/graph.py
+++ b/daiv/automation/agent/graph.py
@@ -314,7 +314,7 @@ async def create_daiv_agent(
         AnthropicPromptCachingMiddleware(),
         ToolCallLoggingMiddleware(),
         ensure_non_empty_response,
-        GitMiddleware(auto_commit_changes=auto_commit_changes, sandbox_client=run_client),
+        GitMiddleware(auto_commit_changes=auto_commit_changes, sandbox_backend=sandbox_backend),
         GitPlatformMiddleware(git_platform=ctx.git_platform, backend=backend),
         dynamic_daiv_system_prompt,
         *(middleware or []),

--- a/daiv/automation/agent/graph.py
+++ b/daiv/automation/agent/graph.py
@@ -264,6 +264,7 @@ async def create_daiv_agent(
             web_fetch_enabled=_web_fetch_enabled,
             fallback_models=fallback_models,
             client=run_client,
+            sandbox_backend=sandbox_backend,
         ),
         create_explore_subagent(backend),
     ]
@@ -278,6 +279,7 @@ async def create_daiv_agent(
         web_fetch_enabled=_web_fetch_enabled,
         fallback_models=fallback_models,
         client=run_client,
+        sandbox_backend=sandbox_backend,
     )
     subagents.extend(custom_subagents)
 

--- a/daiv/automation/agent/middlewares/file_system.py
+++ b/daiv/automation/agent/middlewares/file_system.py
@@ -40,6 +40,8 @@ from core.sandbox.schemas import (
     FsLsRequest,
     FsReadRequest,
     FsWriteRequest,
+    RunCommandsRequest,
+    RunCommandsResponse,
 )
 
 logger = logging.getLogger("daiv.tools")
@@ -204,7 +206,8 @@ class DAIVCompositeBackend(CompositeBackend):
 
 
 class SandboxFileBackend(BackendProtocol):
-    """Deepagents backend whose files live in a sandbox workspace.
+    """Deepagents backend whose files live in a sandbox workspace, and the run's
+    command-execution handle (``run_commands``).
 
     The agent addresses files by their sandbox-absolute path (``/workspace/repo``,
     ``/workspace/skills``, ``/workspace/tmp``); the backend is a thin pass-through to
@@ -250,6 +253,21 @@ class SandboxFileBackend(BackendProtocol):
         if self._client is None or not self._session_id:
             raise RuntimeError("SandboxFileBackend is not bound to a sandbox session")
         return self._client, self._session_id
+
+    async def run_commands(self, commands: list[str], *, fail_fast: bool) -> RunCommandsResponse:
+        """Run shell commands in the bound session's workspace.
+
+        The run's command-execution handle (used by the ``bash`` tool and sandbox-mode
+        ``GitManager``). A thin pass-through to ``DAIVSandboxClient.run_commands`` — it takes a
+        *list* + ``fail_fast`` (not a single command) so multi-command batches run in one
+        round-trip. Like the other methods here it **raises** on transport/HTTP errors;
+        callers that need graceful degradation (the ``bash`` tool) wrap it.
+
+        Intentionally NOT deepagents' ``SandboxBackendProtocol.aexecute``: implementing that
+        protocol would activate deepagents' always-registered, ungated ``execute`` tool.
+        """
+        client, session_id = self._require_bound()
+        return await client.run_commands(session_id, RunCommandsRequest(commands=commands, fail_fast=fail_fast))
 
     # -- path mapping (identity) --------------------------------------------
     # The sandbox is authoritative and the agent addresses files by their

--- a/daiv/automation/agent/middlewares/git.py
+++ b/daiv/automation/agent/middlewares/git.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
 
     from langgraph.runtime import Runtime
 
-    from core.sandbox.client import DAIVSandboxClient
+    from automation.agent.middlewares.file_system import SandboxFileBackend
 
 
 logger = logging.getLogger("daiv.tools")
@@ -104,9 +104,9 @@ class GitMiddleware(AgentMiddleware[GitState, RuntimeCtx]):
         skip_ci: Whether to prefix the commit with ``[skip ci]``.
         auto_commit_changes: Whether the run publishes its changes at all. When ``False`` the
             middleware is inert.
-        sandbox_client: Run-scoped sandbox client injected by ``create_daiv_agent``; forwarded to
-            :class:`GitChangePublisher` so the turn-end publish runs git inside the sandbox. ``None``
-            for sandbox-disabled / local runs.
+        sandbox_backend: Run's bound :class:`SandboxFileBackend` injected by ``create_daiv_agent``;
+            forwarded to :class:`GitChangePublisher` so the turn-end publish runs git inside the
+            sandbox. ``None`` for sandbox-disabled / local runs.
 
     Example:
         ```python
@@ -131,14 +131,14 @@ class GitMiddleware(AgentMiddleware[GitState, RuntimeCtx]):
         *,
         skip_ci: bool = False,
         auto_commit_changes: bool = True,
-        sandbox_client: DAIVSandboxClient | None = None,
+        sandbox_backend: SandboxFileBackend | None = None,
     ) -> None:
         """
         Initialize the middleware.
         """
         self.skip_ci = skip_ci
         self.auto_commit_changes = auto_commit_changes
-        self._sandbox_client = sandbox_client
+        self._sandbox_backend = sandbox_backend
 
     async def abefore_agent(self, state: GitState, runtime: Runtime[RuntimeCtx]) -> dict[str, Any] | None:
         """
@@ -260,10 +260,8 @@ class GitMiddleware(AgentMiddleware[GitState, RuntimeCtx]):
         if not self.auto_commit_changes:
             return None
 
-        publisher = GitChangePublisher(runtime.context, sandbox_client=self._sandbox_client)
-        outcome = await publisher.publish(
-            session_id=state.get("session_id"), merge_request=state.get("merge_request"), skip_ci=self.skip_ci
-        )
+        publisher = GitChangePublisher(runtime.context, sandbox_backend=self._sandbox_backend)
+        outcome = await publisher.publish(merge_request=state.get("merge_request"), skip_ci=self.skip_ci)
 
         if outcome.merge_request is None:
             return None

--- a/daiv/automation/agent/middlewares/sandbox.py
+++ b/daiv/automation/agent/middlewares/sandbox.py
@@ -24,7 +24,7 @@ from core.conf import settings
 from core.sandbox.client import DAIVSandboxClient  # noqa: TC001
 from core.sandbox.command_parser import CommandParseError, parse_command
 from core.sandbox.command_policy import CommandPolicy, DenialReason, evaluate_command_policy, parse_rule
-from core.sandbox.schemas import RunCommandsRequest, RunCommandsResponse, StartSessionRequest
+from core.sandbox.schemas import RunCommandsResponse, StartSessionRequest
 from core.site_settings import site_settings
 
 if TYPE_CHECKING:
@@ -290,12 +290,14 @@ def _make_global_skills_archive() -> bytes | None:
     return buf.getvalue()
 
 
-async def _run_bash_commands(
-    client: DAIVSandboxClient, commands: list[str], session_id: str
-) -> RunCommandsResponse | None:
-    """Run bash commands in the existing sandbox session using the supplied long-lived client."""
+async def _run_bash_commands(backend: SandboxFileBackend, commands: list[str]) -> RunCommandsResponse | None:
+    """Run bash commands through the run's bound :class:`SandboxFileBackend`.
+
+    The backend raises on transport/HTTP errors; this wrapper degrades them to ``None`` so
+    the bash tool can surface a friendly error instead of crashing the run.
+    """
     try:
-        return await client.run_commands(session_id, RunCommandsRequest(commands=commands, fail_fast=True))
+        return await backend.run_commands(commands, fail_fast=True)
     except httpx.RequestError:
         logger.exception("Unexpected error calling sandbox API.")
         return None
@@ -383,10 +385,10 @@ class SandboxMiddleware(AgentMiddleware):
             if denial_error:
                 return denial_error
 
-            if self._client is None:
-                raise RuntimeError("SandboxMiddleware bash tool invoked before abefore_agent opened the sandbox client")
+            if self._sandbox_backend is None:
+                raise RuntimeError("SandboxMiddleware bash tool invoked before abefore_agent bound the sandbox backend")
 
-            response = await _run_bash_commands(self._client, [command], runtime.state["session_id"])
+            response = await _run_bash_commands(self._sandbox_backend, [command])
             if response is None:
                 return (
                     "error: Sandbox call failed (transport or HTTP error — see server logs). "

--- a/daiv/automation/agent/middlewares/sandbox.py
+++ b/daiv/automation/agent/middlewares/sandbox.py
@@ -5,6 +5,7 @@ import io
 import json
 import logging
 import tarfile
+from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, NotRequired
 
@@ -120,9 +121,9 @@ Result interpretation:
 - Always check each `exit_code` and treat non-zero codes or Python tracebacks in `output` as failures that require investigation or fixes.
 - If the tool returns a plain string starting with `error:` instead of JSON, treat it as a sandbox/tool failure, not as a passing check.
 
-Repeated failure policy:
-- If 2 consecutive commands return the same `error:` string indicating that the bash tool is not working properly, assume command execution is unavailable for this conversation. Do not attempt a third command.
-- After that point, stop invoking `{BASH_TOOL_NAME}`, switch to static reasoning only (code reading/search), and clearly mention that you cannot run commands.
+Infrastructure failure policy:
+- The bash tool reports infrastructure problems (not command results) as a string starting with `error:`. Read it: some say the problem is temporary and invite a single retry of the same command; others say the tool is unavailable for the rest of the conversation. Follow the instruction the error gives you.
+- Stop invoking `{BASH_TOOL_NAME}` once an error says the tool is unavailable, OR once the same `error:` string occurs on two consecutive commands. After that, switch to static reasoning only (code reading/search) and clearly mention that you cannot run commands.
 
 Dedicated-tool failure policy:
 - If a dedicated tool (for example `gitlab`, `gh`, `web_search`, or `web_fetch`) exists for the task, do NOT use bash to reproduce or bypass that tool.
@@ -231,7 +232,7 @@ def _check_command_policy(command: str, runtime: ToolRuntime[RuntimeCtx]) -> str
         "The Git middleware commits and pushes file changes automatically at turn-end "
         "(see the Git context section in the system prompt)."
         if matched.startswith("git ")
-        else " This capability is intentionally unavailable — do not rephrase."
+        else " This capability is intentionally unavailable — do not rephrase or try synonyms."
     )
     return (
         f"error: Command blocked by policy ({reason_label}): "
@@ -290,20 +291,70 @@ def _make_global_skills_archive() -> bytes | None:
     return buf.getvalue()
 
 
-async def _run_bash_commands(backend: SandboxFileBackend, commands: list[str]) -> RunCommandsResponse | None:
+class BashFailure(Enum):
+    """Why a bash invocation produced no result, mapped to the guidance the agent gets.
+
+    The agent only knows what the tool message and system prompt tell it — it has no view of
+    transport details — so the failure is classified here into one of two actionable buckets:
+
+    - ``TRANSIENT``: a momentary transport/server hiccup (no HTTP response, or a retryable status
+      like a timeout/rate-limit/5xx). A retry may succeed.
+    - ``PERMANENT``: the sandbox rejected the call in a way a retry will not fix (auth, session
+      gone, malformed request). The bash tool is unusable for the rest of the run.
+    """
+
+    TRANSIENT = "transient"
+    PERMANENT = "permanent"
+
+
+# Sandbox HTTP statuses a retry might clear (timeout, too-early, rate-limit, and the transient 5xx
+# family). Every other status — auth (401/403), session-gone (404), bad-request (400/422),
+# not-implemented (501) — is permanent: retrying only burns a tool call.
+_TRANSIENT_SANDBOX_STATUS = frozenset({408, 425, 429, 500, 502, 503, 504})
+
+# Agent-facing guidance for a bash call that returned no result. Both deliberately start with
+# `error:` so the agent treats them as infrastructure failures, not command output (per the tool
+# description and system prompt). The TRANSIENT text is kept byte-stable (no status codes, no
+# per-call detail) so the system prompt's "two identical `error:` strings ⇒ stop" backstop still
+# fires when a retry fails the same way.
+_BASH_TRANSIENT_ERROR = (
+    "error: The sandbox did not return a result for this command — a temporary problem reaching it "
+    "interrupted the call, so the command may or may not have run. This is usually transient. "
+    "You may retry this exact command ONCE. If the retry returns this same error, stop using the "
+    "bash tool for the rest of this conversation and tell the user you were unable to run commands."
+)
+
+_BASH_PERMANENT_ERROR = (
+    "error: The bash tool is unavailable for the rest of this conversation. The sandbox rejected "
+    "the call in a way that will not recover by retrying, and no command was executed. Do NOT call "
+    "the bash tool again — further calls will fail the same way."
+)
+
+_BASH_FAILURE_MESSAGES = {BashFailure.TRANSIENT: _BASH_TRANSIENT_ERROR, BashFailure.PERMANENT: _BASH_PERMANENT_ERROR}
+
+
+async def _run_bash_commands(backend: SandboxFileBackend, commands: list[str]) -> RunCommandsResponse | BashFailure:
     """Run bash commands through the run's bound :class:`SandboxFileBackend`.
 
-    The backend raises on transport/HTTP errors; this wrapper degrades them to ``None`` so
-    the bash tool can surface a friendly error instead of crashing the run.
+    On success returns the :class:`RunCommandsResponse`. Degrades only ``httpx`` transport/HTTP
+    errors to a :class:`BashFailure` (classified transient vs. permanent) so the bash tool can hand
+    the agent self-contained guidance — retry once vs. stop using the tool — instead of crashing the
+    run. Other failures are intentionally NOT caught and propagate: a malformed or schema-mismatched
+    200 body (``json.JSONDecodeError`` / ``pydantic.ValidationError``) and an unbound-backend
+    ``RuntimeError`` are wire/programming bugs that should fail loud rather than masquerade as a soft
+    sandbox failure.
     """
     try:
         return await backend.run_commands(commands, fail_fast=True)
     except httpx.RequestError:
-        logger.exception("Unexpected error calling sandbox API.")
-        return None
+        # No HTTP response at all (timeout, connection refused, network blip): the sandbox is
+        # momentarily unreachable, so a retry may connect — transient.
+        logger.exception("Transport error calling sandbox API; treating as transient.")
+        return BashFailure.TRANSIENT
     except httpx.HTTPStatusError as e:
-        logger.exception("Status code %s calling sandbox API: %s", e.response.status_code, e.response.text)
-        return None
+        status = e.response.status_code
+        logger.exception("Status code %s calling sandbox API: %s", status, e.response.text)
+        return BashFailure.TRANSIENT if status in _TRANSIENT_SANDBOX_STATUS else BashFailure.PERMANENT
 
 
 class SandboxState(AgentState):
@@ -338,8 +389,10 @@ class SandboxMiddleware(AgentMiddleware):
         agent_root: Virtual path prefix the agent's filesystem tools see (e.g.
             ``/workspace/repo``); the agent's repo root.
         client: The run-scoped sandbox client opened by ``set_runtime_ctx`` and injected here.
-        sandbox_backend: The concrete ``SandboxFileBackend`` to bind the run's session onto.
-            ``None`` for subagents, which share the parent-bound backend.
+        sandbox_backend: The concrete ``SandboxFileBackend`` the run's session is bound onto and
+            that backs the ``bash`` tool. Subagents receive the *same* instance the parent agent
+            uses (forwarded from ``create_daiv_agent``), so they share the parent-bound backend
+            rather than binding their own.
         close_session: Whether to close the session after the agent finishes the execution
             loop. Set to ``False`` when used in subagents so the parent agent owns session
             lifecycle.
@@ -374,7 +427,7 @@ class SandboxMiddleware(AgentMiddleware):
         self.tools = [self._build_bash_tool()]
 
     def _build_bash_tool(self) -> BaseTool:
-        """Build a bash tool bound to this middleware's per-run sandbox client."""
+        """Build a bash tool that runs commands through this middleware's bound SandboxFileBackend."""
 
         @tool(BASH_TOOL_NAME, description=BASH_TOOL_DESCRIPTION)
         async def bash_tool(
@@ -388,24 +441,22 @@ class SandboxMiddleware(AgentMiddleware):
             if self._sandbox_backend is None:
                 raise RuntimeError("SandboxMiddleware bash tool invoked before abefore_agent bound the sandbox backend")
 
-            response = await _run_bash_commands(self._sandbox_backend, [command])
-            if response is None:
-                return (
-                    "error: Sandbox call failed (transport or HTTP error — see server logs). "
-                    "The bash tool may be unavailable for this run."
-                )
+            result = await _run_bash_commands(self._sandbox_backend, [command])
+            if isinstance(result, BashFailure):
+                return _BASH_FAILURE_MESSAGES[result]
 
             # The sandbox is authoritative: bash mutations already live in /workspace/repo,
             # so there is no local repo to keep in sync here.
-            return json.dumps({"commands": [result.model_dump(mode="json") for result in response.results]})
+            return json.dumps({"commands": [r.model_dump(mode="json") for r in result.results]})
 
         return bash_tool
 
     def _bind_session(self, session_id: str) -> None:
         """Bind the run's session onto the injected SandboxFileBackend (main agent only).
 
-        Subagents pass ``sandbox_backend=None`` because they share the parent's backend, which the
-        parent already bound — so this is a no-op for them.
+        Subagents receive the already-bound parent backend and short-circuit in ``abefore_agent``
+        (``close_session=False`` + ``session_id`` already in state) before reaching this method, so
+        they never re-bind. The ``is not None`` guard below stays defensive regardless.
         """
         if self._sandbox_backend is not None:
             self._sandbox_backend.bind_session(session_id)
@@ -465,8 +516,9 @@ class SandboxMiddleware(AgentMiddleware):
             raise RuntimeError("SandboxMiddleware requires an injected run-scoped sandbox client.")
 
         if not self.close_session and "session_id" in state:
-            # Subagent path: the parent owns the session and already bound the shared backend; our
-            # injected client serves this subagent's bash tool. Nothing to set up.
+            # Subagent path: the parent owns the session and already bound the shared backend (which
+            # this subagent received and uses for its bash tool). Our injected client serves only the
+            # non-None guard above. Nothing to set up.
             return None
 
         prior_session_id = state.get("session_id")

--- a/daiv/automation/agent/publishers.py
+++ b/daiv/automation/agent/publishers.py
@@ -22,8 +22,8 @@ from core.site_settings import site_settings
 from .diff_to_metadata.graph import create_diff_to_metadata_graph
 
 if TYPE_CHECKING:
+    from automation.agent.middlewares.file_system import SandboxFileBackend
     from codebase.context import RuntimeCtx
-    from core.sandbox.client import DAIVSandboxClient
 
 
 logger = logging.getLogger("daiv.tools")
@@ -50,10 +50,10 @@ class ChangePublisher:
     Publisher for changes made by the agent.
     """
 
-    def __init__(self, ctx: RuntimeCtx, *, sandbox_client: DAIVSandboxClient | None = None):
+    def __init__(self, ctx: RuntimeCtx, *, sandbox_backend: SandboxFileBackend | None = None):
         self.ctx = ctx
         self.client = RepoClient.create_instance()
-        self.sandbox_client = sandbox_client
+        self.sandbox_backend = sandbox_backend
 
     @abstractmethod
     async def publish(self, **kwargs) -> Any:
@@ -68,13 +68,7 @@ class GitChangePublisher(ChangePublisher):
     """
 
     async def publish(
-        self,
-        *,
-        session_id: str | None = None,
-        merge_request: MergeRequest | None = None,
-        skip_ci: bool = False,
-        as_draft: bool = False,
-        **kwargs,
+        self, *, merge_request: MergeRequest | None = None, skip_ci: bool = False, as_draft: bool = False, **kwargs
     ) -> PublishOutcome:
         """
         Daiv-direct publish: ensure the run's changes reach a merge request.
@@ -87,9 +81,7 @@ class GitChangePublisher(ChangePublisher):
         protected_branch_fallback_source: str | None = None
         default_branch = cast("str", self.ctx.config.default_branch)
 
-        async with open_git_manager(
-            client=self.sandbox_client, session_id=session_id, gitrepo=self.ctx.gitrepo
-        ) as git_manager:
+        async with open_git_manager(sandbox_backend=self.sandbox_backend, gitrepo=self.ctx.gitrepo) as git_manager:
             snapshot = await git_manager.status_snapshot(
                 base_branch=default_branch,
                 mr_source_branch=merge_request.source_branch if merge_request is not None else None,

--- a/daiv/automation/agent/subagents.py
+++ b/daiv/automation/agent/subagents.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
     from deepagents.backends import BackendProtocol
     from langchain.chat_models import BaseChatModel
 
+    from automation.agent.middlewares.file_system import SandboxFileBackend
     from codebase.context import RuntimeCtx
     from core.sandbox.client import DAIVSandboxClient
 
@@ -55,6 +56,7 @@ def _build_general_purpose_middleware(
     web_fetch_enabled: bool,
     fallback_models: list[BaseChatModel] | None = None,
     client: DAIVSandboxClient | None = None,
+    sandbox_backend: SandboxFileBackend | None = None,
 ) -> list:
     """
     Build the middleware stack for a general-purpose subagent.
@@ -91,7 +93,11 @@ def _build_general_purpose_middleware(
 
     if sandbox_enabled:
         agent_path = Path(runtime.gitrepo.working_dir)
-        middleware.append(SandboxMiddleware(agent_root=f"/{agent_path.name}", client=client, close_session=False))
+        middleware.append(
+            SandboxMiddleware(
+                agent_root=f"/{agent_path.name}", client=client, sandbox_backend=sandbox_backend, close_session=False
+            )
+        )
 
     if fallback_models:
         middleware.append(ModelFallbackMiddleware(*fallback_models))
@@ -108,6 +114,7 @@ def create_general_purpose_subagent(
     web_fetch_enabled: bool = True,
     fallback_models: list[BaseChatModel] | None = None,
     client: DAIVSandboxClient | None = None,
+    sandbox_backend: SandboxFileBackend | None = None,
 ) -> CompiledSubAgent:
     """
     Create the general purpose subagent for the DAIV agent.
@@ -117,7 +124,15 @@ def create_general_purpose_subagent(
         tools=[],
         system_prompt=GENERAL_PURPOSE_SYSTEM_PROMPT,
         middleware=_build_general_purpose_middleware(
-            model, backend, runtime, sandbox_enabled, web_search_enabled, web_fetch_enabled, fallback_models, client
+            model,
+            backend,
+            runtime,
+            sandbox_enabled,
+            web_search_enabled,
+            web_fetch_enabled,
+            fallback_models,
+            client,
+            sandbox_backend,
         ),
         name=GENERAL_PURPOSE_NAME,
     )
@@ -278,6 +293,7 @@ async def load_custom_subagents(
     web_fetch_enabled: bool = True,
     fallback_models: list[BaseChatModel] | None = None,
     client: DAIVSandboxClient | None = None,
+    sandbox_backend: SandboxFileBackend | None = None,
 ) -> list[CompiledSubAgent]:
     """
     Load custom subagents from markdown files in the given source paths.
@@ -354,6 +370,7 @@ async def load_custom_subagents(
                     web_fetch_enabled,
                     fallback_models,
                     client,
+                    sandbox_backend,
                 ),
                 name=frontmatter["name"],
             )

--- a/daiv/codebase/managers/base.py
+++ b/daiv/codebase/managers/base.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, Any
 
 from langgraph.store.memory import InMemoryStore
 
+from automation.agent.middlewares.file_system import SandboxFileBackend
 from automation.agent.publishers import GitChangePublisher
 from automation.agent.results import NO_SNAPSHOT, AgentResult, build_agent_result
 from codebase.clients import RepoClient
@@ -43,17 +44,17 @@ class BaseManager:
             snapshot = await agent.aget_state(config=config)
             snapshot_mr = snapshot.values.get("merge_request")
 
-            # Sandbox-mode publish runs git through the run-scoped client opened by set_runtime_ctx
-            # (still active here — recovery runs in the same run scope as the agent). Local /
-            # sandbox-disabled runs need no client.
-            sandbox_client = (
-                get_run_sandbox_client() if self.ctx.sandbox is not None and self.ctx.sandbox.enabled else None
-            )
-            publisher = GitChangePublisher(self.ctx, sandbox_client=sandbox_client)
+            # Sandbox-mode publish runs git through the run's bound backend. Recovery runs in the same
+            # run scope as the agent (client still open), but doesn't hold the agent's backend instance,
+            # so it reconstructs the bound handle from the run-scoped client + the persisted session id.
+            sandbox_backend = None
+            if self.ctx.sandbox is not None and self.ctx.sandbox.enabled and (sid := snapshot.values.get("session_id")):
+                sandbox_backend = SandboxFileBackend(client=get_run_sandbox_client())
+                sandbox_backend.bind_session(sid)
+
+            publisher = GitChangePublisher(self.ctx, sandbox_backend=sandbox_backend)
             outcome = await publisher.publish(
-                session_id=snapshot.values.get("session_id"),
-                merge_request=snapshot_mr,
-                as_draft=(snapshot_mr is None or snapshot_mr.draft),
+                merge_request=snapshot_mr, as_draft=(snapshot_mr is None or snapshot_mr.draft)
             )
 
             if outcome.merge_request is not None:

--- a/tests/unit_tests/automation/agent/middlewares/test_git.py
+++ b/tests/unit_tests/automation/agent/middlewares/test_git.py
@@ -64,7 +64,7 @@ class TestGitMiddleware:
     async def test_aafter_agent_maps_published_outcome_to_state(self):
         """A published outcome maps onto the streamed ``merge_request`` field plus the private
         ``code_changes`` / ``protected_branch_fallback_source`` flags."""
-        mw = GitMiddleware(auto_commit_changes=True, sandbox_client=object())
+        mw = GitMiddleware(auto_commit_changes=True, sandbox_backend=object())
         runtime = MagicMock()
         runtime.context.scope = Scope.GLOBAL
         with patch("automation.agent.middlewares.git.GitChangePublisher") as pub_cls:
@@ -77,7 +77,7 @@ class TestGitMiddleware:
 
     async def test_aafter_agent_returns_none_when_nothing_to_publish(self):
         """A no-op outcome (no MR at all) returns None — nothing to surface in state."""
-        mw = GitMiddleware(auto_commit_changes=True, sandbox_client=object())
+        mw = GitMiddleware(auto_commit_changes=True, sandbox_backend=object())
         runtime = MagicMock()
         runtime.context.scope = Scope.GLOBAL
         with patch("automation.agent.middlewares.git.GitChangePublisher") as pub_cls:
@@ -100,13 +100,13 @@ class TestGitMiddleware:
 
         assert result == {"merge_request": state_mr, "code_changes": True}
 
-    async def test_aafter_agent_publishes_and_threads_session_id(self):
-        """Daiv publishes via the publisher; the sandbox session id is threaded so the publisher
-        runs git in the right (sandbox vs local) mode."""
-        middleware = GitMiddleware()
+    async def test_aafter_agent_passes_backend_to_publisher(self):
+        """Daiv publishes via the publisher; the run's bound backend is injected at construction
+        (no session_id is threaded through publish)."""
+        sentinel_backend = object()
+        middleware = GitMiddleware(sandbox_backend=sentinel_backend)
+        new_mr = _mr()
         runtime = _make_runtime(scope=Scope.GLOBAL)
-        new_mr = _mr(iid=11, branch="daiv/changes")
-
         with patch("automation.agent.middlewares.git.GitChangePublisher") as publisher_cls:
             publisher = MagicMock()
             publisher.publish = AsyncMock(return_value=PublishOutcome(merge_request=new_mr, published=True))
@@ -114,10 +114,10 @@ class TestGitMiddleware:
 
             result = await middleware.aafter_agent({"merge_request": None, "session_id": "sid"}, runtime)
 
-        assert result["merge_request"] is new_mr
-        assert result["code_changes"] is True
+        assert publisher_cls.call_args.kwargs["sandbox_backend"] is sentinel_backend
         publisher.publish.assert_awaited_once()
-        assert publisher.publish.await_args.kwargs["session_id"] == "sid"
+        assert "session_id" not in publisher.publish.await_args.kwargs
+        assert result["merge_request"] is new_mr
 
     async def test_aafter_agent_skips_when_auto_commit_disabled(self):
         middleware = GitMiddleware(auto_commit_changes=False)

--- a/tests/unit_tests/automation/agent/middlewares/test_sandbox.py
+++ b/tests/unit_tests/automation/agent/middlewares/test_sandbox.py
@@ -4,6 +4,7 @@ import tarfile
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
+import pytest
 from git import Repo
 
 from automation.agent.middlewares.file_system import SandboxFileBackend
@@ -92,9 +93,11 @@ def _make_runtime() -> MagicMock:
 
 
 def _bash_tool_with_fake_client(client: Mock):
-    """Build a fresh SandboxMiddleware with ``client`` pre-installed and return its bash tool."""
+    """Build a fresh SandboxMiddleware with a bound backend over ``client`` and return its bash tool."""
+    backend = SandboxFileBackend(client=client)
+    backend.bind_session("sess_1")
     middleware = _make_middleware()
-    middleware._client = client
+    middleware._sandbox_backend = backend
     return middleware.tools[0]
 
 
@@ -134,19 +137,12 @@ class TestBashTool:
 
         assert output.startswith("error: Sandbox call failed")
 
-    async def test_bash_tool_raises_when_client_not_opened(self, tmp_path: Path):
-        """Calling the bash tool before ``abefore_agent`` opens the client must fail loud."""
-        import pytest
-
-        repo_dir = tmp_path / "repoX"
-        repo_dir.mkdir(parents=True)
-        repo = Repo.init(repo_dir)
-
-        runtime = _make_bash_runtime(repo)
-        middleware = _make_middleware(close_session=True)
+    async def test_bash_tool_raises_when_backend_not_set(self):
+        """Calling the bash tool before abefore_agent bound the backend must fail loud."""
+        runtime = _make_bash_runtime(Mock())
+        middleware = _make_middleware()  # no backend installed
         bash_tool = middleware.tools[0]
-
-        with pytest.raises(RuntimeError, match="bash tool invoked before abefore_agent"):
+        with pytest.raises(RuntimeError, match="bound the sandbox backend"):
             await bash_tool.coroutine(command="echo ok", runtime=runtime)
 
 
@@ -298,22 +294,18 @@ class TestBashToolPolicyEnforcement:
 
 
 class TestRunBashCommands:
-    async def test_run_bash_commands_no_archive_field(self):
-        """_run_bash_commands no longer tarballs the working dir; archive is gone from RunCommandsRequest."""
-        run_commands_mock = AsyncMock(return_value=RunCommandsResponse(results=[]))
-        client = Mock()
-        client.run_commands = run_commands_mock
+    async def test_run_bash_commands_forwards_to_backend(self):
+        """_run_bash_commands forwards the command list to the bound backend with fail_fast=True."""
+        backend = SandboxFileBackend(client=Mock())
+        backend.bind_session("sess_1")
+        backend.run_commands = AsyncMock(return_value=RunCommandsResponse(results=[]))
 
-        response = await _run_bash_commands(client, ["echo ok"], "sess_1")
+        response = await _run_bash_commands(backend, ["echo ok"])
 
         assert response is not None
-        run_commands_mock.assert_awaited_once()
-        _session_id, request = run_commands_mock.call_args.args
-
-        # The RunCommandsRequest schema no longer has an archive field.
-        dumped = request.model_dump()
-        assert "archive" not in dumped
-        assert dumped["commands"] == ["echo ok"]
+        backend.run_commands.assert_awaited_once()
+        assert backend.run_commands.await_args.args[0] == ["echo ok"]
+        assert backend.run_commands.await_args.kwargs["fail_fast"] is True
 
 
 class TestSandboxMiddleware:

--- a/tests/unit_tests/automation/agent/middlewares/test_sandbox.py
+++ b/tests/unit_tests/automation/agent/middlewares/test_sandbox.py
@@ -8,7 +8,12 @@ import pytest
 from git import Repo
 
 from automation.agent.middlewares.file_system import SandboxFileBackend
-from automation.agent.middlewares.sandbox import SANDBOX_SYSTEM_PROMPT, SandboxMiddleware, _run_bash_commands
+from automation.agent.middlewares.sandbox import (
+    SANDBOX_SYSTEM_PROMPT,
+    BashFailure,
+    SandboxMiddleware,
+    _run_bash_commands,
+)
 from core.conf import settings as core_settings
 from core.sandbox.schemas import RunCommandResult, RunCommandsResponse
 
@@ -121,7 +126,8 @@ class TestBashTool:
         assert "files_changed" not in payload
         client.run_commands.assert_awaited_once()
 
-    async def test_bash_tool_returns_error_when_sandbox_call_fails(self, tmp_path: Path):
+    async def test_bash_tool_transient_failure_invites_single_retry(self, tmp_path: Path):
+        """A transport error (no HTTP response) yields transient guidance: retry once, then stop."""
         import httpx
 
         repo_dir = tmp_path / "repoX"
@@ -135,7 +141,30 @@ class TestBashTool:
 
         output = await bash_tool.coroutine(command="echo ok", runtime=runtime)
 
-        assert output.startswith("error: Sandbox call failed")
+        assert output.startswith("error:")
+        assert "retry this exact command once" in output.lower()
+        # Must NOT carry the permanent "stop forever" framing — a retry is still warranted.
+        assert "unavailable for the rest of this conversation" not in output.lower()
+
+    async def test_bash_tool_permanent_failure_tells_agent_to_stop(self, tmp_path: Path):
+        """A non-retryable status (e.g. 403) tells the agent the tool is gone for the run."""
+        import httpx
+
+        repo_dir = tmp_path / "repoY"
+        repo_dir.mkdir(parents=True)
+        repo = Repo.init(repo_dir)
+
+        runtime = _make_bash_runtime(repo)
+        err = httpx.HTTPStatusError("forbidden", request=httpx.Request("POST", "x"), response=httpx.Response(403))
+        client = Mock()
+        client.run_commands = AsyncMock(side_effect=err)
+        bash_tool = _bash_tool_with_fake_client(client)
+
+        output = await bash_tool.coroutine(command="echo ok", runtime=runtime)
+
+        assert output.startswith("error:")
+        assert "unavailable for the rest of this conversation" in output.lower()
+        assert "do not call" in output.lower()
 
     async def test_bash_tool_raises_when_backend_not_set(self):
         """Calling the bash tool before abefore_agent bound the backend must fail loud."""
@@ -306,6 +335,32 @@ class TestRunBashCommands:
         backend.run_commands.assert_awaited_once()
         assert backend.run_commands.await_args.args[0] == ["echo ok"]
         assert backend.run_commands.await_args.kwargs["fail_fast"] is True
+
+    async def _run_with_error(self, error: Exception) -> object:
+        backend = SandboxFileBackend(client=Mock())
+        backend.bind_session("sess_1")
+        backend.run_commands = AsyncMock(side_effect=error)
+        return await _run_bash_commands(backend, ["echo ok"])
+
+    async def test_transport_error_is_transient(self):
+        """No HTTP response (timeout/connection blip) → transient: a retry may connect."""
+        import httpx
+
+        assert await self._run_with_error(httpx.RequestError("boom")) is BashFailure.TRANSIENT
+
+    @pytest.mark.parametrize("status", [429, 500, 502, 503, 504])
+    async def test_retryable_status_is_transient(self, status: int):
+        import httpx
+
+        err = httpx.HTTPStatusError("busy", request=httpx.Request("POST", "x"), response=httpx.Response(status))
+        assert await self._run_with_error(err) is BashFailure.TRANSIENT
+
+    @pytest.mark.parametrize("status", [400, 401, 403, 404, 422])
+    async def test_non_retryable_status_is_permanent(self, status: int):
+        import httpx
+
+        err = httpx.HTTPStatusError("nope", request=httpx.Request("POST", "x"), response=httpx.Response(status))
+        assert await self._run_with_error(err) is BashFailure.PERMANENT
 
 
 class TestSandboxMiddleware:

--- a/tests/unit_tests/automation/agent/middlewares/test_sandbox_file_backend.py
+++ b/tests/unit_tests/automation/agent/middlewares/test_sandbox_file_backend.py
@@ -15,6 +15,9 @@ from core.sandbox.schemas import (
     FsLsResponse,
     FsReadResponse,
     FsWriteResponse,
+    RunCommandResult,
+    RunCommandsRequest,
+    RunCommandsResponse,
 )
 
 
@@ -191,3 +194,32 @@ async def test_adownload_files_branches(backend, client):
     client.fs_read.return_value = FsReadResponse(error="boom")
     err = await backend.adownload_files(["/workspace/repo/x.txt"])
     assert err[0].error == "boom" and err[0].content is None
+
+
+async def test_run_commands_forwards_to_client(backend, client):
+    client.run_commands.return_value = RunCommandsResponse(
+        results=[RunCommandResult(command="echo hi", output="hi", exit_code=0)]
+    )
+    result = await backend.run_commands(["echo hi", "ls"], fail_fast=False)
+
+    assert result.results[0].output == "hi"
+    # Forwarded under the bound session id, as a RunCommandsRequest carrying the list + fail_fast.
+    assert client.run_commands.call_args.args[0] == "sid"
+    sent = client.run_commands.call_args.args[1]
+    assert isinstance(sent, RunCommandsRequest)
+    assert sent.commands == ["echo hi", "ls"]
+    assert sent.fail_fast is False
+
+
+async def test_run_commands_before_bind_raises():
+    be = SandboxFileBackend()
+    with pytest.raises(RuntimeError, match="not bound"):
+        await be.run_commands(["echo hi"], fail_fast=True)
+
+
+async def test_run_commands_propagates_transport_error(backend, client):
+    # Unlike the bash tool, the backend is a raising pass-through; graceful degradation
+    # is the caller's job. A transport error must NOT be swallowed here.
+    client.run_commands.side_effect = RuntimeError("boom")
+    with pytest.raises(RuntimeError, match="boom"):
+        await backend.run_commands(["echo hi"], fail_fast=True)

--- a/tests/unit_tests/automation/agent/middlewares/test_sandbox_file_backend.py
+++ b/tests/unit_tests/automation/agent/middlewares/test_sandbox_file_backend.py
@@ -223,3 +223,21 @@ async def test_run_commands_propagates_transport_error(backend, client):
     client.run_commands.side_effect = RuntimeError("boom")
     with pytest.raises(RuntimeError, match="boom"):
         await backend.run_commands(["echo hi"], fail_fast=True)
+
+
+def test_backend_does_not_advertise_execution():
+    """SandboxFileBackend must NOT be a deepagents SandboxBackendProtocol.
+
+    deepagents' FilesystemMiddleware always registers an `execute` tool, gated only at call
+    time on `supports_execution(backend)`. Implementing the protocol would make that ungated
+    tool live, bypassing daiv's _check_command_policy (and would break the read-only explore
+    subagent, which combines _permissions with this backend). Command execution must stay on
+    the policy-gated `bash` tool. See the design spec's "Rejected alternative".
+    """
+    from deepagents.backends.protocol import SandboxBackendProtocol
+    from deepagents.middleware.filesystem import supports_execution
+
+    be = SandboxFileBackend(client=AsyncMock())
+    be.bind_session("sid")
+    assert not isinstance(be, SandboxBackendProtocol)
+    assert supports_execution(be) is False

--- a/tests/unit_tests/automation/agent/test_git_manager.py
+++ b/tests/unit_tests/automation/agent/test_git_manager.py
@@ -13,6 +13,7 @@ from automation.agent.git_manager import (
     RepoStatus,
     _shell_quote,
 )
+from automation.agent.middlewares.file_system import SandboxFileBackend
 from codebase.utils import apply_patch_to_dir
 from core.sandbox.schemas import RunCommandResult, RunCommandsResponse
 
@@ -92,7 +93,9 @@ class FakeSandboxClient:
 
 def _sandbox_manager(responses: dict[str, tuple[int, str]] | None = None) -> tuple[GitManager, FakeSandboxClient]:
     client = FakeSandboxClient(responses)
-    return GitManager(client=client, session_id="sid"), client
+    backend = SandboxFileBackend(client=client)
+    backend.bind_session("sid")
+    return GitManager.for_sandbox(backend), client
 
 
 # ---------------------------------------------------------------------------
@@ -104,13 +107,10 @@ def test_requires_exactly_one_mode(tmp_path: Path) -> None:
     with pytest.raises(ValueError, match="exactly one"):
         GitManager()
     repo = _init_repo(tmp_path)
+    backend = SandboxFileBackend(client=FakeSandboxClient())
+    backend.bind_session("sid")
     with pytest.raises(ValueError, match="exactly one"):
-        GitManager(repo, client=FakeSandboxClient())  # type: ignore[arg-type]
-
-
-def test_sandbox_mode_requires_session_id() -> None:
-    with pytest.raises(ValueError, match="session_id"):
-        GitManager(client=FakeSandboxClient(), session_id="")  # type: ignore[arg-type]
+        GitManager(repo, sandbox_backend=backend)
 
 
 # ---------------------------------------------------------------------------
@@ -199,8 +199,10 @@ def test_classmethod_constructors(tmp_path: Path) -> None:
     repo = _init_repo(tmp_path)
     assert GitManager.for_local(repo).repo is repo
 
-    gm = GitManager.for_sandbox(FakeSandboxClient(), "sid")  # type: ignore[arg-type]
-    assert gm._session_id == "sid"
+    backend = SandboxFileBackend(client=FakeSandboxClient())
+    backend.bind_session("sid")
+    gm = GitManager.for_sandbox(backend)
+    assert gm._sandbox_backend is backend
     assert gm.repo is None
 
 
@@ -259,7 +261,9 @@ async def test_sandbox_empty_results_raises_runtime_error() -> None:
         async def run_commands(self, session_id, request) -> RunCommandsResponse:  # noqa: ARG002
             return RunCommandsResponse(results=[])
 
-    gm = GitManager(client=_EmptyClient(), session_id="sid")  # type: ignore[arg-type]
+    backend = SandboxFileBackend(client=_EmptyClient())
+    backend.bind_session("sid")
+    gm = GitManager.for_sandbox(backend)
     with pytest.raises(RuntimeError, match="no result"):
         await gm.commit_all("msg")
 
@@ -331,12 +335,18 @@ def _resp(*outputs_and_codes):
     )
 
 
+def _backend_for(client) -> SandboxFileBackend:
+    backend = SandboxFileBackend(client=client)
+    backend.bind_session("sess-1")
+    return backend
+
+
 async def test_status_snapshot_one_round_trip_when_clean() -> None:
     client = MagicMock()
     client.run_commands = AsyncMock(
         return_value=_resp(("", 0), ("", 0), ("", 0), ("abc\trefs/heads/main\n", 0), ("", 0))
     )
-    gm = GitManager.for_sandbox(client, "sess-1")
+    gm = GitManager.for_sandbox(_backend_for(client))
     snap = await gm.status_snapshot(base_branch="main", mr_source_branch="feat/x")
     assert isinstance(snap, RepoStatus)
     assert (snap.dirty, snap.diff, snap.remote_branches, snap.has_unpushed) == (False, "", ["main"], False)
@@ -354,7 +364,7 @@ async def test_status_snapshot_second_round_trip_only_for_untracked() -> None:
             _resp(("+++ b/new.py\n+hello\n", 1)),
         ]
     )
-    gm = GitManager.for_sandbox(client, "sess-1")
+    gm = GitManager.for_sandbox(_backend_for(client))
     snap = await gm.status_snapshot(base_branch="main", mr_source_branch=None)
     assert snap.dirty is True
     assert "new.py" in snap.diff
@@ -373,7 +383,7 @@ async def test_status_snapshot_raises_on_batch_a_command_failure(failing_index: 
     outputs[failing_index] = ("boom", 128)
     client = MagicMock()
     client.run_commands = AsyncMock(return_value=_resp(*outputs))
-    gm = GitManager.for_sandbox(client, "sess-1")
+    gm = GitManager.for_sandbox(_backend_for(client))
     with pytest.raises(GitCommandError) as exc_info:
         await gm.status_snapshot(base_branch="main", mr_source_branch=None)
     assert command_fragment in str(exc_info.value)
@@ -387,7 +397,7 @@ async def test_status_snapshot_has_unpushed_true_when_log_has_output() -> None:
     client.run_commands = AsyncMock(
         return_value=_resp(("", 0), ("", 0), ("", 0), ("abc\trefs/heads/main\n", 0), ("abc123 commit\n", 0))
     )
-    gm = GitManager.for_sandbox(client, "sess-1")
+    gm = GitManager.for_sandbox(_backend_for(client))
     snap = await gm.status_snapshot(base_branch="main", mr_source_branch="feat/x")
     assert snap.has_unpushed is True
 
@@ -399,7 +409,7 @@ async def test_status_snapshot_treats_log_failure_as_unpushed() -> None:
     client.run_commands = AsyncMock(
         return_value=_resp(("", 0), ("", 0), ("", 0), ("abc\trefs/heads/main\n", 0), ("fatal: bad revision", 128))
     )
-    gm = GitManager.for_sandbox(client, "sess-1")
+    gm = GitManager.for_sandbox(_backend_for(client))
     snap = await gm.status_snapshot(base_branch="main", mr_source_branch="feat/x")
     assert snap.has_unpushed is True
 
@@ -408,6 +418,6 @@ async def test_status_snapshot_raises_on_result_count_mismatch() -> None:
     # The sandbox returns one result per command; a short list is a wire anomaly, not a parse-to-empty.
     client = MagicMock()
     client.run_commands = AsyncMock(return_value=_resp(("", 0), ("", 0)))  # 2 results for 4 commands
-    gm = GitManager.for_sandbox(client, "sess-1")
+    gm = GitManager.for_sandbox(_backend_for(client))
     with pytest.raises(RuntimeError, match="results for"):
         await gm.status_snapshot(base_branch="main", mr_source_branch=None)

--- a/tests/unit_tests/automation/agent/test_git_utils.py
+++ b/tests/unit_tests/automation/agent/test_git_utils.py
@@ -1,25 +1,17 @@
 from unittest.mock import MagicMock
 
-import pytest
-
 from automation.agent.git_utils import open_git_manager
 
 
-async def test_open_git_manager_sandbox_uses_injected_client():
-    client = MagicMock()
-    async with open_git_manager(client=client, session_id="sess-1", gitrepo=None) as gm:
-        assert gm._client is client
-        assert gm._session_id == "sess-1"
+async def test_open_git_manager_sandbox_uses_injected_backend():
+    backend = MagicMock()
+    async with open_git_manager(sandbox_backend=backend, gitrepo=None) as gm:
+        assert gm._sandbox_backend is backend
+        assert gm.repo is None
 
 
-async def test_open_git_manager_sandbox_requires_client():
-    with pytest.raises(RuntimeError, match="no sandbox client"):
-        async with open_git_manager(client=None, session_id="sess-1", gitrepo=None):
-            pass
-
-
-async def test_open_git_manager_local_mode_ignores_client():
+async def test_open_git_manager_local_mode_when_no_backend():
     repo = MagicMock()
-    async with open_git_manager(client=None, session_id=None, gitrepo=repo) as gm:
+    async with open_git_manager(sandbox_backend=None, gitrepo=repo) as gm:
         assert gm.repo is repo
-        assert gm._client is None
+        assert gm._sandbox_backend is None

--- a/tests/unit_tests/automation/agent/test_publishers.py
+++ b/tests/unit_tests/automation/agent/test_publishers.py
@@ -31,7 +31,7 @@ def _fake_git_manager(*, dirty: bool = True, diff: str = "diff", remote_branches
 
 def _patch_open_git_manager(monkeypatch, gm: Mock) -> None:
     @asynccontextmanager
-    async def _fake_open(*, client, session_id, gitrepo):  # noqa: ARG001
+    async def _fake_open(*, sandbox_backend, gitrepo):  # noqa: ARG001
         yield gm
 
     monkeypatch.setattr("automation.agent.publishers.open_git_manager", _fake_open)
@@ -385,7 +385,7 @@ class TestPublishDecision:
         _patch_open_git_manager(monkeypatch, gm)
 
         with patch.object(publisher, "_diff_to_metadata") as meta:
-            outcome = await publisher.publish(session_id="s", merge_request=None)
+            outcome = await publisher.publish(merge_request=None)
 
         assert outcome == PublishOutcome(merge_request=None, published=False)
         meta.assert_not_called()
@@ -398,7 +398,7 @@ class TestPublishDecision:
         _patch_open_git_manager(monkeypatch, gm)
 
         with patch.object(publisher, "_diff_to_metadata") as meta:
-            outcome = await publisher.publish(session_id="s", merge_request=mr)
+            outcome = await publisher.publish(merge_request=mr)
 
         assert outcome == PublishOutcome(merge_request=mr, published=False)
         meta.assert_not_called()

--- a/tests/unit_tests/automation/agent/test_subagents.py
+++ b/tests/unit_tests/automation/agent/test_subagents.py
@@ -9,7 +9,7 @@ which middlewares to compose.
 """
 
 from typing import TYPE_CHECKING
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from deepagents.middleware.filesystem import FilesystemMiddleware
@@ -65,6 +65,28 @@ class TestGeneralPurposeMiddleware:
         sandbox_middlewares = [m for m in middleware if isinstance(m, SandboxMiddleware)]
         assert len(sandbox_middlewares) == 1
         assert sandbox_middlewares[0].close_session is False
+
+    def test_threads_client_and_sandbox_backend_into_sandbox_middleware(
+        self, mock_model, mock_backend, mock_runtime_ctx
+    ):
+        """The run-scoped client and the parent's bound backend must reach the subagent's
+        SandboxMiddleware: the subagent's bash tool runs through the shared backend, so a dropped
+        argument would make that bash raise ``...bound the sandbox backend`` at runtime."""
+        sentinel_client = Mock()
+        sentinel_backend = Mock()
+        middleware = _build_general_purpose_middleware(
+            mock_model,
+            mock_backend,
+            mock_runtime_ctx,
+            sandbox_enabled=True,
+            web_search_enabled=True,
+            web_fetch_enabled=True,
+            client=sentinel_client,
+            sandbox_backend=sentinel_backend,
+        )
+        sandbox_mw = next(m for m in middleware if isinstance(m, SandboxMiddleware))
+        assert sandbox_mw._client is sentinel_client
+        assert sandbox_mw._sandbox_backend is sentinel_backend
 
     def test_excludes_sandbox_when_disabled(self, mock_model, mock_backend, mock_runtime_ctx):
         middleware = _build_general_purpose_middleware(
@@ -226,6 +248,38 @@ class TestCustomSubagents:
         assert result[0]["name"] == "my-agent"
         assert result[0]["description"] == "Does custom things"
         assert "runnable" in result[0]
+
+    async def test_threads_client_and_sandbox_backend_into_middleware(
+        self, tmp_path: Path, mock_model, mock_runtime_ctx
+    ):
+        """The run-scoped client + parent backend are forwarded (positionally, as the last two
+        args) into each custom subagent's middleware builder, so a custom subagent's bash tool runs
+        through the shared backend rather than raising at runtime. Guards the positional pass-through
+        in ``load_custom_subagents``."""
+        from automation.agent.middlewares.file_system import DAIVFilesystemBackend
+
+        subagents_dir = tmp_path / "repo" / ".agents" / "subagents"
+        subagents_dir.mkdir(parents=True)
+        (subagents_dir / "my-agent.md").write_text(_make_subagent_md(name="my-agent", description="Does things"))
+
+        sentinel_client = Mock()
+        sentinel_backend = Mock()
+        backend = DAIVFilesystemBackend(root_dir=tmp_path, virtual_mode=True)
+        with patch("automation.agent.subagents._build_general_purpose_middleware", return_value=[]) as build_mw:
+            result = await load_custom_subagents(
+                model=mock_model,
+                backend=backend,
+                runtime=mock_runtime_ctx,
+                sources=["/repo/.agents/subagents"],
+                client=sentinel_client,
+                sandbox_backend=sentinel_backend,
+            )
+
+        assert len(result) == 1
+        build_mw.assert_called_once()
+        # client and sandbox_backend are the last two positional args (see load_custom_subagents).
+        assert build_mw.call_args.args[-2] is sentinel_client
+        assert build_mw.call_args.args[-1] is sentinel_backend
 
     async def test_loads_multiple_subagents(self, tmp_path: Path, mock_model, mock_runtime_ctx):
         from automation.agent.middlewares.file_system import DAIVFilesystemBackend


### PR DESCRIPTION
## Summary

Makes the per-run `SandboxFileBackend` the single session handle for the run, and routes bash execution through it instead of a separately-acquired transport. Stacked on top of `feat/sandbox-filebackend-scratchpad` (#1287).

## Changes

- **`run_commands` on `SandboxFileBackend`** — the bound backend can now execute commands, so callers no longer need a second handle to the sandbox.
- **Bash through the bound backend** — the bash path (and the subagents that inherit it) runs commands through the run's bound backend; the git/publish path is threaded the same backend rather than reaching for its own.
- **Transient vs permanent bash failures** — a `BashFailure` enum maps `httpx` errors to `TRANSIENT` (no response, or retryable `408/425/429/5xx`) vs `PERMANENT` (auth, session-gone, bad-request, not-implemented), with distinct agent-facing guidance for each. The transient message is byte-stable so the system prompt's "two identical error strings ⇒ stop" backstop still fires. Non-`httpx` failures (malformed `200` body, unbound-backend `RuntimeError`) propagate as loud wire/programming bugs.
- **Test guard** — asserts the backend never advertises execution where it shouldn't.

## Notes

Re-stacked: the original work landed as #1290 onto `feat/sandbox-transport-injection`; these 5 commits are rebased to sit directly on the merged `#1287` scratchpad base, dropping the now-redundant transport-injection layer.

## Test plan

- `uv run pytest tests/unit_tests/core/sandbox/ tests/unit_tests/automation/agent/test_git_manager.py tests/unit_tests/automation/agent/middlewares/test_git.py tests/unit_tests/automation/agent/middlewares/test_git_platform.py` → **226 passed**
