### PR TITLE
feat(agent): grep is a regex tool — disk + sandbox convergence, truncation surfacing

### DIFF
--- a/daiv/automation/agent/middlewares/ensure_response.py
+++ b/daiv/automation/agent/middlewares/ensure_response.py
@@ -24,7 +24,7 @@ EMPTY_RESPONSE_NUDGE = (
 
 def _is_empty(response: ModelResponse) -> bool:
     last_msg = response.result[-1]
-    return not last_msg.text() and not getattr(last_msg, "tool_calls", None)
+    return not last_msg.text and not getattr(last_msg, "tool_calls", None)
 
 
 @wrap_model_call(name="EnsureNonEmptyResponseMiddleware")  # ty: ignore[invalid-argument-type]  # async is supported at runtime; the protocol only types the sync form

--- a/daiv/automation/agent/middlewares/file_system.py
+++ b/daiv/automation/agent/middlewares/file_system.py
@@ -234,7 +234,7 @@ class DAIVFilesystemBackend(FilesystemBackend):
             return GrepResult(error=f"Error searching path '{path or '.'}': {exc}", matches=[])
         results = self._python_search(pattern, base_full, glob)
         matches = [
-            {"path": fpath, "line": int(line_num), "text": line_text}
+            GrepMatch(path=fpath, line=int(line_num), text=line_text)
             for fpath, items in results.items()
             for (line_num, line_text) in items
         ]

--- a/daiv/automation/agent/middlewares/file_system.py
+++ b/daiv/automation/agent/middlewares/file_system.py
@@ -530,7 +530,20 @@ class SandboxFileBackend(BackendProtocol):
             return GrepResult(error=f"Grep '{pattern}': {_fs_transport_failure_text(exc, 'grep', pattern)}")
         if resp.error is not None:
             return GrepResult(error=f"Grep '{pattern}': {_fs_error_text(resp.error)}")
-        return GrepResult(matches=[GrepMatch(path=self._rel(m.path), line=m.line, text=m.text) for m in resp.matches])
+        matches = [GrepMatch(path=self._rel(m.path), line=m.line, text=m.text) for m in resp.matches]
+        if resp.truncated:
+            logger.warning("grep results truncated for pattern %r under %s", pattern, path)
+            matches.append(
+                GrepMatch(
+                    path="(grep results truncated)",
+                    line=0,
+                    text=(
+                        f"Showing the first {len(resp.matches)} matches. Narrow the path, add a glob, "
+                        "or use a more specific pattern to see the rest."
+                    ),
+                )
+            )
+        return GrepResult(matches=matches)
 
     async def aglob(self, pattern: str, path: str = "/") -> GlobResult:
         client, session_id = self._require_bound()

--- a/daiv/automation/agent/middlewares/file_system.py
+++ b/daiv/automation/agent/middlewares/file_system.py
@@ -293,22 +293,6 @@ class DAIVCompositeBackend(CompositeBackend):
         backend, _ = self._get_backend_and_key(virtual_path)
         return backend
 
-    async def agrep(self, pattern: str, path: str | None = None, glob: str | None = None) -> GrepResult:
-        """Grep with a literal-semantics hint on suspicious zero-match patterns.
-
-        The hint lives here — on the *aggregate* result — and not in the sub-backends on
-        purpose: ``CompositeBackend.agrep`` treats any sub-backend ``error`` as a backend
-        failure and aborts aggregation, so a hint raised below this level would suppress
-        real matches from the other backends and affirmatively tell the model a symbol
-        doesn't exist. At this level the hint fires only when *every* backend found
-        nothing and none errored, and it covers sandbox and disk modes alike. Async-only,
-        like the rest of DAIV's backend surface (the agent path never calls sync).
-        """
-        result = await super().agrep(pattern, path=path, glob=glob)
-        if result.error is None and not result.matches and (hint := _literal_grep_no_match_hint(pattern)):
-            return GrepResult(error=hint)
-        return result
-
 
 def build_disk_workspace_backend(clone_dir: Path, *, skills_cache: Path = SKILLS_CACHE_PATH) -> DAIVCompositeBackend:
     """Build the disk-backed composite that serves the unified ``/workspace`` namespace.
@@ -401,32 +385,6 @@ def _fs_transport_failure_text(exc: httpx.HTTPError, op: str, target: str) -> st
         return _FS_TRANSPORT_TRANSIENT_TEXT
     logger.error("Sandbox %s transport failure for %r (permanent)", op, target, exc_info=exc)
     return _FS_TRANSPORT_PERMANENT_TEXT
-
-
-# High-signal regex constructs in a pattern destined for the *literal* grep backends. Despite the
-# deepagents grep tool description saying "literal string, not regex", models routinely send
-# `foo|bar|baz` and get a silent zero-match back — and then conclude the symbol doesn't exist.
-# Only unambiguous fragments are listed: bare parens/dots/brackets are common in genuinely literal
-# code searches (`def __init__(self):`) and must not trigger the hint.
-_REGEX_LOOKING_FRAGMENTS = ("|", ".*", "\\w", "\\s", "\\d", "\\b")
-
-
-def _literal_grep_no_match_hint(pattern: str) -> str | None:
-    """An agent-facing hint for a zero-match grep whose pattern looks like a regex, else ``None``.
-
-    Returned as the ``GrepResult.error`` so the model sees it verbatim instead of a bare
-    "No matches found" it would misread as "the symbol does not exist". The caller must
-    only invoke this on an empty, error-free aggregate match set — the message asserts
-    "No matches found" (see ``DAIVCompositeBackend.agrep`` for why the composite is the
-    only valid call site).
-    """
-    if not any(fragment in pattern for fragment in _REGEX_LOOKING_FRAGMENTS):
-        return None
-    return (
-        f"No matches found for {pattern!r}. Reminder: grep patterns match as LITERAL text, not regex — "
-        "'|' is not alternation and '.*'/escape classes have no special meaning, so this pattern was "
-        "searched verbatim. Search each term with its own grep call."
-    )
 
 
 class SandboxFileBackend(BackendProtocol):

--- a/daiv/automation/agent/middlewares/file_system.py
+++ b/daiv/automation/agent/middlewares/file_system.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import logging
+import re
 import stat
 from pathlib import Path
 from typing import Protocol, cast, runtime_checkable
@@ -189,6 +190,42 @@ class DAIVFilesystemBackend(FilesystemBackend):
             logger.exception("disk stat failed for %s; mirroring with 0o644 fallback", virtual_path)
             return 0o644
         return stat.S_IMODE(st.st_mode)
+
+    async def agrep(self, pattern: str, path: str | None = None, glob: str | None = None) -> GrepResult:
+        """Regex grep (convergence with the sandbox's ERE search and Claude Code).
+
+        Validates the pattern with Python ``re`` up front so an invalid regex is a clean,
+        model-fixable error rather than a silent zero-match (the inherited backend greps literally
+        via ``rg -F``/``re.escape``; ripgrep also exits 2 quietly on a bad regex). Reuses the
+        parent's ``_python_search`` with the *raw* (unescaped) pattern, which compiles it as a
+        regex — trading ripgrep's speed for correct semantics on local/disk runs (the deployed
+        path is the sandbox backend).
+        """
+        try:
+            re.compile(pattern)
+        except re.error as exc:
+            return GrepResult(error=f"invalid regular expression: {pattern!r} ({exc})")
+        return await asyncio.to_thread(self._regex_grep, pattern, path, glob)
+
+    def _regex_grep(self, pattern: str, path: str | None, glob: str | None) -> GrepResult:
+        try:
+            base_full = self._resolve_path(path or ".")
+        except ValueError:
+            return GrepResult(matches=[])
+        except (OSError, RuntimeError) as exc:
+            return GrepResult(error=f"Error searching path '{path or '.'}': {exc}", matches=[])
+        try:
+            if not base_full.exists():
+                return GrepResult(matches=[])
+        except OSError as exc:
+            return GrepResult(error=f"Error searching path '{path or '.'}': {exc}", matches=[])
+        results = self._python_search(pattern, base_full, glob)
+        matches = [
+            {"path": fpath, "line": int(line_num), "text": line_text}
+            for fpath, items in results.items()
+            for (line_num, line_text) in items
+        ]
+        return GrepResult(matches=matches)
 
 
 @runtime_checkable

--- a/daiv/automation/agent/middlewares/file_system.py
+++ b/daiv/automation/agent/middlewares/file_system.py
@@ -28,7 +28,6 @@ from deepagents.backends.protocol import (
 )
 from deepagents.middleware.filesystem import EDIT_FILE_TOOL_DESCRIPTION as EDIT_FILE_TOOL_DESCRIPTION_BASE
 from deepagents.middleware.filesystem import GLOB_TOOL_DESCRIPTION as GLOB_TOOL_DESCRIPTION_BASE
-from deepagents.middleware.filesystem import GREP_TOOL_DESCRIPTION as GREP_TOOL_DESCRIPTION_BASE
 from deepagents.middleware.filesystem import LIST_FILES_TOOL_DESCRIPTION as LIST_FILES_TOOL_DESCRIPTION_BASE
 from deepagents.middleware.filesystem import READ_FILE_TOOL_DESCRIPTION as READ_FILE_TOOL_DESCRIPTION_BASE
 from deepagents.middleware.filesystem import WRITE_FILE_TOOL_DESCRIPTION as WRITE_FILE_TOOL_DESCRIPTION_BASE
@@ -75,7 +74,21 @@ def _with_path_reminder(base: str, *extras: str) -> str:
     return "\n".join((base, *extras, REMINDER_ABSOLUTE_PATHS))
 
 
-GREP_TOOL_DESCRIPTION = _with_path_reminder(GREP_TOOL_DESCRIPTION_BASE)
+_GREP_DESCRIPTION = r"""Search file contents with a regular expression and return matching files or lines.
+
+The pattern is a REGULAR EXPRESSION (POSIX extended / ERE in sandbox runs; Python `re` on local runs).
+Common constructs work: alternation `foo|bar`, anchors `^def `/`;$`, character classes `[A-Z]`,
+quantifiers `+ * ? {2,3}`, and groups `(...)`. To match a regex metacharacter literally, escape it
+with a backslash, e.g. `def __init__\(self\)` or `value\.attr`.
+
+Parameters:
+- pattern: the regular expression.
+- path: absolute file or directory to search (defaults to the workspace root).
+- glob: optional filename glob to restrict the search (e.g. `*.py`).
+- output_mode: `files_with_matches` (default), `content`, or `count`.
+
+Prefer this tool over shell `grep`/`rg` in bash for searching workspace files."""
+GREP_TOOL_DESCRIPTION = _with_path_reminder(_GREP_DESCRIPTION)
 GLOB_TOOL_DESCRIPTION = _with_path_reminder(GLOB_TOOL_DESCRIPTION_BASE)
 LIST_FILES_TOOL_DESCRIPTION = _with_path_reminder(LIST_FILES_TOOL_DESCRIPTION_BASE)
 READ_FILE_TOOL_DESCRIPTION = _with_path_reminder(READ_FILE_TOOL_DESCRIPTION_BASE)
@@ -345,6 +358,10 @@ _FS_CODE_HINTS: dict[FsErrorCode, str] = {
     FsErrorCode.NOT_A_DIRECTORY: "is not a directory — read it with read_file, not the ls/glob tools",
     FsErrorCode.ALREADY_EXISTS: "already exists — modify it with edit_file (write_file only creates new files)",
     FsErrorCode.NOT_A_TEXT_FILE: "is not a UTF-8 text file and cannot be edited",
+    FsErrorCode.INVALID_PATTERN: (
+        "is not a valid regular expression — fix the syntax, or escape regex metacharacters "
+        "(e.g. \\( \\. \\|) to match them literally"
+    ),
 }
 
 

--- a/daiv/automation/agent/middlewares/file_system.py
+++ b/daiv/automation/agent/middlewares/file_system.py
@@ -81,6 +81,10 @@ Common constructs work: alternation `foo|bar`, anchors `^def `/`;$`, character c
 quantifiers `+ * ? {2,3}`, and groups `(...)`. To match a regex metacharacter literally, escape it
 with a backslash, e.g. `def __init__\(self\)` or `value\.attr`.
 
+Stick to portable syntax: Perl-style escapes (`\d` `\w` `\s` `\b`), lookaround `(?=...)`, and
+backreferences are NOT valid POSIX ERE and will match differently (often nothing) on sandbox runs —
+use `[0-9]`, `[A-Za-z0-9_]`, `[[:space:]]`, and explicit alternation instead.
+
 Parameters:
 - pattern: the regular expression.
 - path: absolute file or directory to search (defaults to the workspace root).
@@ -533,16 +537,16 @@ class SandboxFileBackend(BackendProtocol):
         matches = [GrepMatch(path=self._rel(m.path), line=m.line, text=m.text) for m in resp.matches]
         if resp.truncated:
             logger.warning("grep results truncated for pattern %r under %s", pattern, path)
-            matches.append(
-                GrepMatch(
-                    path="(grep results truncated)",
-                    line=0,
-                    text=(
-                        f"Showing the first {len(resp.matches)} matches. Narrow the path, add a glob, "
-                        "or use a more specific pattern to see the rest."
-                    ),
-                )
+            # The deepagents grep tool formats `matches` itself and, in the default
+            # `files_with_matches` output mode, renders ONLY the paths (the `text` is dropped). So the
+            # actionable guidance must live in the sentinel `path` to survive every output mode; the
+            # bracketed prose can't be mistaken for a real file to read. `text` repeats it for
+            # `content` mode. This is the only fork-free channel to the model.
+            note = (
+                f"(grep results truncated — showing the first {len(resp.matches)} matches; "
+                "narrow the path, add a glob, or use a more specific pattern to see the rest)"
             )
+            matches.append(GrepMatch(path=note, line=0, text=note))
         return GrepResult(matches=matches)
 
     async def aglob(self, pattern: str, path: str = "/") -> GlobResult:

--- a/daiv/automation/agent/middlewares/file_system.py
+++ b/daiv/automation/agent/middlewares/file_system.py
@@ -31,7 +31,7 @@ from deepagents.middleware.filesystem import GLOB_TOOL_DESCRIPTION as GLOB_TOOL_
 from deepagents.middleware.filesystem import LIST_FILES_TOOL_DESCRIPTION as LIST_FILES_TOOL_DESCRIPTION_BASE
 from deepagents.middleware.filesystem import READ_FILE_TOOL_DESCRIPTION as READ_FILE_TOOL_DESCRIPTION_BASE
 from deepagents.middleware.filesystem import WRITE_FILE_TOOL_DESCRIPTION as WRITE_FILE_TOOL_DESCRIPTION_BASE
-from deepagents.middleware.filesystem import FilesystemPermission
+from deepagents.middleware.filesystem import FilesystemPermission, GrepSchema
 
 from automation.agent.constants import REPO_PATH, SKILLS_CACHE_PATH, SKILLS_PATH, TMP_PATH, WORKSPACE_PATH
 from core.sandbox.client import DAIVSandboxClient, is_transient_sandbox_error
@@ -74,6 +74,15 @@ def _with_path_reminder(base: str, *extras: str) -> str:
     return "\n".join((base, *extras, REMINDER_ABSOLUTE_PATHS))
 
 
+# One description for both backends, on purpose. The model's grep description is set once per
+# process — via the harness profile for the main agent (``create_deep_agent`` auto-adds its
+# FilesystemMiddleware from the globally-registered profile, no per-call override) and via
+# ``custom_tool_descriptions`` for subagents — and a run's backend (sandbox ERE vs. disk Python
+# ``re``) is only known per-run, so the text cannot branch on it without racing concurrent runs.
+# It therefore targets the subset both dialects share: the sandbox runs ``grep -E`` on busybox/musl
+# images where Perl-style escapes and lookaround don't work, while Python ``re`` (the disk backend)
+# rejects POSIX bracket classes like ``[[:space:]]`` — so the description sticks to anchors,
+# alternation, ``[...]`` ranges and escaping, which behave identically on both.
 _GREP_DESCRIPTION = r"""Search file contents with a regular expression and return matching files or lines.
 
 The pattern is a REGULAR EXPRESSION (POSIX extended / ERE in sandbox runs; Python `re` on local runs).
@@ -81,18 +90,49 @@ Common constructs work: alternation `foo|bar`, anchors `^def `/`;$`, character c
 quantifiers `+ * ? {2,3}`, and groups `(...)`. To match a regex metacharacter literally, escape it
 with a backslash, e.g. `def __init__\(self\)` or `value\.attr`.
 
-Stick to portable syntax: Perl-style escapes (`\d` `\w` `\s` `\b`), lookaround `(?=...)`, and
+Avoid non-portable constructs: Perl-style escapes (`\d` `\w` `\s` `\b`), lookaround `(?=...)`, and
 backreferences are NOT valid POSIX ERE and will match differently (often nothing) on sandbox runs —
-use `[0-9]`, `[A-Za-z0-9_]`, `[[:space:]]`, and explicit alternation instead.
+use `[0-9]`, `[A-Za-z0-9_]`, a literal space, and explicit alternation instead.
 
-Parameters:
-- pattern: the regular expression.
-- path: absolute file or directory to search (defaults to the workspace root).
-- glob: optional filename glob to restrict the search (e.g. `*.py`).
-- output_mode: `files_with_matches` (default), `content`, or `count`.
+Examples:
+- Search every file: `grep(pattern="TODO")`
+- Anchored alternation in Python files: `grep(pattern="^def |^class ", glob="*.py")`
+- Show the matching lines: `grep(pattern="raise [A-Za-z]+Error", output_mode="content")`
+- Match metacharacters literally (escape them): `grep(pattern="value\.attr")`
+- Count matches per file: `grep(pattern="import", output_mode="count")`
 
 Prefer this tool over shell `grep`/`rg` in bash for searching workspace files."""
 GREP_TOOL_DESCRIPTION = _with_path_reminder(_GREP_DESCRIPTION)
+
+
+# ``_GREP_DESCRIPTION`` (above) overrides only the grep tool's *top-level* description. The model is
+# also shown the tool's INPUT SCHEMA, which deepagents builds from a hardcoded ``GrepSchema`` whose
+# ``pattern``/``path`` fields still read "literal string, not regex" / "current working directory" —
+# a direct contradiction of the regex description that ``custom_tool_descriptions`` cannot reach.
+# Both backends grep by regex now, so realign the arg schema in place. The override is process-wide
+# and constant (never per-run, so race-free) and reaches the main agent and every subagent alike,
+# since they all share this one ``GrepSchema`` class object. Pinned by
+# tests/.../test_file_system.py::test_grep_arg_schema_describes_regex so a deepagents bump that
+# reworks GrepSchema (or restores the literal wording) fails loudly instead of silently regressing.
+_GREP_PATTERN_ARG_DESCRIPTION = "Regular expression to search for (POSIX extended / ERE syntax)."
+_GREP_PATH_ARG_DESCRIPTION = "Absolute file or directory to search. Defaults to the workspace root."
+
+
+def _align_grep_arg_schema() -> None:
+    """Rewrite deepagents' ``GrepSchema`` arg descriptions to match DAIV's regex grep semantics."""
+    overrides = {"pattern": _GREP_PATTERN_ARG_DESCRIPTION, "path": _GREP_PATH_ARG_DESCRIPTION}
+    changed = False
+    for name, description in overrides.items():
+        if (field := GrepSchema.model_fields.get(name)) is not None:
+            field.description = description
+            changed = True
+    if changed:
+        # Pydantic caches the generated JSON schema; force a rebuild so the new descriptions reach
+        # ``model_json_schema()`` — the shape the model is actually shown.
+        GrepSchema.model_rebuild(force=True)
+
+
+_align_grep_arg_schema()
 GLOB_TOOL_DESCRIPTION = _with_path_reminder(GLOB_TOOL_DESCRIPTION_BASE)
 LIST_FILES_TOOL_DESCRIPTION = _with_path_reminder(LIST_FILES_TOOL_DESCRIPTION_BASE)
 READ_FILE_TOOL_DESCRIPTION = _with_path_reminder(READ_FILE_TOOL_DESCRIPTION_BASE)

--- a/daiv/automation/agent/middlewares/sandbox.py
+++ b/daiv/automation/agent/middlewares/sandbox.py
@@ -63,7 +63,7 @@ Intended use:
 Do NOT use bash for file operations when dedicated tools exist:
 - File listing: use `ls` tool (not shell ls)
 - File search: use `glob` (not find)
-- Content search: use dedicated `grep` tool (not shell grep/rg)
+- Content search: use the dedicated `grep` tool — it takes a regex (not shell grep/rg)
 - Read files: use `read_file` (not cat/head/tail)
 - Edit files: use `edit_file` (not sed/awk)
 - Write files: use `write_file` (not echo/heredocs)

--- a/daiv/core/sandbox/schemas.dump.json
+++ b/daiv/core/sandbox/schemas.dump.json
@@ -148,7 +148,8 @@
           "too_large",
           "invalid_offset",
           "permission_denied",
-          "exec_failed"
+          "exec_failed",
+          "invalid_pattern"
         ],
         "title": "FsErrorCode",
         "type": "string"
@@ -244,7 +245,8 @@
           "too_large",
           "invalid_offset",
           "permission_denied",
-          "exec_failed"
+          "exec_failed",
+          "invalid_pattern"
         ],
         "title": "FsErrorCode",
         "type": "string"
@@ -375,7 +377,8 @@
           "too_large",
           "invalid_offset",
           "permission_denied",
-          "exec_failed"
+          "exec_failed",
+          "invalid_pattern"
         ],
         "title": "FsErrorCode",
         "type": "string"
@@ -500,7 +503,8 @@
           "too_large",
           "invalid_offset",
           "permission_denied",
-          "exec_failed"
+          "exec_failed",
+          "invalid_pattern"
         ],
         "title": "FsErrorCode",
         "type": "string"
@@ -552,6 +556,12 @@
         },
         "title": "Matches",
         "type": "array"
+      },
+      "truncated": {
+        "default": false,
+        "description": "True when matches were capped server-side; narrow the search to see the rest.",
+        "title": "Truncated",
+        "type": "boolean"
       }
     },
     "title": "FsGrepResponse",
@@ -626,7 +636,8 @@
           "too_large",
           "invalid_offset",
           "permission_denied",
-          "exec_failed"
+          "exec_failed",
+          "invalid_pattern"
         ],
         "title": "FsErrorCode",
         "type": "string"
@@ -720,7 +731,8 @@
           "too_large",
           "invalid_offset",
           "permission_denied",
-          "exec_failed"
+          "exec_failed",
+          "invalid_pattern"
         ],
         "title": "FsErrorCode",
         "type": "string"
@@ -837,7 +849,8 @@
           "too_large",
           "invalid_offset",
           "permission_denied",
-          "exec_failed"
+          "exec_failed",
+          "invalid_pattern"
         ],
         "title": "FsErrorCode",
         "type": "string"

--- a/daiv/core/sandbox/schemas.py
+++ b/daiv/core/sandbox/schemas.py
@@ -106,6 +106,7 @@ class FsErrorCode(StrEnum):
     INVALID_OFFSET = "invalid_offset"
     PERMISSION_DENIED = "permission_denied"
     EXEC_FAILED = "exec_failed"
+    INVALID_PATTERN = "invalid_pattern"
 
 
 class FsError(BaseModel):
@@ -148,7 +149,7 @@ class FsReadResponse(BaseModel):
 
 
 class FsGrepRequest(BaseModel):
-    pattern: str = Field(description="Literal substring to search for (not a regex).")
+    pattern: str = Field(description="Regular expression to search for (POSIX extended / ERE syntax).")
     path: str = Field(description="Absolute directory/file path under /workspace.")
     glob: str | None = Field(default=None, description="Optional filename glob to restrict the search.")
 
@@ -161,6 +162,9 @@ class FsGrepMatch(BaseModel):
 
 class FsGrepResponse(BaseModel):
     matches: list[FsGrepMatch] = Field(default_factory=list, description="Matches found (empty on error).")
+    truncated: bool = Field(
+        default=False, description="True when matches were capped server-side; narrow the search to see the rest."
+    )
     error: FsError | None = Field(default=None, description="Structured error; null on success.")
 
 

--- a/tests/unit_tests/automation/agent/middlewares/test_file_system.py
+++ b/tests/unit_tests/automation/agent/middlewares/test_file_system.py
@@ -347,8 +347,12 @@ class TestSandboxGrepTruncation:
         result = await backend.agrep("x", path=REPO_PATH)
 
         assert result.error is None
-        assert result.matches[-1]["path"] == "(grep results truncated)"
-        assert "Narrow" in result.matches[-1]["text"]
+        note = result.matches[-1]
+        # The guidance must live in `path` (not just `text`): the default `files_with_matches` output
+        # mode renders only paths, so a text-only note would be invisible to the model there.
+        assert note["path"].startswith("(grep results truncated")
+        assert "narrow the path" in note["path"]
+        assert note["text"] == note["path"]
         assert len(result.matches) == 4  # 3 real + 1 note
 
     async def test_untruncated_response_has_no_note(self):
@@ -361,4 +365,21 @@ class TestSandboxGrepTruncation:
         result = await backend.agrep("x", path=REPO_PATH)
 
         assert len(result.matches) == 1
-        assert all(m["path"] != "(grep results truncated)" for m in result.matches)
+        assert all(not m["path"].startswith("(grep results truncated") for m in result.matches)
+
+    async def test_invalid_pattern_error_maps_to_model_hint(self):
+        """The sandbox returns `invalid_pattern`; the backend must rewrite it to the actionable hint
+        (this is the production path — daiv doesn't validate the regex itself for the sandbox)."""
+        from automation.agent.constants import REPO_PATH
+        from core.sandbox.schemas import FsError, FsErrorCode, FsGrepResponse
+
+        resp = FsGrepResponse(error=FsError(code=FsErrorCode.INVALID_PATTERN, message="invalid regular expression"))
+        backend = self._bound_backend(resp)
+
+        result = await backend.agrep("foo(", path=REPO_PATH)
+
+        assert not result.matches
+        assert result.error is not None
+        assert result.error.startswith("Grep 'foo(': ")
+        assert "not a valid regular expression" in result.error
+        assert "escape regex metacharacters" in result.error

--- a/tests/unit_tests/automation/agent/middlewares/test_file_system.py
+++ b/tests/unit_tests/automation/agent/middlewares/test_file_system.py
@@ -169,57 +169,23 @@ class TestDAIVCompositeBackend:
         assert stat.S_IMODE(skills_mode) == 0o755, "skills-routed stat_mode reads real bits"
         assert stat.S_IMODE(repo_mode) == 0o644, "default-routed stat_mode reads real bits"
 
-    async def test_agrep_hints_on_regexy_zero_match(self, tmp_path: Path):
-        """A zero-match aggregate for a regex-shaped pattern (the backends grep literally)
-        returns an explicit literal-semantics hint instead of a bare "no matches" the model
-        would misread as "the symbol does not exist"."""
+    async def test_agrep_alternation_matches_via_composite(self, tmp_path: Path):
+        """With regex grep, a `foo|bar` alternation returns real matches across routed backends —
+        no literal-semantics hint, no false 'symbol does not exist'.
+
+        ``_make_composite`` layers ``skills-mount`` *under* the default backend's root (``tmp_path``),
+        so a file in the skills route is also visible to the default backend and surfaces from both
+        (production roots are siblings and don't overlap); dedupe the texts so the assertion pins the
+        alternation behavior, not the fixture's incidental double-count.
+        """
         composite, _skills, _repo, skills_root, _repo_root = self._make_composite(tmp_path)
-        (skills_root / "a.md").write_text("nothing relevant\n")
-
-        result = await composite.agrep("get_catalog|list_relations")
-
-        assert result.error is not None
-        assert "LITERAL" in result.error
-        assert "get_catalog|list_relations" in result.error
-
-    async def test_agrep_literal_zero_match_stays_clean(self, tmp_path: Path):
-        """Bare parens/dots are common in genuinely literal code searches; a zero-match for
-        them is a real answer, not a hint trigger."""
-        composite, _skills, _repo, _skills_root, _repo_root = self._make_composite(tmp_path)
-
-        for pattern in ("plainmissing", "def __init__(self):"):
-            result = await composite.agrep(pattern)
-            assert result.error is None, pattern
-            assert not result.matches, pattern
-
-    async def test_agrep_routed_matches_survive_regexy_pattern(self, tmp_path: Path):
-        """The hint must fire on the *aggregate*, never per-backend: a routed backend's real
-        matches must come back even when other backends found nothing for a regexy pattern —
-        a per-backend hint would abort the composite's aggregation and suppress them."""
-        composite, _skills, _repo, skills_root, _repo_root = self._make_composite(tmp_path)
-        (skills_root / "doc.md").write_text("literally contains foo|bar here\n")
+        (skills_root / "doc.md").write_text("has foo here\nand bar there\n")
 
         result = await composite.agrep("foo|bar")
 
         assert result.error is None
-        assert result.matches
-
-    async def test_agrep_subbackend_error_wins_over_hint(self, tmp_path: Path):
-        """A genuine backend failure (grep never ran) must pass through verbatim — masking it
-        with the no-matches hint would tell the model the symbol doesn't exist."""
-        from deepagents.backends.protocol import GrepResult
-
-        composite, _skills, _repo, _skills_root, _repo_root = self._make_composite(tmp_path)
-
-        async def failing_agrep(*args, **kwargs):
-            return GrepResult(error="grep failed")
-
-        composite.default.agrep = failing_agrep
-
-        result = await composite.agrep("foo|bar")
-
-        assert result.error == "grep failed"
-        assert "LITERAL" not in result.error
+        texts = sorted({m["text"] for m in (result.matches or [])})
+        assert texts == ["and bar there", "has foo here"]
 
     async def test_resolve_backend_for_returns_route_target(self, tmp_path: Path):
         composite, skills, repo, _skills_root, _repo_root = self._make_composite(tmp_path)

--- a/tests/unit_tests/automation/agent/middlewares/test_file_system.py
+++ b/tests/unit_tests/automation/agent/middlewares/test_file_system.py
@@ -322,3 +322,43 @@ class TestBuildDiskWorkspaceBackend:
         clone_dir.mkdir()
         backend = build_disk_workspace_backend(clone_dir, skills_cache=tmp_path / "skills_cache")
         assert backend.artifacts_root == "/workspace"
+
+
+class TestSandboxGrepTruncation:
+    def _bound_backend(self, fs_grep_response):
+        from unittest.mock import AsyncMock
+
+        from automation.agent.middlewares.file_system import SandboxFileBackend
+
+        client = AsyncMock()
+        client.fs_grep = AsyncMock(return_value=fs_grep_response)
+        backend = SandboxFileBackend(client=client, session_id="sess-1")
+        return backend
+
+    async def test_truncated_response_appends_a_note_match(self):
+        from automation.agent.constants import REPO_PATH
+        from core.sandbox.schemas import FsGrepMatch, FsGrepResponse
+
+        resp = FsGrepResponse(
+            matches=[FsGrepMatch(path=f"{REPO_PATH}/f{i}.py", line=1, text="x") for i in range(3)], truncated=True
+        )
+        backend = self._bound_backend(resp)
+
+        result = await backend.agrep("x", path=REPO_PATH)
+
+        assert result.error is None
+        assert result.matches[-1]["path"] == "(grep results truncated)"
+        assert "Narrow" in result.matches[-1]["text"]
+        assert len(result.matches) == 4  # 3 real + 1 note
+
+    async def test_untruncated_response_has_no_note(self):
+        from automation.agent.constants import REPO_PATH
+        from core.sandbox.schemas import FsGrepMatch, FsGrepResponse
+
+        resp = FsGrepResponse(matches=[FsGrepMatch(path=f"{REPO_PATH}/a.py", line=1, text="x")], truncated=False)
+        backend = self._bound_backend(resp)
+
+        result = await backend.agrep("x", path=REPO_PATH)
+
+        assert len(result.matches) == 1
+        assert all(m["path"] != "(grep results truncated)" for m in result.matches)

--- a/tests/unit_tests/automation/agent/middlewares/test_file_system.py
+++ b/tests/unit_tests/automation/agent/middlewares/test_file_system.py
@@ -79,6 +79,24 @@ async def test_upstream_success_prefixes_remain_stable(setup):
     )
 
 
+def test_grep_arg_schema_describes_regex(setup):
+    """The grep tool's input schema must describe ``pattern`` as a regex, not literal text.
+
+    deepagents ships ``GrepSchema`` with a "literal string, not regex" ``pattern`` description (and a
+    "current working directory" ``path`` default) that the model sees in the tool's input schema
+    alongside DAIV's regex-aware tool description — a direct contradiction. ``_align_grep_arg_schema``
+    rewrites both at import; pin them here so a deepagents bump that reworks GrepSchema fails loudly
+    instead of silently restoring the contradiction.
+    """
+    props = setup.tools["grep"].args_schema.model_json_schema()["properties"]
+
+    pattern_desc = props["pattern"]["description"]
+    assert "regular expression" in pattern_desc.lower()
+    assert "literal" not in pattern_desc.lower()
+    assert pattern_desc == fs_module._GREP_PATTERN_ARG_DESCRIPTION
+    assert props["path"]["description"] == fs_module._GREP_PATH_ARG_DESCRIPTION
+
+
 class TestDiskBackendRegexGrep:
     def _backend(self, tmp_path: Path):
         from automation.agent.middlewares.file_system import DAIVFilesystemBackend

--- a/tests/unit_tests/automation/agent/middlewares/test_file_system.py
+++ b/tests/unit_tests/automation/agent/middlewares/test_file_system.py
@@ -79,6 +79,29 @@ async def test_upstream_success_prefixes_remain_stable(setup):
     )
 
 
+class TestDiskBackendRegexGrep:
+    def _backend(self, tmp_path: Path):
+        from automation.agent.middlewares.file_system import DAIVFilesystemBackend
+
+        (tmp_path / "a.py").write_text("alpha line\ngamma line\n")
+        (tmp_path / "b.py").write_text("beta line\n")
+        return DAIVFilesystemBackend(root_dir=tmp_path, virtual_mode=True)
+
+    async def test_disk_grep_alternation_matches(self, tmp_path: Path):
+        backend = self._backend(tmp_path)
+        result = await backend.agrep("alpha|beta")
+        assert result.error is None
+        texts = sorted(m["text"] for m in (result.matches or []))
+        assert texts == ["alpha line", "beta line"]
+
+    async def test_disk_grep_invalid_regex_is_clean_error(self, tmp_path: Path):
+        backend = self._backend(tmp_path)
+        result = await backend.agrep("alpha(")
+        assert result.error is not None
+        assert "invalid regular expression" in result.error
+        assert not result.matches
+
+
 class TestDAIVCompositeBackend:
     """Composite routing must preserve the prefix-stripping invariant for DAIV's two
     extension methods (``delete``/``stat_mode``) and the dispatch helper


### PR DESCRIPTION
## Summary
- Grep is now a **regular-expression** tool end-to-end, mirroring Claude Code (no literal-mode flag; escape metacharacters for literal matches).
- Disk backend (`DAIVFilesystemBackend.agrep`) greps with Python `re`, validating the pattern up front so an invalid regex is a clean `invalid regular expression` error rather than a silent zero-match.
- Removed the now-obsolete literal-grep no-match hint (`_literal_grep_no_match_hint`, `_REGEX_LOOKING_FRAGMENTS`, the `DAIVCompositeBackend.agrep` override).
- New regex-focused grep tool description + `invalid_pattern` error hint; bash-tool description nudged ("grep takes a regex").
- Sandbox backend surfaces server-side truncation to the model via an appended `(grep results truncated)` note match (logged at WARNING).
- Wire schemas synced (`FsErrorCode.INVALID_PATTERN`, `FsGrepResponse.truncated`, regex pattern docs) with a **surgical** dump transform that avoids importing unrelated scratch-fs drift.

## Test Plan
- [x] `make test` (3005 passed)
- [x] `make lint-fix` clean; `make lint-typing` at baseline (357, no new diagnostics)
- [x] Schema consistency test green (21)
- [x] Deploy **after** the daiv-sandbox PR (srtab/daiv-sandbox#324) — sending regex to an old literal sandbox would mis-search