### PR TITLE
fix(agent): Give subagents access to the parent MCP toolset

### DIFF
--- a/daiv/automation/agent/graph.py
+++ b/daiv/automation/agent/graph.py
@@ -23,9 +23,8 @@ from automation.agent.constants import (
     WORKSPACE_PATH,
     ModelName,
 )
-from automation.agent.deferred.conf import settings as deferred_settings
 from automation.agent.mcp.toolkits import MCPToolkit
-from automation.agent.middlewares.deferred_tools import DeferredToolsMiddleware
+from automation.agent.middlewares.deferred_tools import deferred_tools_middleware, direct_mcp_tools
 from automation.agent.middlewares.ensure_response import ensure_non_empty_response
 from automation.agent.middlewares.file_system import (
     WORKSPACE_FENCE_PERMISSIONS,
@@ -39,7 +38,7 @@ from automation.agent.middlewares.git_platform import GitPlatformMiddleware
 from automation.agent.middlewares.logging import ToolCallLoggingMiddleware
 from automation.agent.middlewares.prompt_cache import AnthropicPromptCachingMiddleware
 from automation.agent.middlewares.sandbox import BASH_TOOL_NAME, SandboxMiddleware
-from automation.agent.middlewares.skills import SkillsMiddleware
+from automation.agent.middlewares.skills import SKILLS_TOOL_NAME, SkillsMiddleware
 from automation.agent.middlewares.slash_commands import SlashCommandMiddleware
 from automation.agent.middlewares.step_budget import StepBudgetMiddleware
 from automation.agent.middlewares.todos import DAIVTodoListMiddleware
@@ -72,6 +71,9 @@ logger = logging.getLogger("daiv.agent")
 
 
 # Tools always bound to the model; everything else is deferred behind tool_search.
+# DAIV-owned tool names reference their canonical constant (so a rename propagates here);
+# deepagents/langchain-provided names (filesystem, write_todos, task) have no authoritative DAIV
+# constant and stay as literals.
 ALWAYS_LOADED_TOOLS = frozenset({
     "ls",
     "read_file",
@@ -79,9 +81,9 @@ ALWAYS_LOADED_TOOLS = frozenset({
     "edit_file",
     "glob",
     "grep",
-    "bash",
+    BASH_TOOL_NAME,
     "write_todos",
-    "skill",
+    SKILLS_TOOL_NAME,
     "task",
 })
 
@@ -245,6 +247,12 @@ async def create_daiv_agent(
     # the same root the main agent's prompt does (``dynamic_daiv_system_prompt`` derives the same value).
     working_directory = f"{agent_root}/"
 
+    # Fetched before subagents are built so the general-purpose and custom subagents inherit the
+    # parent's MCP toolset — otherwise a `task` delegation that calls an MCP tool fails with
+    # "command not found". Explore and the code-review detectors stay deliberately scoped and don't
+    # receive it.
+    mcp_tools = await MCPToolkit.get_tools()
+
     subagents = [
         create_general_purpose_subagent(
             model,
@@ -257,6 +265,7 @@ async def create_daiv_agent(
             fallback_models=fallback_models,
             client=run_client,
             sandbox_backend=sandbox_backend,
+            mcp_tools=mcp_tools,
         ),
         create_explore_subagent(backend, working_directory, sandbox_enabled=_sandbox_enabled),
         *load_builtin_code_review_detectors(
@@ -283,10 +292,9 @@ async def create_daiv_agent(
         fallback_models=fallback_models,
         client=run_client,
         sandbox_backend=sandbox_backend,
+        mcp_tools=mcp_tools,
     )
     subagents.extend(custom_subagents)
-
-    mcp_tools = await MCPToolkit.get_tools()
 
     user_middleware: list[AgentMiddleware[Any, Any, Any]] = [
         # DAIVTodoListMiddleware (a subclass), not the bare TodoListMiddleware: the harness profile
@@ -307,18 +315,9 @@ async def create_daiv_agent(
         *([WebSearchMiddleware()] if _web_search_enabled else []),
         *([WebFetchMiddleware()] if _web_fetch_enabled else []),
         *([ModelFallbackMiddleware(fallback_models[0], *fallback_models[1:])] if fallback_models else []),
-        *(
-            [
-                DeferredToolsMiddleware(
-                    always_loaded=ALWAYS_LOADED_TOOLS,
-                    extra_tools=mcp_tools,
-                    top_k_default=deferred_settings.TOP_K_DEFAULT,
-                    top_k_max=deferred_settings.TOP_K_MAX,
-                )
-            ]
-            if deferred_settings.ENABLED
-            else []
-        ),
+        # Web search/fetch, git-platform, and MCP tools are all deferred behind tool_search; only the
+        # file/bash/todo core in ALWAYS_LOADED_TOOLS is eagerly bound.
+        *deferred_tools_middleware(ALWAYS_LOADED_TOOLS, mcp_tools),
         # Before the caching middleware so the cache-control placement sees the final
         # message list, including any injected budget reminder.
         StepBudgetMiddleware(),
@@ -336,7 +335,7 @@ async def create_daiv_agent(
         *(middleware or []),
     ]
 
-    initial_tools = [] if deferred_settings.ENABLED else mcp_tools
+    initial_tools = direct_mcp_tools(mcp_tools)
 
     deep_agent = create_deep_agent(
         model=model,

--- a/daiv/automation/agent/middlewares/deferred_tools.py
+++ b/daiv/automation/agent/middlewares/deferred_tools.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 from langchain.agents.middleware import AgentMiddleware
 from langchain_core.messages import AIMessage, ToolMessage
 
+from automation.agent.deferred.conf import settings as deferred_settings
 from automation.agent.deferred.index import DeferredToolsIndex
 from automation.agent.deferred.prompt import build_deferred_tools_block
 from automation.agent.deferred.search_tool import TOOL_SEARCH_NAME, make_tool_search
@@ -143,3 +144,38 @@ class DeferredToolsMiddleware(AgentMiddleware):
 
         if corrective:
             response.messages = [*messages, *corrective]
+
+
+def direct_mcp_tools(mcp_tools: list[BaseTool] | None) -> list[BaseTool]:
+    """MCP tools to bind directly on an agent's model.
+
+    The non-deferred half of the defer-or-bind decision, shared by the main agent and the
+    general-purpose/custom subagents: when deferral is OFF the MCP tools are bound eagerly
+    (returned here); when ON they ride on ``DeferredToolsMiddleware`` instead, so none are bound
+    directly here (the middleware already registers them as executable tools; binding them directly
+    too would be redundant — the ToolNode dedupes by name).
+    """
+    if not mcp_tools or deferred_settings.ENABLED:
+        return []
+    return list(mcp_tools)
+
+
+def deferred_tools_middleware(always_loaded: Iterable[str], mcp_tools: list[BaseTool] | None) -> list[AgentMiddleware]:
+    """The deferred half: a ``DeferredToolsMiddleware`` hiding ``mcp_tools`` (and any other tool not
+    in ``always_loaded``) behind ``tool_search``.
+
+    Installed whenever deferral is enabled — both the main agent and the general-purpose/custom
+    subagents keep only the file/bash/todo core eagerly bound, so they always have non-always-loaded
+    tools (web search/fetch, git-platform, and any MCP tools) to defer. A loaded deferred tool stays
+    loaded for the rest of the session, so the cost is at most one ``tool_search`` per session.
+    """
+    if not deferred_settings.ENABLED:
+        return []
+    return [
+        DeferredToolsMiddleware(
+            always_loaded=always_loaded,
+            extra_tools=mcp_tools or [],
+            top_k_default=deferred_settings.TOP_K_DEFAULT,
+            top_k_max=deferred_settings.TOP_K_MAX,
+        )
+    ]

--- a/daiv/automation/agent/subagents.py
+++ b/daiv/automation/agent/subagents.py
@@ -14,6 +14,7 @@ from langchain.agents.middleware import AgentMiddleware, ModelFallbackMiddleware
 
 from automation.agent import BaseAgent
 from automation.agent.constants import BUILTIN_SKILLS_PATH, REPO_PATH, WORKSPACE_PATH
+from automation.agent.middlewares.deferred_tools import deferred_tools_middleware, direct_mcp_tools
 from automation.agent.middlewares.file_system import (
     CUSTOM_TOOL_DESCRIPTIONS,
     WORKSPACE_ARTIFACT_SUBTREES,
@@ -24,7 +25,7 @@ from automation.agent.middlewares.file_system import (
 from automation.agent.middlewares.git_platform import GitPlatformMiddleware
 from automation.agent.middlewares.logging import ToolCallLoggingMiddleware
 from automation.agent.middlewares.prompt_cache import AnthropicPromptCachingMiddleware
-from automation.agent.middlewares.sandbox import SandboxMiddleware
+from automation.agent.middlewares.sandbox import BASH_TOOL_NAME, SandboxMiddleware
 from automation.agent.middlewares.todos import DAIVTodoListMiddleware
 from automation.agent.middlewares.web_fetch import WebFetchMiddleware
 from automation.agent.middlewares.web_search import WebSearchMiddleware
@@ -35,6 +36,7 @@ if TYPE_CHECKING:
 
     from deepagents.backends import BackendProtocol
     from langchain.chat_models import BaseChatModel
+    from langchain_core.tools import BaseTool
 
     from automation.agent.middlewares.file_system import SandboxFileBackend
     from codebase.context import RuntimeCtx
@@ -67,13 +69,32 @@ def _general_purpose_system_prompt(working_directory: str) -> str:
 """  # noqa: E501
 
 
+# Tools kept eagerly bound on a subagent's model; web search/fetch, git-platform, and the MCP toolset
+# are all deferred behind tool_search — the same policy as the main agent. This mirrors
+# ALWAYS_LOADED_TOOLS (graph.py) minus `skill`/`task` (subagents spawn neither). A deferred tool stays
+# loaded for the rest of the subagent's session once loaded, so a delegate that needs web/git pays at
+# most one tool_search. DAIV-owned tool names reference their canonical constant; deepagents-provided
+# names (filesystem, write_todos) stay as literals.
+SUBAGENT_ALWAYS_LOADED_TOOLS = frozenset({
+    "ls",
+    "read_file",
+    "write_file",
+    "edit_file",
+    "glob",
+    "grep",
+    BASH_TOOL_NAME,
+    "write_todos",
+})
+
+
 def _shared_subagent_middleware(model: BaseChatModel, backend: BackendProtocol) -> list[AgentMiddleware[Any, Any, Any]]:
     """The summarization + observability tail common to every subagent stack.
 
     Shared by the general-purpose, explore, and code-review detector builders: context
     summarization, prompt caching, tool-call logging, and tool-call patching, in that order.
     Callers prepend their own head (todos / filesystem permissions / git-platform / web tools)
-    and append the conditional sandbox + fallback middleware.
+    and append the conditional sandbox + fallback middleware (plus, for the general-purpose and
+    custom builders, a deferred-tools middleware exposing the parent's MCP toolset).
     """
     summarization_defaults = compute_summarization_defaults(model)
     return [
@@ -101,11 +122,16 @@ def _build_general_purpose_middleware(
     fallback_models: list[BaseChatModel] | None = None,
     client: DAIVSandboxClient | None = None,
     sandbox_backend: SandboxFileBackend | None = None,
+    mcp_tools: list[BaseTool] | None = None,
 ) -> list:
     """
     Build the middleware stack for a general-purpose subagent.
 
     ``close_session=False`` lets the subagent reuse the parent agent's sandbox session.
+
+    ``mcp_tools`` is the parent agent's MCP toolset; when deferral is enabled it is exposed to the
+    subagent via a ``DeferredToolsMiddleware`` (otherwise bound directly by the caller). This lets a
+    ``task`` delegation actually call MCP tools instead of failing with ``command not found``.
     """
     # Local import to break a circular dependency: graph.py imports this module.
     from automation.agent.graph import dynamic_write_todos_system_prompt
@@ -134,6 +160,8 @@ def _build_general_purpose_middleware(
 
     if fallback_models:
         middleware.append(ModelFallbackMiddleware(*fallback_models))
+
+    middleware.extend(deferred_tools_middleware(SUBAGENT_ALWAYS_LOADED_TOOLS, mcp_tools))
 
     return middleware
 
@@ -308,13 +336,14 @@ def create_general_purpose_subagent(
     fallback_models: list[BaseChatModel] | None = None,
     client: DAIVSandboxClient | None = None,
     sandbox_backend: SandboxFileBackend | None = None,
+    mcp_tools: list[BaseTool] | None = None,
 ) -> CompiledSubAgent:
     """
     Create the general purpose subagent for the DAIV agent.
     """
     runnable = create_agent(
         model=model,
-        tools=[],
+        tools=direct_mcp_tools(mcp_tools),
         system_prompt=_general_purpose_system_prompt(working_directory),
         middleware=_build_general_purpose_middleware(
             model,
@@ -326,6 +355,7 @@ def create_general_purpose_subagent(
             fallback_models,
             client,
             sandbox_backend,
+            mcp_tools=mcp_tools,
         ),
         name=GENERAL_PURPOSE_NAME,
     )
@@ -509,15 +539,18 @@ def _compile_subagent(
     middleware: list,
     working_directory: str,
     response_format: dict | type | None = None,
+    tools: list[BaseTool] | None = None,
 ) -> CompiledSubAgent:
     """Compile a system-prompt body + middleware stack into a ``CompiledSubAgent``.
 
     Shared by ``load_custom_subagents`` (per-repo markdown subagents) and
-    ``load_builtin_code_review_detectors`` (skill-shipped detector charters).
+    ``load_builtin_code_review_detectors`` (skill-shipped detector charters). ``tools`` binds
+    extra tools directly on the model (used by custom subagents to eagerly bind MCP tools when
+    deferral is off); detectors pass none.
     """
     runnable = create_agent(
         model=model,
-        tools=[],
+        tools=tools or [],
         system_prompt=f"{body}\n\n{filesystem_absolute_path_directive(working_directory)}",
         middleware=middleware,
         name=name,
@@ -538,6 +571,7 @@ async def load_custom_subagents(
     fallback_models: list[BaseChatModel] | None = None,
     client: DAIVSandboxClient | None = None,
     sandbox_backend: SandboxFileBackend | None = None,
+    mcp_tools: list[BaseTool] | None = None,
 ) -> list[CompiledSubAgent]:
     """
     Load custom subagents from markdown files in the given source paths.
@@ -556,6 +590,8 @@ async def load_custom_subagents(
         web_search_enabled: Whether to enable web search middleware.
         web_fetch_enabled: Whether to enable web fetch middleware.
         fallback_models: Optional fallback models for model failover.
+        mcp_tools: The parent agent's MCP toolset, exposed to each custom subagent (deferred behind
+            tool_search when deferral is on, bound directly when off) so a delegated MCP call works.
 
     Returns:
         List of CompiledSubAgent dicts for the loaded custom subagents.
@@ -613,6 +649,7 @@ async def load_custom_subagents(
                 fallback_models,
                 client,
                 sandbox_backend,
+                mcp_tools=mcp_tools,
             )
             subagents.append(
                 _compile_subagent(
@@ -622,6 +659,7 @@ async def load_custom_subagents(
                     body=body,
                     middleware=middleware,
                     working_directory=working_directory,
+                    tools=direct_mcp_tools(mcp_tools),
                 )
             )
 

--- a/tests/unit_tests/automation/agent/test_graph_deferred.py
+++ b/tests/unit_tests/automation/agent/test_graph_deferred.py
@@ -11,7 +11,9 @@ def _common_patches():
         patch("automation.agent.graph.load_custom_subagents", AsyncMock(return_value=[])),
         patch("automation.agent.graph.create_deep_agent"),
         patch("automation.agent.graph.MCPToolkit"),
-        patch("automation.agent.graph.deferred_settings"),
+        # The defer-or-bind decision now reads deferred_settings through the shared helpers in
+        # middlewares.deferred_tools (used by both the main agent and subagents), so patch it there.
+        patch("automation.agent.middlewares.deferred_tools.deferred_settings"),
         patch("automation.agent.graph.BaseAgent"),
         patch("automation.agent.graph.site_settings"),
         # Middleware constructors that validate input — replaced with no-op mocks
@@ -24,7 +26,7 @@ def _common_patches():
 
 
 class TestCreateDaivAgentDeferredFlag:
-    async def _run(self, *, flag_on: bool):
+    async def _run(self, *, flag_on: bool, tools: list | None = None):
         from langchain_core.tools import StructuredTool
 
         from automation.agent.graph import create_daiv_agent
@@ -51,7 +53,8 @@ class TestCreateDaivAgentDeferredFlag:
             mock_deferred_settings.TOP_K_MAX = 10
 
             mcp_tool = StructuredTool.from_function(func=lambda **k: "x", name="t1", description="d")
-            mock_toolkit.get_tools = AsyncMock(return_value=[mcp_tool])
+            # tools=None => default single-tool list; pass tools=[] to exercise the empty-toolset path.
+            mock_toolkit.get_tools = AsyncMock(return_value=[mcp_tool] if tools is None else tools)
 
             mock_base_agent.get_model.return_value = MagicMock()
 
@@ -71,13 +74,20 @@ class TestCreateDaivAgentDeferredFlag:
             ctx.git_platform = MagicMock()
 
             await create_daiv_agent(ctx=ctx, auto_commit_changes=False)
-            return mock_create_deep_agent, mock_toolkit, mcp_tool
+            return (
+                mock_create_deep_agent,
+                mock_toolkit,
+                mcp_tool,
+                mock_create_gp,
+                mock_load_custom,
+                mock_create_explore,
+            )
         finally:
             for p in patches:
                 p.stop()
 
     async def test_flag_off_passes_eager_tools(self):
-        mock_create_deep_agent, mock_toolkit, mcp_tool = await self._run(flag_on=False)
+        mock_create_deep_agent, mock_toolkit, mcp_tool, *_ = await self._run(flag_on=False)
 
         mock_toolkit.get_tools.assert_awaited()
         kwargs = mock_create_deep_agent.call_args.kwargs
@@ -86,7 +96,7 @@ class TestCreateDaivAgentDeferredFlag:
         assert "DeferredToolsMiddleware" not in middleware_types
 
     async def test_flag_on_passes_empty_tools_and_adds_middleware(self):
-        mock_create_deep_agent, mock_toolkit, _ = await self._run(flag_on=True)
+        mock_create_deep_agent, mock_toolkit, _, *_ = await self._run(flag_on=True)
 
         mock_toolkit.get_tools.assert_awaited()
         kwargs = mock_create_deep_agent.call_args.kwargs
@@ -101,11 +111,37 @@ class TestCreateDaivAgentDeferredFlag:
         # compiled subagents handed to create_deep_agent must include every cr-* detector name.
         from automation.agent.subagents import CODE_REVIEW_DETECTOR_NAMES
 
-        mock_create_deep_agent, _, _ = await self._run(flag_on=False)
+        mock_create_deep_agent, _, _, *_ = await self._run(flag_on=False)
 
         subagents = mock_create_deep_agent.call_args.kwargs["subagents"]
         registered = {s["name"] for s in subagents if isinstance(s, dict) and "name" in s}
         assert set(CODE_REVIEW_DETECTOR_NAMES) <= registered
+
+    async def test_threads_mcp_tools_into_general_purpose_and_custom_subagents(self):
+        # P1 harness fix: a `task` delegation that needs an MCP tool fails with "command not
+        # found" unless the subagent's tool registry carries the MCP toolset. The general-purpose
+        # and custom-subagent builders must therefore receive the parent's mcp_tools; explore and
+        # the code-review detectors stay deliberately scoped and do not.
+        _, mock_toolkit, mcp_tool, mock_create_gp, mock_load_custom, mock_create_explore = await self._run(flag_on=True)
+
+        assert mock_create_gp.call_args.kwargs["mcp_tools"] == [mcp_tool]
+        assert mock_load_custom.await_args.kwargs["mcp_tools"] == [mcp_tool]
+        # Explore is deliberately scoped to file search and must NOT receive the MCP toolset. Its
+        # factory takes **kwargs, so a stray mcp_tools= would be silently swallowed rather than
+        # error — assert the graph never passes it. (Detectors are excluded structurally: their
+        # loader has no mcp_tools parameter, so passing it would raise TypeError.)
+        assert "mcp_tools" not in mock_create_explore.call_args.kwargs
+
+    async def test_main_agent_defers_with_empty_toolset_when_flag_on(self):
+        # The main agent's web/git-platform tools are not in ALWAYS_LOADED_TOOLS, so
+        # DeferredToolsMiddleware must still be installed even with zero MCP tools — otherwise those
+        # tools would be silently eager-bound (the exact bloat deferral exists to prevent).
+        mock_create_deep_agent, *_ = await self._run(flag_on=True, tools=[])
+
+        kwargs = mock_create_deep_agent.call_args.kwargs
+        assert kwargs["tools"] == []
+        middleware_types = [type(m).__name__ for m in kwargs["middleware"]]
+        assert "DeferredToolsMiddleware" in middleware_types
 
 
 def test_output_invariants_prompt_keys_off_working_directory():

--- a/tests/unit_tests/automation/agent/test_subagents.py
+++ b/tests/unit_tests/automation/agent/test_subagents.py
@@ -216,6 +216,230 @@ class TestGeneralPurposeSubagent:
         assert "e.g., /repo/src" not in prompt  # not the stale bare-/repo/ example
 
 
+class TestSubagentMcpTools:
+    """MCP tools must reach the general-purpose and custom subagents.
+
+    Without this, a ``task`` delegation that calls an MCP tool (e.g. ``rt_search_tickets``)
+    fails — the tool isn't in the subagent's registry, so the model tries it as a shell
+    command and gets ``command not found``. The subagent mirrors the main agent: MCP tools
+    are deferred behind ``tool_search`` when deferral is on, bound directly when it's off.
+    """
+
+    @pytest.fixture
+    def mock_backend(self):
+        return Mock()
+
+    @pytest.fixture
+    def mock_model(self):
+        return Mock()
+
+    @pytest.fixture
+    def mock_runtime_ctx(self, tmp_path):
+        repo_dir = tmp_path / "repo"
+        repo_dir.mkdir()
+        ctx = Mock()
+        ctx.gitrepo.working_dir = str(repo_dir)
+        return ctx
+
+    @pytest.fixture
+    def mcp_tool(self):
+        from langchain_core.tools import StructuredTool
+
+        return StructuredTool.from_function(func=lambda **k: "x", name="rt_search_tickets", description="Search RT")
+
+    def test_builder_defers_mcp_tools_when_deferral_enabled(self, mock_model, mock_backend, mock_runtime_ctx, mcp_tool):
+        from automation.agent.middlewares.deferred_tools import DeferredToolsMiddleware
+        from automation.agent.subagents import SUBAGENT_ALWAYS_LOADED_TOOLS
+
+        with patch("automation.agent.middlewares.deferred_tools.deferred_settings") as ds:
+            ds.ENABLED = True
+            ds.TOP_K_DEFAULT = 3
+            ds.TOP_K_MAX = 10
+            middleware = _build_general_purpose_middleware(
+                mock_model,
+                mock_backend,
+                mock_runtime_ctx,
+                sandbox_enabled=True,
+                web_search_enabled=True,
+                web_fetch_enabled=True,
+                mcp_tools=[mcp_tool],
+            )
+
+        dtm = next(m for m in middleware if isinstance(m, DeferredToolsMiddleware))
+        assert dtm._extra_tools == [mcp_tool]
+        # The subagent's own tools stay always-loaded — only MCP tools are deferred.
+        assert dtm._always_loaded >= SUBAGENT_ALWAYS_LOADED_TOOLS
+
+    def test_builder_still_installs_deferred_middleware_without_mcp_tools(
+        self, mock_model, mock_backend, mock_runtime_ctx
+    ):
+        # Even with no MCP tools, a subagent still gets DeferredToolsMiddleware when deferral is on:
+        # it defers the subagent's own web search/fetch + git-platform tools (not in
+        # SUBAGENT_ALWAYS_LOADED_TOOLS), mirroring the main agent.
+        from automation.agent.middlewares.deferred_tools import DeferredToolsMiddleware
+
+        with patch("automation.agent.middlewares.deferred_tools.deferred_settings") as ds:
+            ds.ENABLED = True
+            ds.TOP_K_DEFAULT = 3
+            ds.TOP_K_MAX = 10
+            middleware = _build_general_purpose_middleware(
+                mock_model,
+                mock_backend,
+                mock_runtime_ctx,
+                sandbox_enabled=True,
+                web_search_enabled=True,
+                web_fetch_enabled=True,
+                mcp_tools=[],
+            )
+
+        dtm = next(m for m in middleware if isinstance(m, DeferredToolsMiddleware))
+        assert dtm._extra_tools == []
+
+    def test_builder_omits_deferred_middleware_when_deferral_disabled(
+        self, mock_model, mock_backend, mock_runtime_ctx, mcp_tool
+    ):
+        from automation.agent.middlewares.deferred_tools import DeferredToolsMiddleware
+
+        with patch("automation.agent.middlewares.deferred_tools.deferred_settings") as ds:
+            ds.ENABLED = False
+            middleware = _build_general_purpose_middleware(
+                mock_model,
+                mock_backend,
+                mock_runtime_ctx,
+                sandbox_enabled=True,
+                web_search_enabled=True,
+                web_fetch_enabled=True,
+                mcp_tools=[mcp_tool],
+            )
+
+        assert not any(isinstance(m, DeferredToolsMiddleware) for m in middleware)
+
+    def test_web_git_and_mcp_deferred_file_bash_core_stays_loaded(
+        self, mock_model, mock_backend, mock_runtime_ctx, mcp_tool
+    ):
+        # Subagents mirror the main agent: the file/bash/todo core stays eagerly bound, while web
+        # search/fetch, git-platform, and MCP tools all fall behind tool_search.
+        from langchain_core.tools import StructuredTool
+
+        from automation.agent.middlewares.deferred_tools import DeferredToolsMiddleware
+
+        native = [
+            StructuredTool.from_function(func=lambda **k: "", name=n, description=n)
+            for n in ("read_file", "bash", "web_search", "gitlab")
+        ]
+        with patch("automation.agent.middlewares.deferred_tools.deferred_settings") as ds:
+            ds.ENABLED = True
+            ds.TOP_K_DEFAULT = 3
+            ds.TOP_K_MAX = 10
+            middleware = _build_general_purpose_middleware(
+                mock_model,
+                mock_backend,
+                mock_runtime_ctx,
+                sandbox_enabled=True,
+                web_search_enabled=True,
+                web_fetch_enabled=True,
+                mcp_tools=[mcp_tool],
+            )
+
+        dtm = next(m for m in middleware if isinstance(m, DeferredToolsMiddleware))
+        deferred = {e.name for e in dtm._build_index(native).deferred_entries()}
+        assert deferred == {"web_search", "gitlab", "rt_search_tickets"}  # web/git + MCP deferred
+        assert "read_file" not in deferred and "bash" not in deferred  # file/bash core stays loaded
+
+    def test_general_purpose_binds_mcp_tools_directly_when_deferral_disabled(
+        self, mock_model, mock_backend, mock_runtime_ctx, mcp_tool
+    ):
+        with (
+            patch("automation.agent.middlewares.deferred_tools.deferred_settings") as ds,
+            patch("automation.agent.subagents.create_agent") as mock_create,
+        ):
+            ds.ENABLED = False
+            mock_create.return_value = Mock()
+            create_general_purpose_subagent(
+                mock_model, mock_backend, mock_runtime_ctx, "/workspace/repo/", mcp_tools=[mcp_tool]
+            )
+
+        assert mock_create.call_args.kwargs["tools"] == [mcp_tool]
+
+    def test_general_purpose_passes_empty_tools_when_deferral_enabled(
+        self, mock_model, mock_backend, mock_runtime_ctx, mcp_tool
+    ):
+        # Deferral on: the MCP tools ride on DeferredToolsMiddleware, so create_agent gets none
+        # directly (the middleware already registers them; binding them directly too is redundant).
+        with (
+            patch("automation.agent.middlewares.deferred_tools.deferred_settings") as ds,
+            patch("automation.agent.subagents.create_agent") as mock_create,
+        ):
+            ds.ENABLED = True
+            ds.TOP_K_DEFAULT = 3
+            ds.TOP_K_MAX = 10
+            mock_create.return_value = Mock()
+            create_general_purpose_subagent(
+                mock_model, mock_backend, mock_runtime_ctx, "/workspace/repo/", mcp_tools=[mcp_tool]
+            )
+
+        assert mock_create.call_args.kwargs["tools"] == []
+
+    async def test_custom_subagents_receive_mcp_tools(self, tmp_path, mock_model, mock_runtime_ctx, mcp_tool):
+        from automation.agent.middlewares.file_system import DAIVFilesystemBackend
+
+        subagents_dir = tmp_path / "repo" / ".agents" / "subagents"
+        subagents_dir.mkdir(parents=True)
+        (subagents_dir / "my-agent.md").write_text(_make_subagent_md(name="my-agent", description="Does things"))
+
+        backend = DAIVFilesystemBackend(root_dir=tmp_path, virtual_mode=True)
+        with patch("automation.agent.subagents._build_general_purpose_middleware", return_value=[]) as build_mw:
+            await load_custom_subagents(
+                model=mock_model,
+                backend=backend,
+                runtime=mock_runtime_ctx,
+                sources=["/repo/.agents/subagents"],
+                working_directory="/workspace/repo/",
+                mcp_tools=[mcp_tool],
+            )
+
+        build_mw.assert_called_once()
+        assert build_mw.call_args.kwargs["mcp_tools"] == [mcp_tool]
+
+    async def test_custom_subagents_bind_mcp_tools_directly_when_deferral_disabled(
+        self, tmp_path, mock_model, mock_runtime_ctx, mcp_tool
+    ):
+        # Custom subagents are a distinct create_agent call site (_compile_subagent), so the
+        # deferral-off direct-bind path needs its own coverage alongside the general-purpose one.
+        from automation.agent.middlewares.file_system import DAIVFilesystemBackend
+
+        subagents_dir = tmp_path / "repo" / ".agents" / "subagents"
+        subagents_dir.mkdir(parents=True)
+        (subagents_dir / "my-agent.md").write_text(_make_subagent_md(name="my-agent", description="Does things"))
+
+        backend = DAIVFilesystemBackend(root_dir=tmp_path, virtual_mode=True)
+        with (
+            patch("automation.agent.middlewares.deferred_tools.deferred_settings") as ds,
+            patch("automation.agent.subagents.create_agent") as mock_create,
+        ):
+            ds.ENABLED = False
+            mock_create.return_value = Mock()
+            await load_custom_subagents(
+                model=mock_model,
+                backend=backend,
+                runtime=mock_runtime_ctx,
+                sources=["/repo/.agents/subagents"],
+                working_directory="/workspace/repo/",
+                mcp_tools=[mcp_tool],
+            )
+
+        assert mock_create.call_args.kwargs["tools"] == [mcp_tool]
+
+    def test_direct_mcp_tools_returns_empty_for_none_or_empty(self):
+        # ``mcp_tools`` defaults to None on every subagent factory, so the helper must guard None/[]
+        # before ``list(mcp_tools)`` — a caller that omits MCP tools never hits an AttributeError.
+        # Both cases return [] regardless of the deferral flag (the ``not mcp_tools`` guard fires first).
+        from automation.agent.middlewares.deferred_tools import direct_mcp_tools
+
+        assert direct_mcp_tools(None) == []
+        assert direct_mcp_tools([]) == []
+
+
 @pytest.mark.django_db
 class TestExploreSubagent:
     """Tests for the public ``create_explore_subagent`` factory."""


### PR DESCRIPTION
## What

Subagents spawned via the `task` tool had **no access to the parent agent's MCP toolset** (RT, Sentry, GitLab, Grafana, …). When the main agent delegated a tool-dependent step, the subagent tried to invoke the MCP tool as a shell command and failed with `command not found` — silently losing the step or wasting a round-trip. This was the highest-impact harness issue surfaced by the production trace analysis.

## Fix

- Thread the parent's MCP toolset into the **general-purpose** and **custom** subagents (the delegation targets). `explore` and the code-review detectors stay deliberately scoped (read-only / structured) and receive no MCP tools.
- Consolidate the defer-or-bind decision into two shared helpers — `direct_mcp_tools` and `deferred_tools_middleware` — in `middlewares/deferred_tools.py`, used by **both** the main agent (`graph.py`) and the subagents (`subagents.py`). Single source of truth for the `deferred_settings` reads.
- Subagents now **mirror the main agent's deferral policy**: only the file/bash/todo core is eagerly bound; web search/fetch, git-platform, and MCP tools are all deferred behind `tool_search`. A loaded deferred tool stays loaded for the session, so a delegate that needs web/git pays at most one `tool_search`.

## Why deferral (not eager binding)

The production MCP toolset is large (Grafana alone ~70 tools); binding it eagerly on every short-lived subagent turn would bloat context and break prompt caching. Deferral matches the main agent and stays scalable. Trace analysis of 46 production runs informed the consistency decision: general-purpose/custom subagents are spawned rarely (4 in 46 runs), and the main agent already defers `gitlab` while calling it 53× off a single load — so the one-time `tool_search` cost is negligible.

## Test plan

- New `TestSubagentMcpTools` (subagents.py) + graph-wiring tests: deferral on/off paths, empty-MCP path, web/git+MCP deferred while file/bash core stays loaded, explore/detector exclusion, custom-subagent direct-bind.
- `989` automation tests pass; lint + type-check clean (net-zero new diagnostics).

> Stacked on `feat/code-review-detector-fanout` (#1274) — base is set to that branch so this diff shows only the MCP-subagent work. Retarget to `main` once #1274 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
