### PR TITLE
feat(agent): unify graph workspace root to /workspace with disk-only fence

### DIFF
--- a/daiv/automation/agent/constants.py
+++ b/daiv/automation/agent/constants.py
@@ -21,6 +21,9 @@ GLOBAL_SKILLS_ROUTE = f"{GLOBAL_SKILLS_PATH}/"
 WORKSPACE_PATH = "/workspace"
 REPO_PATH = "/workspace/repo"
 SKILLS_PATH = "/workspace/skills"
+# Per-run ephemeral scratchpad. In sandbox mode it is a real sandbox dir; in disk mode it is the
+# composite's default fall-through area (alongside offloaded artifacts).
+TMP_PATH = "/workspace/tmp"
 
 # On-disk root the composite backend mounts at ``GLOBAL_SKILLS_PATH``. Created at module
 # import (loud failure if ``$TMPDIR`` is unwritable, which would manifest as a startup

--- a/daiv/automation/agent/constants.py
+++ b/daiv/automation/agent/constants.py
@@ -7,14 +7,6 @@ from daiv.settings.components import PROJECT_DIR
 # Path where the builtin skills are stored in the filesystem to be copied to the repository.
 BUILTIN_SKILLS_PATH = PROJECT_DIR / "automation" / "agent" / "skills"
 
-# Virtual path the disk-backed (non-sandbox) composite backend serves global skills from.
-# Mounted onto ``SKILLS_CACHE_PATH`` on disk so per-turn skill uploads are idempotent and
-# writes under ``/skills/`` don't round-trip through the agent's state. Sandbox runs do NOT
-# use this route: they address skills by their sandbox-absolute path ``SKILLS_PATH``
-# (``/workspace/skills``) directly, since the backend is a pass-through.
-GLOBAL_SKILLS_PATH = "/skills"
-GLOBAL_SKILLS_ROUTE = f"{GLOBAL_SKILLS_PATH}/"
-
 # Unified sandbox workspace. One backend (sandbox-authoritative) serves all of /workspace.
 # The sandbox holds the one true workspace: repo at /workspace/repo, seeded skills at
 # /workspace/skills, and the per-run scratchpad at /workspace/tmp.
@@ -25,7 +17,7 @@ SKILLS_PATH = "/workspace/skills"
 # composite's default fall-through area (alongside offloaded artifacts).
 TMP_PATH = "/workspace/tmp"
 
-# On-disk root the composite backend mounts at ``GLOBAL_SKILLS_PATH``. Created at module
+# On-disk root the composite backend mounts at ``SKILLS_PATH``. Created at module
 # import (loud failure if ``$TMPDIR`` is unwritable, which would manifest as a startup
 # ImportError on production, or a confusing pytest collection error locally).
 #

--- a/daiv/automation/agent/graph.py
+++ b/daiv/automation/agent/graph.py
@@ -17,10 +17,7 @@ from langchain.agents.middleware import (
 from automation.agent.base import BaseAgent, ThinkingLevel
 from automation.agent.constants import (
     AGENTS_MEMORY_PATH,
-    GLOBAL_SKILLS_PATH,
-    GLOBAL_SKILLS_ROUTE,
     REPO_PATH,
-    SKILLS_CACHE_PATH,
     SKILLS_PATH,
     SKILLS_SOURCES,
     SUBAGENTS_SOURCES,
@@ -32,9 +29,10 @@ from automation.agent.mcp.toolkits import MCPToolkit
 from automation.agent.middlewares.deferred_tools import DeferredToolsMiddleware
 from automation.agent.middlewares.ensure_response import ensure_non_empty_response
 from automation.agent.middlewares.file_system import (
+    WORKSPACE_FENCE_PERMISSIONS,
     DAIVCompositeBackend,
-    DAIVFilesystemBackend,
     SandboxFileBackend,
+    build_disk_workspace_backend,
     filesystem_absolute_path_directive,
 )
 from automation.agent.middlewares.git import GitMiddleware
@@ -59,6 +57,7 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
     from deepagents.backends.protocol import BackendProtocol
+    from deepagents.middleware.filesystem import FilesystemPermission
     from langgraph.checkpoint.base import BaseCheckpointSaver
     from langgraph.store.base import BaseStore
 
@@ -86,8 +85,8 @@ class _Unset:
 
 
 def _output_invariants_system_prompt(working_directory: str) -> str:
-    """Output invariants keyed to the run's absolute repo prefix (``/workspace/repo/`` for
-    sandbox runs, ``/<clone-name>/`` for disk-backed runs)."""
+    """Output invariants keyed to the run's absolute repo prefix (always ``/workspace/repo/`` —
+    unified across sandbox and disk-backed runs)."""
     prefix = working_directory.rstrip("/") + "/"
     return f"""\
 <output_invariants>
@@ -103,19 +102,6 @@ Applies to ALL user-visible text:
 </output_invariants>"""  # noqa: E501
 
 
-def _resolve_working_directory(context: RuntimeCtx) -> str:
-    """The run's absolute repo root (trailing slash) the model should address files under.
-
-    Sandbox-enabled runs operate under the sandbox-authoritative ``/workspace/repo``; disk-backed
-    runs see the local clone's basename. This mirrors ``create_daiv_agent``'s ``agent_root`` decision
-    (sandbox → ``REPO_PATH``, disk → ``/{clone-name}``) so the prompt's working directory and output
-    invariants match the paths the agent's tools and subagents address.
-    """
-    if context.sandbox and context.sandbox.enabled:
-        return f"{REPO_PATH}/"
-    return f"/{Path(context.gitrepo.working_dir).name}/"
-
-
 @dynamic_prompt
 async def dynamic_daiv_system_prompt(request: ModelRequest) -> str:
     """
@@ -128,7 +114,8 @@ async def dynamic_daiv_system_prompt(request: ModelRequest) -> str:
         str: The dynamic prompt for the DAIV system.
     """
     context = cast("RuntimeCtx", request.runtime.context)
-    working_directory = _resolve_working_directory(context)
+    # Unified across modes: repo files live under /workspace/repo regardless of sandbox.
+    working_directory = f"{REPO_PATH}/"
 
     daiv_system_prompt = await DAIV_SYSTEM_PROMPT.aformat(
         current_date=timezone.now().strftime("%d %B, %Y"),
@@ -219,47 +206,31 @@ async def create_daiv_agent(
     _web_fetch_enabled = web_fetch_enabled if web_fetch_enabled is not None else site_settings.web_fetch_enabled
     _web_search_enabled = web_search_enabled if web_search_enabled is not None else site_settings.web_search_enabled
 
+    # Unified workspace namespace: the agent addresses /workspace/repo, /workspace/skills and
+    # /workspace/tmp regardless of sandbox mode. Only the backend behind /workspace differs.
+    agent_root = REPO_PATH
+    global_skills_source = SKILLS_PATH
+
     sandbox_backend: SandboxFileBackend | None = None
     run_client = None
+    main_agent_permissions: list[FilesystemPermission] | None = None
     if _sandbox_enabled:
-        # Sandbox-authoritative: one backend serves all of /workspace (repo at
-        # /workspace/repo, seeded skills at /workspace/skills, scratchpad at
-        # /workspace/tmp). The agent uses these sandbox-absolute paths directly, so the
-        # backend is a pass-through, bound to the run's session by
-        # SandboxMiddleware.abefore_agent once the session exists.
-        agent_root = REPO_PATH
-        global_skills_source = SKILLS_PATH
-        # Read the run-scoped sandbox client opened by set_runtime_ctx EXACTLY ONCE, here, and inject
-        # it explicitly everywhere it's needed. The client is supplied to SandboxFileBackend at
-        # construction, so the FilesystemMiddleware/SummarizationMiddleware artifacts_root machinery
-        # (which needs a CompositeBackend) still works, and the session is bound late by
-        # SandboxMiddleware via bind_session — no composite-unwrapping required.
-        #
-        # Wrap the single /workspace backend in a composite purely to carry an
-        # ``artifacts_root`` under /workspace. The middlewares that offload to the
-        # filesystem (FilesystemMiddleware tool-result + HumanMessage eviction,
-        # SummarizationMiddleware history) derive their write prefix from
-        # ``artifacts_root`` *only when the backend is a CompositeBackend*, defaulting
-        # to "/" otherwise. A bare SandboxFileBackend would send those writes to
-        # ``/large_tool_results`` / ``/conversation_history`` at the container root —
-        # outside /workspace, which the sandbox rejects — so eviction would silently
-        # no-op. There is no route: every /workspace path falls through to the default
-        # backend with its full path, identity-mapped into the sandbox.
+        # Sandbox-authoritative: one pass-through SandboxFileBackend serves all of /workspace, bound
+        # to the run's session by SandboxMiddleware.abefore_agent. It is wrapped in a composite only
+        # so the offloading middlewares get an ``artifacts_root`` under /workspace (a bare backend
+        # would default to "/" and write evictions outside /workspace, which the sandbox rejects).
         run_client = get_run_sandbox_client()
         sandbox_backend = SandboxFileBackend(client=run_client)
         backend: BackendProtocol = DAIVCompositeBackend(
             default=sandbox_backend, routes={}, artifacts_root=WORKSPACE_PATH
         )
     else:
-        # Sandbox-disabled runs keep the disk-backed composite: repo files from disk;
-        # ``/skills/`` from the shared SKILLS_CACHE_PATH so per-turn skill uploads become a
-        # no-op once primed. Preserves repoless/no-sandbox flows.
-        agent_path = Path(ctx.gitrepo.working_dir)
-        agent_root = f"/{agent_path.name}"
-        global_skills_source = GLOBAL_SKILLS_PATH
-        repo_backend = DAIVFilesystemBackend(root_dir=agent_path.parent, virtual_mode=True)
-        skills_backend = DAIVFilesystemBackend(root_dir=SKILLS_CACHE_PATH, virtual_mode=True)
-        backend = DAIVCompositeBackend(default=repo_backend, routes={GLOBAL_SKILLS_ROUTE: skills_backend})
+        # Disk-backed: a composite maps the same /workspace namespace onto the local clone
+        # (/workspace/repo), the shared skills cache (/workspace/skills) and a per-run scratch dir
+        # (/workspace/tmp + offloaded artifacts). The fence keeps the agent's file tools inside
+        # those three subtrees; bash is sandbox-only so it needs no equivalent here.
+        backend = build_disk_workspace_backend(Path(ctx.gitrepo.working_dir))
+        main_agent_permissions = WORKSPACE_FENCE_PERMISSIONS
 
     # The run's absolute repo root, shared with subagents so their filesystem path directives name
     # the same root the main agent's prompt does (``dynamic_daiv_system_prompt`` derives the same value).
@@ -278,7 +249,7 @@ async def create_daiv_agent(
             client=run_client,
             sandbox_backend=sandbox_backend,
         ),
-        create_explore_subagent(backend, working_directory),
+        create_explore_subagent(backend, working_directory, sandbox_enabled=_sandbox_enabled),
     ]
 
     custom_subagents = await load_custom_subagents(
@@ -345,6 +316,7 @@ async def create_daiv_agent(
         subagents=subagents,
         memory=[f"{agent_root}/{ctx.config.context_file_name}", f"{agent_root}/{AGENTS_MEMORY_PATH}"],
         backend=backend,
+        permissions=main_agent_permissions,
         interrupt_on=interrupt_on,
         context_schema=RuntimeCtx,
         checkpointer=checkpointer,

--- a/daiv/automation/agent/middlewares/file_system.py
+++ b/daiv/automation/agent/middlewares/file_system.py
@@ -32,7 +32,7 @@ from deepagents.middleware.filesystem import READ_FILE_TOOL_DESCRIPTION as READ_
 from deepagents.middleware.filesystem import WRITE_FILE_TOOL_DESCRIPTION as WRITE_FILE_TOOL_DESCRIPTION_BASE
 from deepagents.middleware.filesystem import FilesystemPermission
 
-from automation.agent.constants import REPO_PATH, SKILLS_PATH, TMP_PATH, WORKSPACE_PATH
+from automation.agent.constants import REPO_PATH, SKILLS_CACHE_PATH, SKILLS_PATH, TMP_PATH, WORKSPACE_PATH
 from core.sandbox.client import DAIVSandboxClient  # noqa: TC001
 from core.sandbox.schemas import (
     FsDeleteRequest,
@@ -238,6 +238,31 @@ class DAIVCompositeBackend(CompositeBackend):
         """
         backend, _ = self._get_backend_and_key(virtual_path)
         return backend
+
+
+def build_disk_workspace_backend(clone_dir: Path, *, skills_cache: Path = SKILLS_CACHE_PATH) -> DAIVCompositeBackend:
+    """Build the disk-backed composite that serves the unified ``/workspace`` namespace.
+
+    Routes:
+      - ``/workspace/repo/``   → the local git clone (``clone_dir``)
+      - ``/workspace/skills/`` → the shared global skills cache (``SKILLS_CACHE_PATH``)
+      - everything else under ``/workspace`` (the ``/workspace/tmp`` scratchpad and the offloaded
+        artifact dirs derived from ``artifacts_root``) → a per-run scratch backend rooted at the
+        clone's parent (the ``set_runtime_ctx`` tempdir, auto-removed at run end). Non-routed paths
+        reach this default with their full path, so they materialise under ``<parent>/workspace/``,
+        siblings to the clone and never committed.
+
+    The skills cache is a route (not copied per run) so the global-cache idempotency in
+    ``SkillsMiddleware`` is preserved.
+    """
+    repo_backend = DAIVFilesystemBackend(root_dir=clone_dir, virtual_mode=True)
+    skills_backend = DAIVFilesystemBackend(root_dir=skills_cache, virtual_mode=True)
+    scratch_backend = DAIVFilesystemBackend(root_dir=clone_dir.parent, virtual_mode=True)
+    return DAIVCompositeBackend(
+        default=scratch_backend,
+        routes={f"{REPO_PATH}/": repo_backend, f"{SKILLS_PATH}/": skills_backend},
+        artifacts_root=WORKSPACE_PATH,
+    )
 
 
 # Every fs soft failure now arrives in the 200 body as a structured ``FsError`` (the sandbox no

--- a/daiv/automation/agent/middlewares/file_system.py
+++ b/daiv/automation/agent/middlewares/file_system.py
@@ -113,15 +113,31 @@ def filesystem_absolute_path_directive(working_directory: str) -> str:
 
 # Disk-mode fence. The disk composite routes /workspace/repo and /workspace/skills and lets
 # everything else under /workspace fall through to the scratch/artifacts backend. These rules keep
-# the agent's file tools inside the three real subtrees: bare /workspace (which would not enumerate
-# the routed subdirs) and the offloaded-artifact dirs (/workspace/large_tool_results,
-# /workspace/conversation_history) are denied. First-rule-wins, default allow; artifact eviction
-# writes through the backend directly and is not affected. Sandbox runs do NOT use this — bash is
-# unconstrained there, so fencing only the file tools would be inconsistent.
+# the agent's file tools inside the three real subtrees (repo, skills, tmp), grant read-only access
+# to the offloaded-artifact dirs (so eviction read-back works — see below), and deny bare /workspace
+# (which would not enumerate the routed subdirs) plus any other path beneath it. First-rule-wins,
+# default allow. Sandbox runs do NOT use this — bash is unconstrained there, so fencing only the file
+# tools would be inconsistent.
 WORKSPACE_FENCE_SUBTREES = [REPO_PATH, f"{REPO_PATH}/**", SKILLS_PATH, f"{SKILLS_PATH}/**", TMP_PATH, f"{TMP_PATH}/**"]
+
+# Offloaded-artifact dirs derived from ``artifacts_root`` (= /workspace in the disk composite).
+# deepagents' large-tool-result / conversation-history eviction and git_platform's ``output_to_file``
+# all WRITE here through the backend directly (bypassing the fence) and then hand the agent the path
+# to read back. Without an explicit read carve-out ahead of the deny, that read-back hits the
+# ``/workspace/**`` deny and dead-ends — the full content is written but unrecoverable. Write stays
+# denied (the agent never writes here itself; only the framework does, and that bypasses the fence).
+# These suffixes mirror deepagents' ``FilesystemMiddleware``; a drift-guard test pins them to the
+# framework's computed prefixes so a rename fails loudly instead of silently re-breaking read-back.
+WORKSPACE_ARTIFACT_SUBTREES = [
+    f"{WORKSPACE_PATH}/large_tool_results",
+    f"{WORKSPACE_PATH}/large_tool_results/**",
+    f"{WORKSPACE_PATH}/conversation_history",
+    f"{WORKSPACE_PATH}/conversation_history/**",
+]
 
 WORKSPACE_FENCE_PERMISSIONS = [
     FilesystemPermission(operations=["read", "write"], paths=WORKSPACE_FENCE_SUBTREES, mode="allow"),
+    FilesystemPermission(operations=["read"], paths=WORKSPACE_ARTIFACT_SUBTREES, mode="allow"),
     FilesystemPermission(operations=["read", "write"], paths=[WORKSPACE_PATH, f"{WORKSPACE_PATH}/**"], mode="deny"),
 ]
 

--- a/daiv/automation/agent/middlewares/file_system.py
+++ b/daiv/automation/agent/middlewares/file_system.py
@@ -30,8 +30,9 @@ from deepagents.middleware.filesystem import GREP_TOOL_DESCRIPTION as GREP_TOOL_
 from deepagents.middleware.filesystem import LIST_FILES_TOOL_DESCRIPTION as LIST_FILES_TOOL_DESCRIPTION_BASE
 from deepagents.middleware.filesystem import READ_FILE_TOOL_DESCRIPTION as READ_FILE_TOOL_DESCRIPTION_BASE
 from deepagents.middleware.filesystem import WRITE_FILE_TOOL_DESCRIPTION as WRITE_FILE_TOOL_DESCRIPTION_BASE
+from deepagents.middleware.filesystem import FilesystemPermission
 
-from automation.agent.constants import REPO_PATH, WORKSPACE_PATH
+from automation.agent.constants import REPO_PATH, SKILLS_PATH, TMP_PATH, WORKSPACE_PATH
 from core.sandbox.client import DAIVSandboxClient  # noqa: TC001
 from core.sandbox.schemas import (
     FsDeleteRequest,
@@ -109,6 +110,20 @@ def filesystem_absolute_path_directive(working_directory: str) -> str:
         f'not a repo-relative path like "/path/to/file.py".'
     )
 
+
+# Disk-mode fence. The disk composite routes /workspace/repo and /workspace/skills and lets
+# everything else under /workspace fall through to the scratch/artifacts backend. These rules keep
+# the agent's file tools inside the three real subtrees: bare /workspace (which would not enumerate
+# the routed subdirs) and the offloaded-artifact dirs (/workspace/large_tool_results,
+# /workspace/conversation_history) are denied. First-rule-wins, default allow; artifact eviction
+# writes through the backend directly and is not affected. Sandbox runs do NOT use this — bash is
+# unconstrained there, so fencing only the file tools would be inconsistent.
+WORKSPACE_FENCE_SUBTREES = [REPO_PATH, f"{REPO_PATH}/**", SKILLS_PATH, f"{SKILLS_PATH}/**", TMP_PATH, f"{TMP_PATH}/**"]
+
+WORKSPACE_FENCE_PERMISSIONS = [
+    FilesystemPermission(operations=["read", "write"], paths=WORKSPACE_FENCE_SUBTREES, mode="allow"),
+    FilesystemPermission(operations=["read", "write"], paths=[WORKSPACE_PATH, f"{WORKSPACE_PATH}/**"], mode="deny"),
+]
 
 CUSTOM_TOOL_DESCRIPTIONS = {
     "grep": GREP_TOOL_DESCRIPTION,

--- a/daiv/automation/agent/middlewares/skills.py
+++ b/daiv/automation/agent/middlewares/skills.py
@@ -16,7 +16,7 @@ from langgraph.types import Command
 from skills.services import _record_invocation
 
 from automation.agent.conf import settings as agent_settings
-from automation.agent.constants import BUILTIN_SKILLS_PATH, GLOBAL_SKILLS_PATH, SKILLS_CACHE_PATH
+from automation.agent.constants import BUILTIN_SKILLS_PATH, SKILLS_CACHE_PATH, SKILLS_PATH
 from automation.agent.middlewares.file_system import WRITE_TOOL_NAMES
 from automation.agent.utils import extract_body_from_frontmatter
 from codebase.context import RuntimeCtx  # noqa: TC001
@@ -104,7 +104,7 @@ AVAILABLE_SKILLS_TEMPLATE = PromptTemplate.from_template(
 class SkillsMiddleware(DeepAgentsSkillsMiddleware):
     """
     Middleware that loads skill metadata and, in disk-backed (non-sandbox) mode, copies builtin
-    and custom global skills into the ``/skills`` cache so they are available even when the
+    and custom global skills into the ``/workspace/skills`` cache so they are available even when the
     project skills directory is not set up. In sandbox mode global skills are provisioned by the
     sandbox seed (SandboxMiddleware), so no upload happens here.
     """
@@ -122,7 +122,7 @@ class SkillsMiddleware(DeepAgentsSkillsMiddleware):
     ) -> SkillsStateUpdate | dict | None:
         """
         Load skill metadata and (disk-mode only) materialize global skills into the
-        ``/skills`` cache. In sandbox mode global skills are provisioned by the sandbox
+        ``/workspace/skills`` cache. In sandbox mode global skills are provisioned by the sandbox
         seed (SandboxMiddleware), so no upload happens here; discovery reads the bound,
         seeded sandbox via ``super().abefore_agent``.
 
@@ -151,7 +151,7 @@ class SkillsMiddleware(DeepAgentsSkillsMiddleware):
 
     async def _copy_global_skills(self) -> list[str]:
         """
-        Materialize builtin and custom global skills into the virtual ``GLOBAL_SKILLS_PATH``,
+        Materialize builtin and custom global skills into the virtual ``SKILLS_PATH``,
         sibling to the agent's working directory. Custom global skills override builtins with
         the same name at first cache population.
 
@@ -159,7 +159,7 @@ class SkillsMiddleware(DeepAgentsSkillsMiddleware):
         """
         files_to_upload: list[tuple[str, bytes]] = []
         errors: list[str] = []
-        skills_path = Path(GLOBAL_SKILLS_PATH)
+        skills_path = Path(SKILLS_PATH)
 
         self._collect_skill_files(BUILTIN_SKILLS_PATH, skills_path, files_to_upload, errors)
 
@@ -213,7 +213,7 @@ class SkillsMiddleware(DeepAgentsSkillsMiddleware):
                     rel = source_path.relative_to(source_root)
                     # Real existence check on the disk-backed skills cache so per-turn
                     # uploads become a no-op once the cache is populated. ``dest_path``
-                    # is a virtual path under ``GLOBAL_SKILLS_PATH``, which never exists
+                    # is a virtual path under ``SKILLS_PATH``, which never exists
                     # on the host fs — the disk equivalent is ``SKILLS_CACHE_PATH/rel``.
                     dest_path = project_skills_path / rel
                     if (SKILLS_CACHE_PATH / rel).exists():

--- a/daiv/automation/agent/subagents.py
+++ b/daiv/automation/agent/subagents.py
@@ -1,6 +1,5 @@
 import logging
 import re
-from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import yaml
@@ -13,7 +12,13 @@ from langchain.agents import create_agent
 from langchain.agents.middleware import AgentMiddleware, ModelFallbackMiddleware, TodoListMiddleware
 
 from automation.agent import BaseAgent
-from automation.agent.middlewares.file_system import CUSTOM_TOOL_DESCRIPTIONS, filesystem_absolute_path_directive
+from automation.agent.constants import REPO_PATH, WORKSPACE_PATH
+from automation.agent.middlewares.file_system import (
+    CUSTOM_TOOL_DESCRIPTIONS,
+    WORKSPACE_FENCE_PERMISSIONS,
+    WORKSPACE_FENCE_SUBTREES,
+    filesystem_absolute_path_directive,
+)
 from automation.agent.middlewares.git_platform import GitPlatformMiddleware
 from automation.agent.middlewares.logging import ToolCallLoggingMiddleware
 from automation.agent.middlewares.prompt_cache import AnthropicPromptCachingMiddleware
@@ -74,7 +79,11 @@ def _build_general_purpose_middleware(
 
     middleware: list[AgentMiddleware[Any, Any, Any]] = [
         TodoListMiddleware(system_prompt=dynamic_write_todos_system_prompt(bash_tool_enabled=sandbox_enabled)),
-        FilesystemMiddleware(backend=backend, custom_tool_descriptions=CUSTOM_TOOL_DESCRIPTIONS),
+        FilesystemMiddleware(
+            backend=backend,
+            custom_tool_descriptions=CUSTOM_TOOL_DESCRIPTIONS,
+            _permissions=None if sandbox_enabled else WORKSPACE_FENCE_PERMISSIONS,
+        ),
         GitPlatformMiddleware(git_platform=runtime.git_platform, backend=backend),
         SummarizationMiddleware(
             model=model,
@@ -96,11 +105,8 @@ def _build_general_purpose_middleware(
         middleware.append(WebFetchMiddleware())
 
     if sandbox_enabled:
-        agent_path = Path(runtime.gitrepo.working_dir)
         middleware.append(
-            SandboxMiddleware(
-                agent_root=f"/{agent_path.name}", client=client, sandbox_backend=sandbox_backend, close_session=False
-            )
+            SandboxMiddleware(agent_root=REPO_PATH, client=client, sandbox_backend=sandbox_backend, close_session=False)
         )
 
     if fallback_models:
@@ -196,8 +202,24 @@ READ_ONLY_PERMISSIONS: list[FilesystemPermission] = [
     FilesystemPermission(operations=["write"], paths=["/**"], mode="deny")
 ]
 
+# Disk-mode explore permissions: read-only (deny all writes) AND fenced to the three real
+# /workspace subtrees for reads, so the explore agent never surfaces bare-/workspace or
+# offloaded-artifact paths in its report. Sandbox mode keeps plain read-only (bash is unconstrained).
+EXPLORE_DISK_PERMISSIONS: list[FilesystemPermission] = [
+    *READ_ONLY_PERMISSIONS,
+    FilesystemPermission(operations=["read"], paths=WORKSPACE_FENCE_SUBTREES, mode="allow"),
+    FilesystemPermission(operations=["read"], paths=[WORKSPACE_PATH, f"{WORKSPACE_PATH}/**"], mode="deny"),
+]
 
-def create_explore_subagent(backend: BackendProtocol, working_directory: str, **kwargs) -> CompiledSubAgent:
+
+def _explore_permissions(*, sandbox_enabled: bool) -> list[FilesystemPermission]:
+    """Read-only everywhere; additionally fence reads to the real subtrees in disk mode."""
+    return READ_ONLY_PERMISSIONS if sandbox_enabled else EXPLORE_DISK_PERMISSIONS
+
+
+def create_explore_subagent(
+    backend: BackendProtocol, working_directory: str, *, sandbox_enabled: bool = True, **kwargs
+) -> CompiledSubAgent:
     """
     Create the explore subagent.
     """
@@ -210,7 +232,9 @@ def create_explore_subagent(backend: BackendProtocol, working_directory: str, **
     middleware: list[AgentMiddleware[Any, Any, Any]] = [
         TodoListMiddleware(system_prompt=dynamic_write_todos_system_prompt(bash_tool_enabled=False)),
         FilesystemMiddleware(
-            backend=backend, custom_tool_descriptions=CUSTOM_TOOL_DESCRIPTIONS, _permissions=READ_ONLY_PERMISSIONS
+            backend=backend,
+            custom_tool_descriptions=CUSTOM_TOOL_DESCRIPTIONS,
+            _permissions=_explore_permissions(sandbox_enabled=sandbox_enabled),
         ),
         SummarizationMiddleware(
             model=model,

--- a/daiv/automation/agent/subagents.py
+++ b/daiv/automation/agent/subagents.py
@@ -15,6 +15,7 @@ from automation.agent import BaseAgent
 from automation.agent.constants import REPO_PATH, WORKSPACE_PATH
 from automation.agent.middlewares.file_system import (
     CUSTOM_TOOL_DESCRIPTIONS,
+    WORKSPACE_ARTIFACT_SUBTREES,
     WORKSPACE_FENCE_PERMISSIONS,
     WORKSPACE_FENCE_SUBTREES,
     filesystem_absolute_path_directive,
@@ -202,12 +203,15 @@ READ_ONLY_PERMISSIONS: list[FilesystemPermission] = [
     FilesystemPermission(operations=["write"], paths=["/**"], mode="deny")
 ]
 
-# Disk-mode explore permissions: read-only (deny all writes) AND fenced to the three real
-# /workspace subtrees for reads, so the explore agent never surfaces bare-/workspace or
-# offloaded-artifact paths in its report. Sandbox mode keeps plain read-only (bash is unconstrained).
+# Disk-mode explore permissions: read-only (deny all writes) AND fenced for reads to the three real
+# /workspace subtrees plus the offloaded-artifact dirs (so the explore agent's own eviction read-back
+# still works — same asymmetry as WORKSPACE_FENCE_PERMISSIONS), denying bare /workspace and any other
+# path beneath it. Sandbox mode keeps plain read-only (bash is unconstrained).
 EXPLORE_DISK_PERMISSIONS: list[FilesystemPermission] = [
     *READ_ONLY_PERMISSIONS,
-    FilesystemPermission(operations=["read"], paths=WORKSPACE_FENCE_SUBTREES, mode="allow"),
+    FilesystemPermission(
+        operations=["read"], paths=[*WORKSPACE_FENCE_SUBTREES, *WORKSPACE_ARTIFACT_SUBTREES], mode="allow"
+    ),
     FilesystemPermission(operations=["read"], paths=[WORKSPACE_PATH, f"{WORKSPACE_PATH}/**"], mode="deny"),
 ]
 

--- a/daiv/skills/services.py
+++ b/daiv/skills/services.py
@@ -21,7 +21,7 @@ from django.db.utils import Error as DjangoDBError
 import yaml
 
 from automation.agent.conf import settings as agent_settings
-from automation.agent.constants import BUILTIN_SKILLS_PATH, GLOBAL_SKILLS_PATH, SKILLS_CACHE_PATH
+from automation.agent.constants import BUILTIN_SKILLS_PATH, SKILLS_CACHE_PATH, SKILLS_PATH
 from skills.constants import (
     ALLOWED_SUFFIXES,
     FORBIDDEN_PATH_PARTS,
@@ -298,11 +298,11 @@ async def _classify_source(name: str, skill_path: str) -> SkillInvocation.Source
 
     A custom global skill shadows a built-in of the same name, so a
     ``GlobalSkill`` row wins over ``BUILTIN_SKILL_NAMES`` membership when both
-    match. Anything outside ``GLOBAL_SKILLS_PATH`` is treated as per-repo; if
+    match. Anything outside ``SKILLS_PATH`` is treated as per-repo; if
     a new skill location is introduced and not added here, the caller logs a
     warning.
     """
-    if skill_path.startswith(GLOBAL_SKILLS_PATH + "/"):
+    if skill_path.startswith(SKILLS_PATH + "/"):
         if await GlobalSkill.objects.filter(name=name).aexists():
             return SkillInvocation.Source.GLOBAL
         if name in BUILTIN_SKILL_NAMES:

--- a/tests/unit_tests/automation/agent/middlewares/test_file_system.py
+++ b/tests/unit_tests/automation/agent/middlewares/test_file_system.py
@@ -6,10 +6,16 @@ from typing import TYPE_CHECKING, Any
 
 import pytest
 from deepagents.middleware.filesystem import FilesystemMiddleware as UpstreamFilesystemMiddleware
+from deepagents.middleware.filesystem import _check_fs_permission
 from langchain_core.messages import ToolMessage
 
 from automation.agent.middlewares import file_system as fs_module
-from automation.agent.middlewares.file_system import EDIT_SUCCESS_PREFIX, WRITE_SUCCESS_PREFIX, DAIVFilesystemBackend
+from automation.agent.middlewares.file_system import (
+    EDIT_SUCCESS_PREFIX,
+    WORKSPACE_FENCE_PERMISSIONS,
+    WRITE_SUCCESS_PREFIX,
+    DAIVFilesystemBackend,
+)
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -194,3 +200,28 @@ def test_filesystem_absolute_path_directive_normalizes_trailing_slash():
     from automation.agent.middlewares.file_system import filesystem_absolute_path_directive
 
     assert "/workspace/repo/path/to/file.py" in filesystem_absolute_path_directive("/workspace/repo")
+
+
+class TestWorkspaceFencePermissions:
+    """Disk-mode fence: allow the three real subtrees, deny the bare /workspace root
+    and the offloaded-artifact dirs, for both read and write."""
+
+    def test_allows_real_subtrees(self):
+        for op in ("read", "write"):
+            for path in (
+                "/workspace/repo",
+                "/workspace/repo/daiv/foo.py",
+                "/workspace/skills",
+                "/workspace/skills/code-review/SKILL.md",
+                "/workspace/tmp",
+                "/workspace/tmp/scratch.txt",
+            ):
+                assert _check_fs_permission(WORKSPACE_FENCE_PERMISSIONS, op, path) == "allow", (op, path)
+
+    def test_denies_bare_root_and_artifact_dirs(self):
+        for op in ("read", "write"):
+            for path in ("/workspace", "/workspace/large_tool_results/x", "/workspace/conversation_history/y"):
+                assert _check_fs_permission(WORKSPACE_FENCE_PERMISSIONS, op, path) == "deny", (op, path)
+
+    def test_paths_outside_workspace_default_allow(self):
+        assert _check_fs_permission(WORKSPACE_FENCE_PERMISSIONS, "read", "/etc/passwd") == "allow"

--- a/tests/unit_tests/automation/agent/middlewares/test_file_system.py
+++ b/tests/unit_tests/automation/agent/middlewares/test_file_system.py
@@ -204,8 +204,9 @@ def test_filesystem_absolute_path_directive_normalizes_trailing_slash():
 
 
 class TestWorkspaceFencePermissions:
-    """Disk-mode fence: allow the three real subtrees, deny the bare /workspace root
-    and the offloaded-artifact dirs, for both read and write."""
+    """Disk-mode fence: allow read+write under the three real subtrees, read-only access to the
+    offloaded-artifact dirs (so eviction read-back works), and deny the bare /workspace root plus
+    any other path beneath it."""
 
     def test_allows_real_subtrees(self):
         for op in ("read", "write"):
@@ -219,10 +220,37 @@ class TestWorkspaceFencePermissions:
             ):
                 assert _check_fs_permission(WORKSPACE_FENCE_PERMISSIONS, op, path) == "allow", (op, path)
 
-    def test_denies_bare_root_and_artifact_dirs(self):
+    def test_denies_bare_root_and_unrelated_workspace_paths(self):
+        # Bare /workspace (the deny needs the literal pattern; /workspace/** does not match it) and
+        # any path under /workspace that isn't a real subtree or an artifact dir are denied both ways.
         for op in ("read", "write"):
-            for path in ("/workspace", "/workspace/large_tool_results/x", "/workspace/conversation_history/y"):
+            for path in ("/workspace", "/workspace/random", "/workspace/repofoo", "/workspace/repofoo/x"):
                 assert _check_fs_permission(WORKSPACE_FENCE_PERMISSIONS, op, path) == "deny", (op, path)
+
+    def test_artifact_dirs_are_readable_but_not_writable(self):
+        # Eviction / output_to_file write here through the backend directly (bypassing the fence);
+        # the agent must be able to read the offloaded file back, but never writes here itself.
+        for path in (
+            "/workspace/large_tool_results",
+            "/workspace/large_tool_results/call_abc",
+            "/workspace/conversation_history",
+            "/workspace/conversation_history/uuid.md",
+        ):
+            assert _check_fs_permission(WORKSPACE_FENCE_PERMISSIONS, "read", path) == "allow", path
+            assert _check_fs_permission(WORKSPACE_FENCE_PERMISSIONS, "write", path) == "deny", path
+
+    def test_fence_allows_framework_offload_prefixes(self, tmp_path):
+        """Drift-guard: the artifact read carve-out must cover whatever offload prefixes deepagents
+        derives from ``artifacts_root``. If a framework bump renames those dirs, this fails loudly
+        instead of silently re-breaking offload read-back in disk mode."""
+        clone_dir = tmp_path / "repo"
+        clone_dir.mkdir()
+        backend = build_disk_workspace_backend(clone_dir, skills_cache=tmp_path / "skills_cache")
+        middleware = UpstreamFilesystemMiddleware(backend=backend, _permissions=WORKSPACE_FENCE_PERMISSIONS)
+
+        for prefix in (middleware._large_tool_results_prefix, middleware._conversation_history_prefix):
+            assert _check_fs_permission(WORKSPACE_FENCE_PERMISSIONS, "read", f"{prefix}/some-id") == "allow", prefix
+            assert _check_fs_permission(WORKSPACE_FENCE_PERMISSIONS, "write", f"{prefix}/some-id") == "deny", prefix
 
     def test_paths_outside_workspace_default_allow(self):
         assert _check_fs_permission(WORKSPACE_FENCE_PERMISSIONS, "read", "/etc/passwd") == "allow"

--- a/tests/unit_tests/automation/agent/middlewares/test_file_system.py
+++ b/tests/unit_tests/automation/agent/middlewares/test_file_system.py
@@ -15,6 +15,7 @@ from automation.agent.middlewares.file_system import (
     WORKSPACE_FENCE_PERMISSIONS,
     WRITE_SUCCESS_PREFIX,
     DAIVFilesystemBackend,
+    build_disk_workspace_backend,
 )
 
 if TYPE_CHECKING:
@@ -225,3 +226,30 @@ class TestWorkspaceFencePermissions:
 
     def test_paths_outside_workspace_default_allow(self):
         assert _check_fs_permission(WORKSPACE_FENCE_PERMISSIONS, "read", "/etc/passwd") == "allow"
+
+
+class TestBuildDiskWorkspaceBackend:
+    """The disk composite maps the unified /workspace namespace onto local disk locations."""
+
+    async def test_routes_repo_skills_and_tmp(self, tmp_path):
+        clone_dir = tmp_path / "repo"
+        clone_dir.mkdir()
+        skills_cache = tmp_path / "skills_cache"
+        skills_cache.mkdir()
+
+        backend = build_disk_workspace_backend(clone_dir, skills_cache=skills_cache)
+
+        assert (await backend.awrite("/workspace/repo/a.txt", "R")).error is None
+        assert (clone_dir / "a.txt").read_text() == "R"
+
+        assert (await backend.awrite("/workspace/skills/s.txt", "S")).error is None
+        assert (skills_cache / "s.txt").read_text() == "S"
+
+        assert (await backend.awrite("/workspace/tmp/t.txt", "T")).error is None
+        assert (clone_dir.parent / "workspace" / "tmp" / "t.txt").read_text() == "T"
+
+    def test_artifacts_root_is_workspace(self, tmp_path):
+        clone_dir = tmp_path / "repo"
+        clone_dir.mkdir()
+        backend = build_disk_workspace_backend(clone_dir, skills_cache=tmp_path / "skills_cache")
+        assert backend.artifacts_root == "/workspace"

--- a/tests/unit_tests/automation/agent/middlewares/test_skills.py
+++ b/tests/unit_tests/automation/agent/middlewares/test_skills.py
@@ -94,7 +94,12 @@ class TestSkillsMiddleware:
         state = {
             "messages": [HumanMessage(content="hello")],
             "skills_metadata": [
-                {"name": "skill-one", "description": "ok", "path": "/skills/skill-one/SKILL.md", "metadata": {}}
+                {
+                    "name": "skill-one",
+                    "description": "ok",
+                    "path": "/workspace/skills/skill-one/SKILL.md",
+                    "metadata": {},
+                }
             ],
         }
 
@@ -218,11 +223,16 @@ class TestSkillsMiddleware:
     def test_format_skills_list_renders_xml(self):
         middleware = SkillsMiddleware(backend=Mock(), sources=["/skills"])
         formatted = middleware._format_skills_list([
-            {"name": "skill-one", "description": "does one", "path": "/skills/skill-one/SKILL.md", "metadata": {}},
+            {
+                "name": "skill-one",
+                "description": "does one",
+                "path": "/workspace/skills/skill-one/SKILL.md",
+                "metadata": {},
+            },
             {
                 "name": "custom-skill",
                 "description": "does custom",
-                "path": "/skills/custom-skill/SKILL.md",
+                "path": "/workspace/skills/custom-skill/SKILL.md",
                 "metadata": {},
             },
         ])
@@ -280,7 +290,7 @@ class TestSkillsMiddleware:
         tool = middleware._skill_tool_generator()
 
         runtime = Mock()
-        runtime.state = {"skills_metadata": [{"name": "demo", "path": "/skills/demo/SKILL.md"}]}
+        runtime.state = {"skills_metadata": [{"name": "demo", "path": "/workspace/skills/demo/SKILL.md"}]}
         runtime.tool_call_id = "call_1"
 
         with patch("skills.services.SkillInvocation.objects.acreate", new_callable=AsyncMock) as mock_acreate:
@@ -296,7 +306,7 @@ class TestSkillsMiddleware:
         tool = middleware._skill_tool_generator()
 
         runtime = Mock()
-        runtime.state = {"skills_metadata": [{"name": "demo", "path": "/skills/demo/SKILL.md"}]}
+        runtime.state = {"skills_metadata": [{"name": "demo", "path": "/workspace/skills/demo/SKILL.md"}]}
         runtime.tool_call_id = "call_1"
 
         with patch("skills.services.SkillInvocation.objects.acreate", new_callable=AsyncMock) as mock_acreate:
@@ -319,7 +329,7 @@ class TestSkillsMiddleware:
         tool = middleware._skill_tool_generator()
 
         runtime = Mock()
-        runtime.state = {"skills_metadata": [{"name": "demo", "path": "/skills/demo/SKILL.md"}]}
+        runtime.state = {"skills_metadata": [{"name": "demo", "path": "/workspace/skills/demo/SKILL.md"}]}
         runtime.tool_call_id = "call_1"
 
         with patch("automation.agent.middlewares.skills._record_invocation", new_callable=AsyncMock):
@@ -341,7 +351,7 @@ class TestSkillsMiddleware:
         tool = middleware._skill_tool_generator()
 
         runtime = Mock()
-        runtime.state = {"skills_metadata": [{"name": "demo", "path": "/skills/demo/SKILL.md"}]}
+        runtime.state = {"skills_metadata": [{"name": "demo", "path": "/workspace/skills/demo/SKILL.md"}]}
         runtime.tool_call_id = "call_1"
 
         with patch("automation.agent.middlewares.skills._record_invocation", new_callable=AsyncMock):
@@ -850,7 +860,7 @@ class TestCustomGlobalSkills:
             _make_skill_md(name="leftover", description="staging leftover")
         )
 
-        project_skills_path = _Path("/skills")
+        project_skills_path = _Path("/workspace/skills")
         files_to_upload: list[tuple[str, bytes]] = []
         errors: list[str] = []
 
@@ -859,7 +869,7 @@ class TestCustomGlobalSkills:
 
         # Only files under demo/ should be collected. No .trash, .zips, or .tmp entries.
         dest_paths = [dest for dest, _ in files_to_upload]
-        assert dest_paths == ["/skills/demo/SKILL.md"]
+        assert dest_paths == ["/workspace/skills/demo/SKILL.md"]
         assert not any(".trash" in dest for dest in dest_paths)
         assert not any(".zips" in dest for dest in dest_paths)
         assert not any(".tmp" in dest for dest in dest_paths)
@@ -890,7 +900,7 @@ class TestSkillToolRecordsInvocation:
                 {
                     "name": "code-review",
                     "description": "review code",
-                    "path": "/skills/code-review/SKILL.md",
+                    "path": "/workspace/skills/code-review/SKILL.md",
                     "metadata": {},
                 }
             ]

--- a/tests/unit_tests/automation/agent/middlewares/test_skills.py
+++ b/tests/unit_tests/automation/agent/middlewares/test_skills.py
@@ -64,7 +64,7 @@ class TestSkillsMiddleware:
         (builtin / "__pycache__" / "ignored.txt").write_text("ignored\n")
 
         backend = FilesystemBackend(root_dir=tmp_path, virtual_mode=True)
-        middleware = SkillsMiddleware(backend=backend, sources=["/skills"])
+        middleware = SkillsMiddleware(backend=backend, sources=["/workspace/skills"])
         runtime = _make_runtime(repo_working_dir=str(tmp_path / repo_name))
 
         with patch("automation.agent.middlewares.skills.BUILTIN_SKILLS_PATH", builtin):
@@ -75,8 +75,8 @@ class TestSkillsMiddleware:
         assert set(skills) == {"skill-one", "skill-two"}
         assert skills["skill-one"]["description"] == "does one"
         assert skills["skill-two"]["description"] == "does two"
-        assert skills["skill-one"]["path"] == "/skills/skill-one/SKILL.md"
-        assert skills["skill-two"]["path"] == "/skills/skill-two/SKILL.md"
+        assert skills["skill-one"]["path"] == "/workspace/skills/skill-one/SKILL.md"
+        assert skills["skill-two"]["path"] == "/workspace/skills/skill-two/SKILL.md"
 
     async def test_skips_copy_global_skills_when_metadata_already_cached(self, tmp_path: Path):
         """Once skills_metadata is in state, abefore_agent must not re-walk the filesystem."""
@@ -125,7 +125,7 @@ class TestSkillsMiddleware:
         )
 
         backend = FilesystemBackend(root_dir=tmp_path, virtual_mode=True)
-        middleware = SkillsMiddleware(backend=backend, sources=["/skills", f"/{repo_name}/.agents/skills"])
+        middleware = SkillsMiddleware(backend=backend, sources=["/workspace/skills", f"/{repo_name}/.agents/skills"])
         runtime = _make_runtime(repo_working_dir=str(tmp_path / repo_name))
 
         with patch("automation.agent.middlewares.skills.BUILTIN_SKILLS_PATH", builtin):
@@ -157,12 +157,12 @@ class TestSkillsMiddleware:
         (builtin / "__pycache__" / "ignored.txt").write_text("ignored\n")
 
         backend = FilesystemBackend(root_dir=tmp_path, virtual_mode=True)
-        middleware = SkillsMiddleware(backend=backend, sources=["/skills"])
+        middleware = SkillsMiddleware(backend=backend, sources=["/workspace/skills"])
 
         with patch("automation.agent.middlewares.skills.BUILTIN_SKILLS_PATH", builtin):
             await middleware._copy_global_skills()
 
-        skills_root = tmp_path / "skills"
+        skills_root = tmp_path / "workspace" / "skills"
         assert (skills_root / "skill-one" / "SKILL.md").read_text() == _make_skill_md(
             name="skill-one", description="does one"
         )
@@ -184,7 +184,7 @@ class TestSkillsMiddleware:
 
         cache_root = tmp_path / "skills"
         backend = FilesystemBackend(root_dir=tmp_path, virtual_mode=True)
-        middleware = SkillsMiddleware(backend=backend, sources=["/skills"])
+        middleware = SkillsMiddleware(backend=backend, sources=["/workspace/skills"])
 
         existing_skill_md = cache_root / "skill-one" / "SKILL.md"
         existing_skill_md.parent.mkdir(parents=True, exist_ok=True)
@@ -198,7 +198,7 @@ class TestSkillsMiddleware:
 
         # SKILL.md must not be overwritten; sibling files are still uploaded.
         assert existing_skill_md.read_text() == _make_skill_md(name="skill-one", description="existing")
-        assert (tmp_path / "skills" / "skill-one" / "helpers" / "util.py").read_text() == "print('one')\n"
+        assert (tmp_path / "workspace" / "skills" / "skill-one" / "helpers" / "util.py").read_text() == "print('one')\n"
 
     async def test_raises_when_backend_returns_error(self, tmp_path: Path):
         builtin = tmp_path / "builtin_skills"
@@ -374,7 +374,7 @@ class TestSkillsMiddleware:
 
         backend = FilesystemBackend(root_dir=tmp_path, virtual_mode=True)
         middleware = SkillsMiddleware(
-            backend=backend, sources=["/skills", *[f"/{repo_name}/{source}" for source in SKILLS_SOURCES]]
+            backend=backend, sources=["/workspace/skills", *[f"/{repo_name}/{source}" for source in SKILLS_SOURCES]]
         )
         runtime = _make_runtime(repo_working_dir=str(tmp_path / repo_name))
 
@@ -564,7 +564,7 @@ class TestCustomGlobalSkills:
         )
 
         backend = FilesystemBackend(root_dir=tmp_path, virtual_mode=True)
-        middleware = SkillsMiddleware(backend=backend, sources=["/skills"])
+        middleware = SkillsMiddleware(backend=backend, sources=["/workspace/skills"])
         runtime = _make_runtime(repo_working_dir=str(tmp_path / repo_name))
 
         with (
@@ -592,7 +592,7 @@ class TestCustomGlobalSkills:
         (custom_global / "plan" / "SKILL.md").write_text(_make_skill_md(name="plan", description="custom plan"))
 
         backend = FilesystemBackend(root_dir=tmp_path, virtual_mode=True)
-        middleware = SkillsMiddleware(backend=backend, sources=["/skills"])
+        middleware = SkillsMiddleware(backend=backend, sources=["/workspace/skills"])
         runtime = _make_runtime(repo_working_dir=str(tmp_path / repo_name))
 
         with (
@@ -619,7 +619,7 @@ class TestCustomGlobalSkills:
         )
 
         backend = FilesystemBackend(root_dir=tmp_path, virtual_mode=True)
-        middleware = SkillsMiddleware(backend=backend, sources=["/skills"])
+        middleware = SkillsMiddleware(backend=backend, sources=["/workspace/skills"])
 
         with (
             patch("automation.agent.middlewares.skills.BUILTIN_SKILLS_PATH", builtin),
@@ -628,7 +628,7 @@ class TestCustomGlobalSkills:
             await middleware._copy_global_skills()
 
         # File-level: custom global SKILL.md must have been materialized into the cache.
-        assert (tmp_path / "skills" / "global-skill" / "SKILL.md").exists()
+        assert (tmp_path / "workspace" / "skills" / "global-skill" / "SKILL.md").exists()
 
     async def test_per_repo_skill_overrides_custom_global(self, tmp_path: Path):
         from deepagents.backends.filesystem import FilesystemBackend
@@ -671,7 +671,7 @@ class TestCustomGlobalSkills:
         (builtin / "skill-one" / "SKILL.md").write_text(_make_skill_md(name="skill-one", description="builtin one"))
 
         backend = FilesystemBackend(root_dir=tmp_path, virtual_mode=True)
-        middleware = SkillsMiddleware(backend=backend, sources=["/skills"])
+        middleware = SkillsMiddleware(backend=backend, sources=["/workspace/skills"])
 
         with (
             patch("automation.agent.middlewares.skills.BUILTIN_SKILLS_PATH", builtin),
@@ -680,7 +680,7 @@ class TestCustomGlobalSkills:
             assert await middleware._copy_global_skills() == []
 
         # Built-in skill was materialized.
-        assert (tmp_path / "skills" / "skill-one" / "SKILL.md").exists()
+        assert (tmp_path / "workspace" / "skills" / "skill-one" / "SKILL.md").exists()
 
     async def test_custom_global_skills_missing_path_does_not_surface_to_agent(self, tmp_path: Path):
         from deepagents.backends.filesystem import FilesystemBackend
@@ -690,7 +690,7 @@ class TestCustomGlobalSkills:
         (builtin / "skill-one" / "SKILL.md").write_text(_make_skill_md(name="skill-one", description="builtin one"))
 
         backend = FilesystemBackend(root_dir=tmp_path, virtual_mode=True)
-        middleware = SkillsMiddleware(backend=backend, sources=["/skills"])
+        middleware = SkillsMiddleware(backend=backend, sources=["/workspace/skills"])
         missing = tmp_path / "nonexistent"
 
         with (
@@ -702,7 +702,7 @@ class TestCustomGlobalSkills:
         # A misconfigured host path is an operator concern, not an agent one — it's logged
         # but must not surface in skills_load_errors where the agent would see it.
         assert errors == []
-        assert (tmp_path / "skills" / "skill-one" / "SKILL.md").exists()
+        assert (tmp_path / "workspace" / "skills" / "skill-one" / "SKILL.md").exists()
 
     async def test_custom_global_skills_oserror_surfaces_in_load_errors(self, tmp_path: Path):
         """An OSError raised while walking the custom-skills dir must reach skills_load_errors."""

--- a/tests/unit_tests/automation/agent/test_graph_construction.py
+++ b/tests/unit_tests/automation/agent/test_graph_construction.py
@@ -51,15 +51,11 @@ def test_graph_constructs_sandbox_backend_without_root():
     assert "SandboxFileBackend(root=" not in src, "graph.py must NOT pass a root to SandboxFileBackend (pass-through)"
 
 
-def test_graph_sandbox_global_skills_source_is_workspace_skills():
+def test_global_skills_source_is_workspace_skills():
     src = inspect.getsource(graph_module)
-    # In sandbox mode the global-skills discovery source must be the real sandbox dir,
-    # not the route-relative "/skills" used by the disk-backed composite.
+    # global_skills_source is now unconditional (/workspace/skills) across sandbox and disk modes.
     assert "global_skills_source = SKILLS_PATH" in src, (
         "graph.py sandbox branch must use SKILLS_PATH (/workspace/skills) as the global-skills source"
-    )
-    assert "global_skills_source = GLOBAL_SKILLS_PATH" in src, (
-        "graph.py non-sandbox branch must keep GLOBAL_SKILLS_PATH (/skills) as the global-skills source"
     )
 
 

--- a/tests/unit_tests/automation/agent/test_graph_construction.py
+++ b/tests/unit_tests/automation/agent/test_graph_construction.py
@@ -27,7 +27,7 @@ def test_general_purpose_subagent_passes_backend_and_agent_root_to_sandbox_middl
     assert "SandboxMiddleware(" in src and "backend=backend" in src, (
         "subagents.py must construct SandboxMiddleware with backend"
     )
-    assert 'agent_root=f"/{agent_path.name}"' in src, "subagents.py must pass agent_root to SandboxMiddleware"
+    assert "agent_root=REPO_PATH" in src, "subagents.py must pass agent_root to SandboxMiddleware"
     assert "if sandbox_enabled:" in src, "subagents.py must gate SandboxMiddleware on sandbox_enabled"
 
 

--- a/tests/unit_tests/automation/agent/test_graph_deferred.py
+++ b/tests/unit_tests/automation/agent/test_graph_deferred.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 def _common_patches():
     """Patches that disable side effects unrelated to the deferred-tools wiring."""
     return [
-        patch("automation.agent.graph.DAIVFilesystemBackend"),
+        patch("automation.agent.graph.build_disk_workspace_backend"),
         patch("automation.agent.graph.DAIVCompositeBackend"),
         patch("automation.agent.graph.create_general_purpose_subagent"),
         patch("automation.agent.graph.create_explore_subagent"),
@@ -105,29 +105,3 @@ def test_output_invariants_prompt_keys_off_working_directory():
 
     disk = _output_invariants_system_prompt("/myrepo/")
     assert '"/myrepo/"' in disk
-
-
-def test_resolve_working_directory_derivation_per_runtime():
-    """``_resolve_working_directory`` derives the prompt's repo root from runtime context, mirroring
-    ``create_daiv_agent``'s ``agent_root``: a sandbox run roots at ``REPO_PATH`` (sandbox-authoritative,
-    ignoring the on-disk ``working_dir``); a disk-backed run roots at the clone basename. Pinning this
-    (previously untested) keeps the main agent's prompt from silently desyncing from the paths its
-    tools and subagents address."""
-    from automation.agent.constants import REPO_PATH
-    from automation.agent.graph import _resolve_working_directory
-
-    def _ctx(*, sandbox_enabled: bool, working_dir: str):
-        ctx = MagicMock()
-        ctx.sandbox.enabled = sandbox_enabled
-        ctx.gitrepo.working_dir = working_dir
-        return ctx
-
-    # Sandbox: rooted at the sandbox-authoritative REPO_PATH, ignoring the on-disk working_dir basename.
-    assert _resolve_working_directory(_ctx(sandbox_enabled=True, working_dir="/on/disk/clone")) == f"{REPO_PATH}/"
-    # Disk-backed: rooted at the clone basename.
-    assert _resolve_working_directory(_ctx(sandbox_enabled=False, working_dir="/home/app/myclone")) == "/myclone/"
-    # A null sandbox runtime is treated as disabled (disk-backed), not an attribute error.
-    no_sandbox = MagicMock()
-    no_sandbox.sandbox = None
-    no_sandbox.gitrepo.working_dir = "/home/app/other"
-    assert _resolve_working_directory(no_sandbox) == "/other/"

--- a/tests/unit_tests/automation/agent/test_subagents.py
+++ b/tests/unit_tests/automation/agent/test_subagents.py
@@ -146,6 +146,36 @@ class TestGeneralPurposeMiddleware:
         )
         assert not any(isinstance(m, ModelFallbackMiddleware) for m in middleware)
 
+    def test_disk_mode_applies_workspace_fence(self, mock_model, mock_backend, mock_runtime_ctx):
+        from deepagents.middleware.filesystem import FilesystemMiddleware
+
+        from automation.agent.middlewares.file_system import WORKSPACE_FENCE_PERMISSIONS
+
+        middleware = _build_general_purpose_middleware(
+            mock_model,
+            mock_backend,
+            mock_runtime_ctx,
+            sandbox_enabled=False,
+            web_search_enabled=False,
+            web_fetch_enabled=False,
+        )
+        fs = next(m for m in middleware if isinstance(m, FilesystemMiddleware))
+        assert fs._permissions == WORKSPACE_FENCE_PERMISSIONS
+
+    def test_sandbox_mode_has_no_fence(self, mock_model, mock_backend, mock_runtime_ctx):
+        from deepagents.middleware.filesystem import FilesystemMiddleware
+
+        middleware = _build_general_purpose_middleware(
+            mock_model,
+            mock_backend,
+            mock_runtime_ctx,
+            sandbox_enabled=True,
+            web_search_enabled=False,
+            web_fetch_enabled=False,
+        )
+        fs = next(m for m in middleware if isinstance(m, FilesystemMiddleware))
+        assert fs._permissions == []
+
 
 class TestGeneralPurposeSubagent:
     """Tests for the public ``create_general_purpose_subagent`` factory."""
@@ -517,3 +547,22 @@ class TestCustomSubagents:
         names = {s["name"] for s in result}
         assert "bad-model" not in names
         assert "good" in names
+
+
+class TestExplorePermissions:
+    def test_sandbox_explore_is_read_only_only(self):
+        from automation.agent.subagents import READ_ONLY_PERMISSIONS, _explore_permissions
+
+        assert _explore_permissions(sandbox_enabled=True) == READ_ONLY_PERMISSIONS
+
+    def test_disk_explore_is_read_only_plus_read_fence(self):
+        from deepagents.middleware.filesystem import _check_fs_permission
+
+        from automation.agent.subagents import _explore_permissions
+
+        perms = _explore_permissions(sandbox_enabled=False)
+        assert _check_fs_permission(perms, "write", "/workspace/repo/foo.py") == "deny"
+        assert _check_fs_permission(perms, "read", "/workspace/repo/foo.py") == "allow"
+        assert _check_fs_permission(perms, "read", "/workspace/skills/x/SKILL.md") == "allow"
+        assert _check_fs_permission(perms, "read", "/workspace") == "deny"
+        assert _check_fs_permission(perms, "read", "/workspace/large_tool_results/x") == "deny"

--- a/tests/unit_tests/automation/agent/test_subagents.py
+++ b/tests/unit_tests/automation/agent/test_subagents.py
@@ -565,4 +565,6 @@ class TestExplorePermissions:
         assert _check_fs_permission(perms, "read", "/workspace/repo/foo.py") == "allow"
         assert _check_fs_permission(perms, "read", "/workspace/skills/x/SKILL.md") == "allow"
         assert _check_fs_permission(perms, "read", "/workspace") == "deny"
-        assert _check_fs_permission(perms, "read", "/workspace/large_tool_results/x") == "deny"
+        # offloaded-artifact dirs are readable (eviction read-back) but stay write-denied (read-only agent)
+        assert _check_fs_permission(perms, "read", "/workspace/large_tool_results/x") == "allow"
+        assert _check_fs_permission(perms, "write", "/workspace/large_tool_results/x") == "deny"

--- a/tests/unit_tests/skills/test_services.py
+++ b/tests/unit_tests/skills/test_services.py
@@ -25,7 +25,10 @@ def test_list_builtins_returns_dicts_with_name_and_description():
 async def test_classify_source_builtin_when_no_override_row():
     # No GlobalSkill row for this name → built-in resolution wins.
     with patch("skills.services.BUILTIN_SKILL_NAMES", frozenset({"code-review"})):
-        assert await _classify_source("code-review", "/skills/code-review/SKILL.md") == SkillInvocation.Source.BUILTIN
+        assert (
+            await _classify_source("code-review", "/workspace/skills/code-review/SKILL.md")
+            == SkillInvocation.Source.BUILTIN
+        )
 
 
 @pytest.mark.django_db(transaction=True)
@@ -36,19 +39,25 @@ async def test_classify_source_global_overrides_builtin_when_row_exists():
     from telemetry."""
     await GlobalSkill.objects.acreate(name="code-review", description="x", size_bytes=1, file_count=1, checksum="c")
     with patch("skills.services.BUILTIN_SKILL_NAMES", frozenset({"code-review"})):
-        assert await _classify_source("code-review", "/skills/code-review/SKILL.md") == SkillInvocation.Source.GLOBAL
+        assert (
+            await _classify_source("code-review", "/workspace/skills/code-review/SKILL.md")
+            == SkillInvocation.Source.GLOBAL
+        )
 
 
 @pytest.mark.django_db(transaction=True)
 async def test_classify_source_global_when_path_under_global_skills_path():
     await GlobalSkill.objects.acreate(name="custom-thing", description="x", size_bytes=1, file_count=1, checksum="c")
     with patch("skills.services.BUILTIN_SKILL_NAMES", frozenset()):
-        assert await _classify_source("custom-thing", "/skills/custom-thing/SKILL.md") == SkillInvocation.Source.GLOBAL
+        assert (
+            await _classify_source("custom-thing", "/workspace/skills/custom-thing/SKILL.md")
+            == SkillInvocation.Source.GLOBAL
+        )
 
 
 @pytest.mark.django_db(transaction=True)
 async def test_classify_source_repo_when_path_outside_global_skills_path():
-    # Pin the invariant that GLOBAL_SKILLS_PATH is the only gate to BUILTIN —
+    # Pin the invariant that SKILLS_PATH is the only gate to BUILTIN —
     # a per-repo skill whose name happens to match a built-in must still be
     # classified REPO, so per-repo overrides aren't mis-attributed in telemetry.
     with patch("skills.services.BUILTIN_SKILL_NAMES", frozenset({"repo-skill"})):
@@ -88,7 +97,7 @@ async def test_record_invocation_creates_row():
     tid = str(uuid.uuid4())
     rt = _runtime(repo_slug="org/repo", thread_id=tid)
     with patch("skills.services.BUILTIN_SKILL_NAMES", frozenset({"code-review"})):
-        await _record_invocation(name="code-review", skill_path="/skills/code-review/SKILL.md", runtime=rt)
+        await _record_invocation(name="code-review", skill_path="/workspace/skills/code-review/SKILL.md", runtime=rt)
     row = await SkillInvocation.objects.aget()
     assert row.name == "code-review"
     assert row.source == SkillInvocation.Source.BUILTIN
@@ -108,7 +117,7 @@ async def test_record_invocation_swallows_db_errors(caplog):
         patch.object(SkillInvocation.objects, "acreate", new=AsyncMock(side_effect=DatabaseError("db down"))),
     ):
         # Must not raise — telemetry failure cannot abort a skill invocation.
-        await _record_invocation(name="anything", skill_path="/skills/anything/SKILL.md", runtime=rt)
+        await _record_invocation(name="anything", skill_path="/workspace/skills/anything/SKILL.md", runtime=rt)
     assert any("Failed to record skill invocation" in rec.message for rec in caplog.records)
 
 
@@ -120,7 +129,7 @@ async def test_record_invocation_swallows_missing_thread_id(caplog):
     rt.context.repository.slug = "org/repo"
     rt.config = {"configurable": {}}  # no thread_id
     with patch("skills.services.BUILTIN_SKILL_NAMES", frozenset()):
-        await _record_invocation(name="anything", skill_path="/skills/anything/SKILL.md", runtime=rt)
+        await _record_invocation(name="anything", skill_path="/workspace/skills/anything/SKILL.md", runtime=rt)
     # No row created and the failure was logged.
     assert await SkillInvocation.objects.acount() == 0
     assert any("Failed to record skill invocation" in rec.message for rec in caplog.records)
@@ -136,6 +145,6 @@ async def test_record_invocation_swallows_none_config(caplog):
     rt.context.repository.slug = "org/repo"
     rt.config = None
     with patch("skills.services.BUILTIN_SKILL_NAMES", frozenset()):
-        await _record_invocation(name="anything", skill_path="/skills/anything/SKILL.md", runtime=rt)
+        await _record_invocation(name="anything", skill_path="/workspace/skills/anything/SKILL.md", runtime=rt)
     assert await SkillInvocation.objects.acount() == 0
     assert any("Failed to record skill invocation" in rec.message for rec in caplog.records)


### PR DESCRIPTION
## Summary

Unifies the agent's graph workspace root under a single `/workspace` namespace and adds a disk-only fence so the file tools stay inside the real subtrees.

- Add `TMP_PATH` and disk-mode `/workspace` fence permissions, plus `build_disk_workspace_backend` for the unified namespace.
- Route `/workspace/repo` and `/workspace/skills` through the disk composite; upload global skills under `/workspace/skills`.
- Fence subagents (incl. explore) to the real `/workspace` subtrees in disk mode; sandbox mode stays unconstrained (bash isn't fenced there).
- Allow read-back of offloaded-artifact dirs (`large_tool_results`, `conversation_history`) under the fence — the framework writes them through the backend directly, so the agent needs read (not write) to recover the content. Pinned with a drift-guard test against deepagents' computed prefixes.
- Drop the now-unused `GLOBAL_SKILLS_*` constants and stale `/repo` path guidance in the agent prompts.

## Notes

Targets `feat/sandbox-filebackend-scratchpad` (not `main`). Opened as a draft.

## Test plan

- [x] `uv run pytest tests/unit_tests/automation/agent/middlewares/test_file_system.py tests/unit_tests/automation/agent/test_subagents.py` — 42 passed