### PR TITLE
feat(agent): Steer ls/glob over shell ls/find and fix glob /-anchoring footgun

### DIFF
--- a/daiv/automation/agent/middlewares/file_system.py
+++ b/daiv/automation/agent/middlewares/file_system.py
@@ -6,7 +6,7 @@ import logging
 import re
 import stat
 from pathlib import Path
-from typing import Protocol, cast, runtime_checkable
+from typing import TYPE_CHECKING, Protocol, cast, runtime_checkable
 
 import httpx
 from deepagents.backends.composite import CompositeBackend
@@ -48,6 +48,9 @@ from core.sandbox.schemas import (
     RunCommandsRequest,
     RunCommandsResponse,
 )
+
+if TYPE_CHECKING:
+    from pydantic import BaseModel
 
 logger = logging.getLogger("daiv.tools")
 
@@ -118,27 +121,32 @@ _GREP_PATTERN_ARG_DESCRIPTION = "Regular expression to search for (POSIX extende
 _GREP_PATH_ARG_DESCRIPTION = "Absolute file or directory to search. Defaults to the workspace root."
 
 
-def _align_grep_arg_schema() -> None:
-    """Rewrite deepagents' ``GrepSchema`` arg descriptions to match DAIV's regex grep semantics."""
-    overrides = {"pattern": _GREP_PATTERN_ARG_DESCRIPTION, "path": _GREP_PATH_ARG_DESCRIPTION}
+def _align_arg_schema(schema_cls: type[BaseModel], overrides: dict[str, str]) -> None:
+    """Rewrite a deepagents arg-schema's field descriptions in place.
+
+    deepagents builds each tool's INPUT SCHEMA from a hardcoded Pydantic model that
+    ``custom_tool_descriptions`` cannot reach, so its field text can contradict DAIV's overridden tool
+    description. The override is process-wide and constant (never per-run, so race-free) and reaches the
+    main agent and every subagent alike, since they all share the one schema class object.
+    """
     changed = False
     for name, description in overrides.items():
-        if (field := GrepSchema.model_fields.get(name)) is not None:
+        if (field := schema_cls.model_fields.get(name)) is not None:
             field.description = description
             changed = True
     if changed:
         # Pydantic caches the generated JSON schema; force a rebuild so the new descriptions reach
         # ``model_json_schema()`` — the shape the model is actually shown.
-        GrepSchema.model_rebuild(force=True)
+        schema_cls.model_rebuild(force=True)
 
 
-_align_grep_arg_schema()
+_align_arg_schema(GrepSchema, {"pattern": _GREP_PATTERN_ARG_DESCRIPTION, "path": _GREP_PATH_ARG_DESCRIPTION})
 
 # deepagents' ``GlobSchema`` ships a ``pattern`` field description carrying a bare `*.txt` example and a
 # ``path`` default of "/" that actively mislead: glob's base directory defaults to the FILESYSTEM
 # root, not the repository, so a bare repo-relative pattern (`tests/**/*.py`) silently matches
 # nothing. The model sees this arg schema alongside the tool description, so realign it in place —
-# same process-wide-constant, race-free mechanism as ``_align_grep_arg_schema``. Pinned by
+# same process-wide-constant, race-free mechanism as the grep alignment above. Pinned by
 # tests/.../test_file_system.py::test_glob_arg_schema_warns_root_anchoring.
 _GLOB_PATTERN_ARG_DESCRIPTION = (
     "Glob pattern (supports *, **, ?, [abc]). Lead with `**/` to match anywhere beneath the search "
@@ -148,23 +156,7 @@ _GLOB_PATH_ARG_DESCRIPTION = (
     "Absolute base directory to search from. Defaults to the filesystem root `/` — which is NOT the "
     "repository. Set it to the repository root to scope the search there, or lead the pattern with `**/`."
 )
-
-
-def _align_glob_arg_schema() -> None:
-    """Rewrite deepagents' ``GlobSchema`` arg descriptions to flag the `/`-anchored default and `**/`."""
-    overrides = {"pattern": _GLOB_PATTERN_ARG_DESCRIPTION, "path": _GLOB_PATH_ARG_DESCRIPTION}
-    changed = False
-    for name, description in overrides.items():
-        if (field := GlobSchema.model_fields.get(name)) is not None:
-            field.description = description
-            changed = True
-    if changed:
-        # Pydantic caches the generated JSON schema; force a rebuild so the new descriptions reach
-        # ``model_json_schema()`` — the shape the model is actually shown.
-        GlobSchema.model_rebuild(force=True)
-
-
-_align_glob_arg_schema()
+_align_arg_schema(GlobSchema, {"pattern": _GLOB_PATTERN_ARG_DESCRIPTION, "path": _GLOB_PATH_ARG_DESCRIPTION})
 
 _GLOB_EXTRA = (
     "Prefer this tool over shell `find` in bash to locate files by name or pattern inside the "

--- a/daiv/automation/agent/middlewares/file_system.py
+++ b/daiv/automation/agent/middlewares/file_system.py
@@ -31,7 +31,7 @@ from deepagents.middleware.filesystem import GLOB_TOOL_DESCRIPTION as GLOB_TOOL_
 from deepagents.middleware.filesystem import LIST_FILES_TOOL_DESCRIPTION as LIST_FILES_TOOL_DESCRIPTION_BASE
 from deepagents.middleware.filesystem import READ_FILE_TOOL_DESCRIPTION as READ_FILE_TOOL_DESCRIPTION_BASE
 from deepagents.middleware.filesystem import WRITE_FILE_TOOL_DESCRIPTION as WRITE_FILE_TOOL_DESCRIPTION_BASE
-from deepagents.middleware.filesystem import FilesystemPermission, GrepSchema
+from deepagents.middleware.filesystem import FilesystemPermission, GlobSchema, GrepSchema
 
 from automation.agent.constants import REPO_PATH, SKILLS_CACHE_PATH, SKILLS_PATH, TMP_PATH, WORKSPACE_PATH
 from core.sandbox.client import DAIVSandboxClient, is_transient_sandbox_error
@@ -133,7 +133,48 @@ def _align_grep_arg_schema() -> None:
 
 
 _align_grep_arg_schema()
-GLOB_TOOL_DESCRIPTION = _with_path_reminder(GLOB_TOOL_DESCRIPTION_BASE)
+
+# deepagents' ``GlobSchema`` ships a ``pattern`` field description carrying a bare `*.txt` example and a
+# ``path`` default of "/" that actively mislead: glob's base directory defaults to the FILESYSTEM
+# root, not the repository, so a bare repo-relative pattern (`tests/**/*.py`) silently matches
+# nothing. The model sees this arg schema alongside the tool description, so realign it in place —
+# same process-wide-constant, race-free mechanism as ``_align_grep_arg_schema``. Pinned by
+# tests/.../test_file_system.py::test_glob_arg_schema_warns_root_anchoring.
+_GLOB_PATTERN_ARG_DESCRIPTION = (
+    "Glob pattern (supports *, **, ?, [abc]). Lead with `**/` to match anywhere beneath the search "
+    "root, e.g. `**/*.py` or `**/test_*.py`."
+)
+_GLOB_PATH_ARG_DESCRIPTION = (
+    "Absolute base directory to search from. Defaults to the filesystem root `/` — which is NOT the "
+    "repository. Set it to the repository root to scope the search there, or lead the pattern with `**/`."
+)
+
+
+def _align_glob_arg_schema() -> None:
+    """Rewrite deepagents' ``GlobSchema`` arg descriptions to flag the `/`-anchored default and `**/`."""
+    overrides = {"pattern": _GLOB_PATTERN_ARG_DESCRIPTION, "path": _GLOB_PATH_ARG_DESCRIPTION}
+    changed = False
+    for name, description in overrides.items():
+        if (field := GlobSchema.model_fields.get(name)) is not None:
+            field.description = description
+            changed = True
+    if changed:
+        # Pydantic caches the generated JSON schema; force a rebuild so the new descriptions reach
+        # ``model_json_schema()`` — the shape the model is actually shown.
+        GlobSchema.model_rebuild(force=True)
+
+
+_align_glob_arg_schema()
+
+_GLOB_EXTRA = (
+    "Prefer this tool over shell `find` in bash to locate files by name or pattern inside the "
+    "workspace. IMPORTANT: `path` defaults to the FILESYSTEM ROOT `/`, not the repository, so a bare "
+    "pattern like `tests/**/*.py` matches nothing under the repo. Either lead the pattern with `**/` "
+    "(e.g. `**/test_*.py`) so it descends into the repo, or set `path` to the repository root. "
+    "(Searching outside the workspace, `find`-style `-path` predicates, and piping matches into "
+    "`grep` have no glob equivalent — those remain legitimate uses of bash `find`.)"
+)
+GLOB_TOOL_DESCRIPTION = _with_path_reminder(GLOB_TOOL_DESCRIPTION_BASE, _GLOB_EXTRA)
 LIST_FILES_TOOL_DESCRIPTION = _with_path_reminder(LIST_FILES_TOOL_DESCRIPTION_BASE)
 READ_FILE_TOOL_DESCRIPTION = _with_path_reminder(READ_FILE_TOOL_DESCRIPTION_BASE)
 WRITE_FILE_TOOL_DESCRIPTION = _with_path_reminder(WRITE_FILE_TOOL_DESCRIPTION_BASE, _WRITE_FILE_EXTRA)

--- a/daiv/automation/agent/middlewares/file_system.py
+++ b/daiv/automation/agent/middlewares/file_system.py
@@ -175,7 +175,14 @@ _GLOB_EXTRA = (
     "`grep` have no glob equivalent — those remain legitimate uses of bash `find`.)"
 )
 GLOB_TOOL_DESCRIPTION = _with_path_reminder(GLOB_TOOL_DESCRIPTION_BASE, _GLOB_EXTRA)
-LIST_FILES_TOOL_DESCRIPTION = _with_path_reminder(LIST_FILES_TOOL_DESCRIPTION_BASE)
+_LS_EXTRA = (
+    "Use this to explore directory layout AND to confirm a path before read_file/edit_file. "
+    "`path` is REQUIRED and must be absolute: there is no implicit working directory, so calling `ls` "
+    "with no path errors — pass e.g. the repository root. "
+    "Prefer this tool over shell `ls` in bash. To list files by pattern or recursively use `glob`, and "
+    "to filter by content use `grep`, rather than piping shell `ls` output."
+)
+LIST_FILES_TOOL_DESCRIPTION = _with_path_reminder(LIST_FILES_TOOL_DESCRIPTION_BASE, _LS_EXTRA)
 READ_FILE_TOOL_DESCRIPTION = _with_path_reminder(READ_FILE_TOOL_DESCRIPTION_BASE)
 WRITE_FILE_TOOL_DESCRIPTION = _with_path_reminder(WRITE_FILE_TOOL_DESCRIPTION_BASE, _WRITE_FILE_EXTRA)
 EDIT_FILE_TOOL_DESCRIPTION = _with_path_reminder(EDIT_FILE_TOOL_DESCRIPTION_BASE)

--- a/tests/unit_tests/automation/agent/middlewares/test_file_system.py
+++ b/tests/unit_tests/automation/agent/middlewares/test_file_system.py
@@ -97,6 +97,30 @@ def test_grep_arg_schema_describes_regex(setup):
     assert props["path"]["description"] == fs_module._GREP_PATH_ARG_DESCRIPTION
 
 
+def test_glob_description_steers_over_find(setup):
+    """glob's own description must steer the model away from shell `find` and warn about the
+    `/`-anchoring footgun, mirroring grep's 'prefer over bash' treatment."""
+    desc = setup.tools["glob"].description
+    low = desc.lower()
+    assert "prefer this tool" in low
+    assert "find" in low  # names the shell tool it replaces
+    assert "**/" in desc  # the anchoring guidance the model must learn
+    assert fs_module._GLOB_EXTRA in desc
+
+
+def test_glob_arg_schema_warns_root_anchoring(setup):
+    """deepagents ships GlobSchema with a bare `*.txt` pattern example and a "Defaults to root '/'"
+    path description. `_align_glob_arg_schema` rewrites both at import; pin them so a deepagents bump
+    that reworks GlobSchema fails loudly instead of silently regressing."""
+    props = setup.tools["glob"].args_schema.model_json_schema()["properties"]
+    assert props["pattern"]["description"] == fs_module._GLOB_PATTERN_ARG_DESCRIPTION
+    assert props["path"]["description"] == fs_module._GLOB_PATH_ARG_DESCRIPTION
+    # the bare `*.txt` example (no `**/` prefix) must be replaced
+    assert "*.txt" not in props["pattern"]["description"]
+    # the path description must warn it is NOT the repository root
+    assert "filesystem root" in props["path"]["description"].lower()
+
+
 class TestDiskBackendRegexGrep:
     def _backend(self, tmp_path: Path):
         from automation.agent.middlewares.file_system import DAIVFilesystemBackend

--- a/tests/unit_tests/automation/agent/middlewares/test_file_system.py
+++ b/tests/unit_tests/automation/agent/middlewares/test_file_system.py
@@ -84,7 +84,7 @@ def test_grep_arg_schema_describes_regex(setup):
 
     deepagents ships ``GrepSchema`` with a "literal string, not regex" ``pattern`` description (and a
     "current working directory" ``path`` default) that the model sees in the tool's input schema
-    alongside DAIV's regex-aware tool description — a direct contradiction. ``_align_grep_arg_schema``
+    alongside DAIV's regex-aware tool description — a direct contradiction. ``_align_arg_schema``
     rewrites both at import; pin them here so a deepagents bump that reworks GrepSchema fails loudly
     instead of silently restoring the contradiction.
     """
@@ -110,7 +110,7 @@ def test_glob_description_steers_over_find(setup):
 
 def test_glob_arg_schema_warns_root_anchoring(setup):
     """deepagents ships GlobSchema with a bare `*.txt` pattern example and a "Defaults to root '/'"
-    path description. `_align_glob_arg_schema` rewrites both at import; pin them so a deepagents bump
+    path description. `_align_arg_schema` rewrites both at import; pin them so a deepagents bump
     that reworks GlobSchema fails loudly instead of silently regressing."""
     props = setup.tools["glob"].args_schema.model_json_schema()["properties"]
     assert props["pattern"]["description"] == fs_module._GLOB_PATTERN_ARG_DESCRIPTION

--- a/tests/unit_tests/automation/agent/middlewares/test_file_system.py
+++ b/tests/unit_tests/automation/agent/middlewares/test_file_system.py
@@ -121,6 +121,18 @@ def test_glob_arg_schema_warns_root_anchoring(setup):
     assert "filesystem root" in props["path"]["description"].lower()
 
 
+def test_ls_description_steers_over_shell_ls(setup):
+    """ls's own description must steer the model away from shell `ls`, reframe it as a directory
+    explorer (not only a read precursor), and state that `path` is required/absolute (shell `ls`
+    defaults to cwd; the dedicated tool errors with no path)."""
+    desc = setup.tools["ls"].description
+    low = desc.lower()
+    assert "prefer this tool" in low
+    assert "shell `ls`" in low
+    assert "required" in low  # the no-implicit-cwd footgun
+    assert fs_module._LS_EXTRA in desc
+
+
 class TestDiskBackendRegexGrep:
     def _backend(self, tmp_path: Path):
         from automation.agent.middlewares.file_system import DAIVFilesystemBackend

--- a/tests/unit_tests/automation/agent/middlewares/test_file_system.py
+++ b/tests/unit_tests/automation/agent/middlewares/test_file_system.py
@@ -103,7 +103,7 @@ def test_glob_description_steers_over_find(setup):
     desc = setup.tools["glob"].description
     low = desc.lower()
     assert "prefer this tool" in low
-    assert "find" in low  # names the shell tool it replaces
+    assert "shell `find`" in low  # names the shell tool it replaces
     assert "**/" in desc  # the anchoring guidance the model must learn
     assert fs_module._GLOB_EXTRA in desc
 


### PR DESCRIPTION
## Summary

Trace analysis of past DAIV runs showed the agent overwhelmingly reaches for `bash ls`/`find` instead of the dedicated `ls`/`glob` tools — **~3-4% dedicated-tool share** (3 `ls`, 2 `glob` calls vs 104 `bash ls` + 46 `bash find`), against `grep`'s 72% and `read_file`'s 97%. The steering already exists in the bash description and system prompt, so the gap is specific to these two tools. Two addressable causes:

1. **No "prefer over bash" line in the tools' own descriptions** — `grep` has one (and the high dedicated share); `ls`/`glob` use the thin upstream deepagents text.
2. **Footguns that push the model back to its shell prior:**
   - `ls` requires an absolute `path` (no implicit cwd), so `ls()` errors — observed once in the traces.
   - `glob` defaults `path` to the **filesystem root `/`**, so a repo-relative pattern like `tests/**/*.py` silently returns `[]`. Only `**/`-prefixed patterns descend into the repo. The upstream `*.txt` ("in root") schema example actively misleads.

This mirrors the existing `grep` treatment (`_GREP_DESCRIPTION` + `_align_grep_arg_schema`):

- **glob:** append `_GLOB_EXTRA` (prefer over shell `find`; lead patterns with `**/` or set `path` to the repo root; outside-repo / `-path` / `xargs grep` remain legitimate `find` uses) and realign the `GlobSchema` `pattern`/`path` arg descriptions via `_align_glob_arg_schema()`.
- **ls:** append `_LS_EXTRA` (prefer over shell `ls`; reframe as a directory explorer, not just a read precursor; flag that `path` is required/absolute).

No tool function bodies or default *values* are changed — the repo root varies per run on disk and the schema is a process-wide singleton, so a "default to repo root" change would race concurrent runs (the exact footgun the existing code comments warn against). Steering lives in the descriptions/arg-text, where `grep` already proves it works.

Complements (does not duplicate) the existing `use ls/glob not shell` lines in `sandbox.py`; the new text lives in the tools' own descriptions, where the agent looks when deciding to *use* the tool.

## Test Plan

- [x] 3 new pin-tests in `test_file_system.py` (modeled on `test_grep_arg_schema_describes_regex`) assert the steering phrases, the `**/` guidance, and the realigned `GlobSchema` arg descriptions — failing loudly if a deepagents bump reverts them.
- [x] `uv run pytest tests/unit_tests/automation/agent/middlewares/test_file_system.py` — green.
- [x] `make test` — 3013 passed.
- [x] `make lint-typing` — clean for the changed file.

## Notes

Efficiency improvement, not a correctness fix: all observed occurrences were in `success` runs. `grep`'s 72% (with the same nudge) suggests descriptions alone won't reach ~95%; compositional `bash find`/`ls` (pipes, `-path`, outside-repo) are correct and intentionally preserved. Suggested follow-up metric: plain `bash ls`/`find -name` per run and dedicated-tool share on the next ~20 traces.

Plan: `docs/superpowers/plans/2026-06-15-ls-glob-tool-steering.md` (note: not committed on this branch — it sits in the working tree).