### PR TITLE
fix(agent): Measure step budget per run, not absolute langgraph_step

### DIFF
--- a/daiv/automation/agent/middlewares/step_budget.py
+++ b/daiv/automation/agent/middlewares/step_budget.py
@@ -54,6 +54,18 @@ class StepBudgetMiddleware(AgentMiddleware):
     per-turn superstep cost it is trying to guard). The reminder is appended only to the
     in-flight request and never persisted to the conversation state, so it repeats on
     every call while the budget stays low.
+
+    Budget is measured *per run*, not against the absolute ``langgraph_step``. LangGraph
+    applies ``recursion_limit`` relative to the resume point (it sets
+    ``stop = resume_step + recursion_limit + 1`` on every entry), so each invocation gets a
+    fresh budget. The raw ``langgraph_step`` instead accumulates across every turn on a
+    thread (and survives ``/clear``, which cannot reset LangGraph's internal step counter
+    under the same ``thread_id``), so comparing it directly to ``recursion_limit`` would trip
+    the reminder on the first model call of any long-lived thread. We therefore capture the
+    step this run started at (lazily, on the first model call) and count consumption from
+    there. ``create_daiv_agent`` binds per-run state (sandbox, checkpointer, context) into the
+    middleware stack, so the agent — and this instance — is necessarily rebuilt per invocation;
+    the baseline thus resets each run without needing a graph node.
     """
 
     def __init__(
@@ -62,6 +74,9 @@ class StepBudgetMiddleware(AgentMiddleware):
         super().__init__()
         self.warn_remaining_steps = warn_remaining_steps
         self.finalize_remaining_steps = finalize_remaining_steps
+        # Absolute ``langgraph_step`` this run started at, captured lazily on the first model
+        # call; consumption is then measured relative to it (see class docstring).
+        self._baseline_step: int | None = None
 
     async def awrap_model_call(
         self, request: ModelRequest, handler: Callable[[ModelRequest], Awaitable[ModelResponse]]
@@ -79,7 +94,23 @@ class StepBudgetMiddleware(AgentMiddleware):
         if not limit or step is None:
             return None
 
-        remaining = limit - step
+        # Anchor the budget to where THIS run started (see class docstring): the first model
+        # call records the baseline, and remaining is measured from supersteps consumed since.
+        if self._baseline_step is None:
+            self._baseline_step = step
+        consumed = step - self._baseline_step
+        if consumed < 0:
+            # langgraph_step below the captured baseline means the per-run-rebuild invariant this
+            # relies on has broken (see class docstring). Clamp so the budget reads as full rather
+            # than reporting nonsense, and surface the anomaly instead of failing silently.
+            logger.warning(
+                "langgraph_step=%d is below the captured baseline=%d; treating run budget as full.",
+                step,
+                self._baseline_step,
+            )
+            consumed = 0
+
+        remaining = limit - consumed
         if remaining <= self.finalize_remaining_steps:
             template = BUDGET_FINALIZE
         elif remaining <= self.warn_remaining_steps:
@@ -88,5 +119,10 @@ class StepBudgetMiddleware(AgentMiddleware):
             return None
 
         turns = max(remaining // STEPS_PER_TURN, 1)
-        logger.info("Run is %d supersteps away from recursion_limit=%d; injecting budget reminder.", remaining, limit)
+        logger.info(
+            "Run has consumed %d of %d supersteps (%d remaining); injecting budget reminder.",
+            consumed,
+            limit,
+            remaining,
+        )
         return template.format(turns=turns)

--- a/tests/unit_tests/automation/agent/middlewares/test_step_budget.py
+++ b/tests/unit_tests/automation/agent/middlewares/test_step_budget.py
@@ -25,16 +25,25 @@ def _patched_config(recursion_limit: int | None, step: int | None):
     return patch("automation.agent.middlewares.step_budget.get_config", return_value=_config(recursion_limit, step))
 
 
-class TestStepBudgetMiddleware:
-    middleware = StepBudgetMiddleware(warn_remaining_steps=40, finalize_remaining_steps=16)
+def _middleware(baseline: int | None = 0) -> StepBudgetMiddleware:
+    """A fresh middleware whose run started at ``baseline`` (default 0, i.e. a fresh thread).
 
+    ``None`` leaves the baseline uncaptured so the next ``_budget_reminder`` call records it,
+    mirroring the lazy capture on the first model call of a run.
+    """
+    middleware = StepBudgetMiddleware(warn_remaining_steps=40, finalize_remaining_steps=16)
+    middleware._baseline_step = baseline
+    return middleware
+
+
+class TestStepBudgetMiddleware:
     def test_no_reminder_far_from_limit(self):
         with _patched_config(recursion_limit=500, step=100):
-            assert self.middleware._budget_reminder() is None
+            assert _middleware()._budget_reminder() is None
 
     def test_warning_reminder_in_warn_zone(self):
         with _patched_config(recursion_limit=500, step=470):
-            reminder = self.middleware._budget_reminder()
+            reminder = _middleware()._budget_reminder()
         assert reminder is not None
         # 30 supersteps left ≈ 15 turns
         assert "15 tool-call turns" in reminder
@@ -42,17 +51,59 @@ class TestStepBudgetMiddleware:
 
     def test_finalize_reminder_near_limit(self):
         with _patched_config(recursion_limit=500, step=490):
-            reminder = self.middleware._budget_reminder()
+            reminder = _middleware()._budget_reminder()
         assert reminder is not None
         assert "NOW" in reminder
 
     def test_no_reminder_without_recursion_limit_in_config(self):
         with _patched_config(recursion_limit=None, step=470):
-            assert self.middleware._budget_reminder() is None
+            assert _middleware()._budget_reminder() is None
 
     def test_no_reminder_without_step_in_config(self):
         with _patched_config(recursion_limit=500, step=None):
-            assert self.middleware._budget_reminder() is None
+            assert _middleware()._budget_reminder() is None
+
+    def test_resumed_run_starts_with_full_budget(self):
+        # A thread that has already accumulated supersteps across prior turns resumes at a high
+        # absolute langgraph_step, but recursion_limit is applied relative to the resume point, so
+        # the run still has a full budget. The first model call must not trip the reminder.
+        middleware = _middleware(baseline=None)
+        with _patched_config(recursion_limit=500, step=467):
+            assert middleware._budget_reminder() is None
+
+    def test_resumed_run_warns_after_consuming_budget(self):
+        # Same resumed thread (baseline 467): once THIS run has consumed exactly 470 supersteps
+        # the warning fires, proving consumption is measured per-run, not against absolute step.
+        middleware = _middleware(baseline=None)
+        with _patched_config(recursion_limit=500, step=467):
+            assert middleware._budget_reminder() is None  # captures baseline = 467
+        with _patched_config(recursion_limit=500, step=937):  # consumed 470 → 30 remaining
+            reminder = middleware._budget_reminder()
+        assert reminder is not None
+        assert "15 tool-call turns" in reminder
+
+    def test_baseline_captured_once_and_not_re_anchored(self):
+        # The baseline is anchored on the first call and never re-captured, so consumption keeps
+        # growing (remaining shrinking) as langgraph_step advances. Pins the "capture once"
+        # contract: an unconditional re-assignment would reset consumed to 0 every call and
+        # silently disable the warning for the whole run.
+        middleware = _middleware(baseline=None)
+        with _patched_config(recursion_limit=500, step=467):
+            assert middleware._budget_reminder() is None  # baseline = 467, consumed 0
+        with _patched_config(recursion_limit=500, step=917):
+            assert middleware._budget_reminder() is None  # consumed 450 → 50 remaining, still quiet
+        with _patched_config(recursion_limit=500, step=937):
+            assert middleware._budget_reminder() is not None  # consumed 470 → 30 remaining → warn
+        assert middleware._baseline_step == 467  # never re-anchored
+
+    def test_step_below_baseline_fails_safe_to_full_budget(self):
+        # Defensive: if langgraph_step is ever observed below the captured baseline (the per-run
+        # rebuild invariant broke), consumed is clamped to 0 so we never spuriously tell the model
+        # to finalize. The original baseline is left untouched.
+        middleware = _middleware(baseline=500)
+        with _patched_config(recursion_limit=500, step=470):  # raw consumed would be -30
+            assert middleware._budget_reminder() is None
+        assert middleware._baseline_step == 500
 
     async def test_wrap_model_call_appends_reminder_to_request(self):
         seen_requests = []
@@ -63,7 +114,7 @@ class TestStepBudgetMiddleware:
 
         request = _request()
         with _patched_config(recursion_limit=500, step=470):
-            await self.middleware.awrap_model_call(request, handler)
+            await _middleware().awrap_model_call(request, handler)
 
         assert len(seen_requests[0].messages) == 2
         assert "tool-call turns" in seen_requests[0].messages[-1].content
@@ -79,6 +130,6 @@ class TestStepBudgetMiddleware:
 
         request = _request()
         with _patched_config(recursion_limit=500, step=100):
-            await self.middleware.awrap_model_call(request, handler)
+            await _middleware().awrap_model_call(request, handler)
 
         assert seen_requests[0] is request


### PR DESCRIPTION
## Problem

The step-budget reminder fired spuriously on long-lived / freshly-cleared MR threads. A user running `/clear` on a previously-run MR saw `Run is 33 supersteps away from recursion_limit=500; injecting budget reminder.` immediately after clearing.

**Root cause:** `StepBudgetMiddleware` compared the cumulative `langgraph_step` to `recursion_limit`. But LangGraph applies `recursion_limit` *relative to a run's resume point* — on every entry it sets `stop = resume_step + recursion_limit + 1` (`pregel/_loop.py`), so each invocation gets a fresh budget. `langgraph_step` instead grows across every turn on a thread, so on any thread with > ~460 cumulative supersteps the reminder fired on the first model call of every turn.

`/clear` didn't help: it deletes the Redis checkpoint and wipes message history, but cannot reset LangGraph's internal step counter under the same deterministic `thread_id` (the run that processes `/clear` writes a final checkpoint back at the continued step). So a cleared thread still resumed at the high step — `33 = 500 − 467`.

## Fix

Measure the budget **per run**: capture a baseline `langgraph_step` lazily on the first model call, then `remaining = limit − (step − baseline)`. The middleware is rebuilt per invocation (`create_daiv_agent` binds per-run state and is never cached), so the baseline resets each run without adding a graph node.

Defensively clamp and `warning`-log if a step below the baseline is ever observed, surfacing a broken invariant instead of silently disabling the reminder.

## Tests

- `test_resumed_run_starts_with_full_budget` / `test_resumed_run_warns_after_consuming_budget` — the regression: a high absolute step no longer warns; the warning fires only after the run actually consumes its budget. Both fail against the old code.
- `test_baseline_captured_once_and_not_re_anchored` — pins the capture-once contract.
- `test_step_below_baseline_fails_safe_to_full_budget` — the defensive clamp.

11/11 pass; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)