### PR TITLE
fix(agent): recover from non-fast-forward push rejections

### DIFF
--- a/daiv/automation/agent/git_manager.py
+++ b/daiv/automation/agent/git_manager.py
@@ -13,6 +13,8 @@ from automation.agent.constants import REPO_PATH
 from core.utils import is_git_auth_error_text
 
 if TYPE_CHECKING:
+    from typing import NoReturn
+
     from git import Repo
 
     from automation.agent.middlewares.file_system import SandboxFileBackend
@@ -304,18 +306,82 @@ class GitManager:
         await self._git("add", "-A")
         await self._git("commit", "-m", message)
 
-    async def push_head_to(self, branch: str, *, force: bool = False) -> str:
+    async def push_head_to(self, branch: str, *, force: bool = False, integrate_on_reject: bool = False) -> str:
         """Push the current ``HEAD`` to ``origin/<branch>`` (creating it if needed).
 
-        Raises ``GitPushPermissionError`` on an auth/permission failure,
-        ``GitPushNetworkError`` when the remote host is unreachable (e.g. a network-disabled
-        sandbox), and ``GitCommandError`` on any other push failure. Returns ``branch``.
+        When ``integrate_on_reject`` is set and a *non-fast-forward* rejection comes back — the
+        remote branch advanced under the run, e.g. a dependabot force-push of its rebased PR
+        branch, or a concurrent human push to an MR's source branch — the manager fetches the
+        remote tip, rebases ``HEAD`` onto it, and retries the push once. This preserves the agent's
+        work instead of discarding it. Pass it only when adding onto a branch is the intent (an
+        existing MR's source branch); a fresh-branch push leaves it off so we never graft the run's
+        commits onto unrelated history that happens to occupy a colliding ref.
+
+        Raises ``GitPushStaleError`` on a non-fast-forward rejection that cannot be (or was asked not
+        to be) integrated — including a rebase conflict or a remote that advanced again before the
+        retry. Raises ``GitPushPermissionError`` on an auth/permission failure, ``GitPushNetworkError``
+        when the remote host is unreachable (e.g. a network-disabled sandbox), and ``GitCommandError``
+        on any other push failure. Returns ``branch``.
         """
         push_args = ["push", "origin", f"HEAD:{branch}", *(["--force"] if force else [])]
         push = await self._git(*push_args, check=False)
-        if push.exit_code != 0:
-            _raise_for_push_failure(push_args, push)
-        return branch
+        if push.exit_code == 0:
+            return branch
+
+        # A non-fast-forward rejection is the only failure that integrating remote work can fix; an
+        # auth/network/other failure won't change after a fetch+rebase, so it falls straight through
+        # to classification below. On a successful integrate, retry the push and return on success.
+        if integrate_on_reject and not force and _is_push_stale_error_text(push.output):
+            await self._rebase_onto_remote(branch)  # raises GitPushStaleError on a rebase conflict
+            push = await self._git(*push_args, check=False)
+            if push.exit_code == 0:
+                return branch
+
+        # Either the push failed and we couldn't/didn't integrate, or the retry was still rejected
+        # (remote advanced again) — classify whichever failed push result we are holding.
+        _raise_for_push_failure(push_args, push)
+
+    async def _rebase_onto_remote(self, branch: str) -> None:
+        """Fetch ``origin/<branch>`` and rebase ``HEAD`` onto it so a non-fast-forward push can retry.
+
+        On success ``HEAD`` is the run's commits replayed on top of the latest remote tip. A failed
+        fetch is classified by transport (auth → ``GitPushPermissionError``, unreachable host →
+        ``GitPushNetworkError``, else ``GitCommandError``) — via the operation-neutral
+        :func:`_raise_for_transport_failure` rather than the push classifier, so a fetch never raises
+        a nonsensical non-fast-forward error — keeping the actionable typed error the direct push
+        would have produced instead of degrading to a raw ``GitCommandError``. On a rebase conflict
+        the rebase is aborted (restoring the pre-rebase ``HEAD`` rather than stranding the workspace
+        mid-rebase) and a typed :class:`GitPushStaleError` is raised. A *failed* abort cannot restore
+        ``HEAD``: it is logged at error level (never silently swallowed) and flagged in the raised
+        message, since the workspace is then left mid-rebase and must not be re-published.
+        """
+        fetch_args = ["fetch", "origin", branch]
+        fetch = await self._git(*fetch_args, check=False)
+        if fetch.exit_code != 0:
+            _raise_for_transport_failure(fetch_args, fetch)
+            raise GitCommandError(["git", *fetch_args], fetch.exit_code, fetch.output)
+
+        rebase = await self._git("rebase", "FETCH_HEAD", check=False)
+        if rebase.exit_code != 0:
+            abort = await self._git("rebase", "--abort", check=False)
+            if abort.exit_code != 0:
+                logger.error(
+                    "git rebase --abort failed after a conflict on '%s' (exit %s); the workspace is left "
+                    "mid-rebase. Output: %s",
+                    branch,
+                    abort.exit_code,
+                    abort.output.strip(),
+                )
+                raise GitPushStaleError(
+                    f"The remote branch '{branch}' moved while DAIV was working and its changes conflict "
+                    "with DAIV's. The conflicted rebase could not be aborted, so the workspace is in an "
+                    "inconsistent state. Re-trigger DAIV to retry from a fresh clone."
+                )
+            raise GitPushStaleError(
+                f"The remote branch '{branch}' moved while DAIV was working and its changes conflict "
+                "with DAIV's, so they could not be rebased automatically. Re-trigger DAIV to retry "
+                "against the updated branch."
+            )
 
     # -- helpers -------------------------------------------------------------
     @staticmethod
@@ -364,6 +430,16 @@ class GitPushPermissionError(RuntimeError):
     """
 
 
+class GitPushStaleError(RuntimeError):
+    """Raised when a push is rejected as non-fast-forward and cannot be integrated.
+
+    The remote branch advanced under the run (a dependabot force-push of its rebased PR branch, or a
+    concurrent push to an MR's source branch) so ``HEAD`` is no longer a descendant of the remote tip.
+    Kept distinct from the raw ``GitCommandError`` so callers surface an actionable "the branch moved;
+    re-trigger" note instead of crashing the task on an inherently transient race.
+    """
+
+
 class GitPushNetworkError(RuntimeError):
     """Raised when pushing fails because the remote host is unreachable.
 
@@ -398,25 +474,65 @@ def _is_push_network_error_text(output: str) -> bool:
     )
 
 
-def _raise_for_push_failure(push_args: list[str], result: _GitResult) -> None:
-    """Translate a failed ``git push`` into a typed, actionable error.
+def _is_push_stale_error_text(output: str) -> bool:
+    """Check if git push output indicates a non-fast-forward rejection (the remote branch advanced).
 
-    Auth/permission → ``GitPushPermissionError``; an unreachable host → ``GitPushNetworkError``;
-    anything else → the raw ``GitCommandError``. Auth is checked first so it always wins.
+    Within :func:`_raise_for_push_failure` this is checked *after* the auth and network markers, so a
+    stale rejection that also mentions a URL or host is never misclassified there, and a genuine
+    auth/network failure never reads as stale. The early gate in :meth:`GitManager.push_head_to` also
+    calls this before any auth/network check, which is safe because it only gates a recoverable
+    fetch+rebase and real auth/network output does not contain these non-fast-forward markers.
+    """
+    text = output.lower()
+    return any(
+        marker in text
+        for marker in (
+            "fetch first",
+            "non-fast-forward",
+            "updates were rejected because the remote contains work",
+            "tip of your current branch is behind",
+        )
+    )
+
+
+def _raise_for_transport_failure(args: list[str], result: _GitResult) -> None:
+    """Raise a typed error for an auth/permission or unreachable-host git failure; return otherwise.
+
+    Operation-neutral on purpose: a credential or host-reachability problem (and its remedy) is the
+    same whether the failing command was a ``push`` or the ``fetch`` of a push-recovery rebase, so
+    both share this classification. Returns (does not raise) when the output matches neither marker,
+    leaving the caller to layer operation-specific classification (e.g. push's non-fast-forward
+    branch) on top. Auth is checked before network so an auth failure that also names a host wins.
     """
     if is_git_auth_error_text(result.output):
-        logger.warning("git push auth failure: %s", result.output)
+        logger.warning("git transport auth failure: %s", result.output)
         raise GitPushPermissionError(
-            "Failed to push changes to the remote repository due to authentication or permission issues. "
+            "Failed to authenticate to the remote repository (authentication or permission issue). "
             "The credential embedded in the workspace may be expired (a session resumed a day or more "
             "after it was created holds an expired clone token — a fresh session re-clones with a new "
-            "one), or branch protection rules may not allow this credential to push to this branch."
+            "one), or branch protection rules may not allow this credential to write to this branch."
         )
     if _is_push_network_error_text(result.output):
-        logger.warning("git push network failure: %s", result.output)
+        logger.warning("git transport network failure: %s", result.output)
         raise GitPushNetworkError(
-            "Failed to push changes: the remote host is unreachable. Sandbox-authoritative auto-commit "
-            "pushes from inside the sandbox, so the sandbox environment must run as an egress-enabled "
-            "sandbox."
+            "Failed to reach the remote host (it is unreachable). DAIV runs git from inside the sandbox, "
+            "so the sandbox environment must run as an egress-enabled sandbox."
+        )
+
+
+def _raise_for_push_failure(push_args: list[str], result: _GitResult) -> NoReturn:
+    """Translate a failed ``git push`` into a typed, actionable error (always raises).
+
+    Auth/permission → ``GitPushPermissionError``; an unreachable host → ``GitPushNetworkError`` (both
+    via :func:`_raise_for_transport_failure`, checked first so they win); a non-fast-forward rejection
+    → ``GitPushStaleError``; anything else → the raw ``GitCommandError``.
+    """
+    _raise_for_transport_failure(push_args, result)
+    if _is_push_stale_error_text(result.output):
+        logger.warning("git push non-fast-forward rejection: %s", result.output)
+        raise GitPushStaleError(
+            "Failed to push changes: the remote branch advanced while DAIV was working (a non-fast-forward "
+            "rejection). DAIV could not integrate the remote changes automatically. Re-trigger DAIV to "
+            "retry against the updated branch."
         )
     raise GitCommandError(["git", *push_args], result.exit_code, result.output)

--- a/daiv/automation/agent/publishers.py
+++ b/daiv/automation/agent/publishers.py
@@ -126,7 +126,10 @@ class GitChangePublisher(ChangePublisher):
             else:
                 branch_name = merge_request.source_branch
 
-            await git_manager.push_head_to(branch_name)
+            # Only an existing MR's source branch may have advanced under the run (a dependabot
+            # force-push, or a concurrent push) — integrate + retry there so the work isn't lost.
+            # A fresh, unique branch can't, so leave integration off for new MRs.
+            await git_manager.push_head_to(branch_name, integrate_on_reject=merge_request is not None)
 
         logger.info("Published changes to branch: '%s' [skip_ci: %s]", branch_name, skip_ci)
 

--- a/tests/unit_tests/automation/agent/test_git_manager.py
+++ b/tests/unit_tests/automation/agent/test_git_manager.py
@@ -10,7 +10,9 @@ from automation.agent.git_manager import (
     GitManager,
     GitPushNetworkError,
     GitPushPermissionError,
+    GitPushStaleError,
     RepoStatus,
+    _is_push_stale_error_text,
     _shell_quote,
 )
 from automation.agent.middlewares.file_system import SandboxFileBackend
@@ -260,6 +262,187 @@ async def test_push_head_to_auth_wins_over_network_markers() -> None:
     })
     with pytest.raises(GitPushPermissionError):
         await gm.push_head_to("b")
+
+
+# ---------------------------------------------------------------------------
+# push_head_to non-fast-forward recovery (integrate_on_reject)
+# ---------------------------------------------------------------------------
+
+# A real non-fast-forward push rejection (the remote branch advanced under the run, e.g. a
+# dependabot force-push of its rebased PR branch).
+_NON_FF_REJECT = (
+    "To https://github.com/x/y.git\n"
+    " ! [rejected]        HEAD -> b (fetch first)\n"
+    "error: failed to push some refs to 'https://github.com/x/y.git'\n"
+    "hint: Updates were rejected because the remote contains work that you do not have locally.\n"
+)
+
+
+def _issued(client: MagicMock) -> list[str]:
+    """The single git command issued in each ``run_commands`` round-trip, in order."""
+    return [call.args[1].commands[0] for call in client.run_commands.await_args_list]
+
+
+async def test_push_head_to_integrates_remote_and_retries_on_non_fast_forward() -> None:
+    # First push is rejected as non-fast-forward; the manager fetches + rebases onto the remote
+    # tip and retries the push, which then succeeds — the agent's work is preserved.
+    client = MagicMock()
+    client.run_commands = AsyncMock(
+        side_effect=[_resp((_NON_FF_REJECT, 1)), _resp(("", 0)), _resp(("", 0)), _resp(("", 0))]
+    )
+    gm = GitManager.for_sandbox(_backend_for(client))
+
+    assert await gm.push_head_to("b", integrate_on_reject=True) == "b"
+
+    issued = _issued(client)
+    assert issued[0].endswith("push origin HEAD:b")
+    assert "fetch origin b" in issued[1]
+    assert "rebase FETCH_HEAD" in issued[2]
+    assert issued[3].endswith("push origin HEAD:b")
+
+
+async def test_push_head_to_raises_stale_on_rebase_conflict() -> None:
+    # The remote moved and its changes conflict with the agent's; the rebase fails, the manager
+    # aborts it (restoring HEAD) and raises a typed stale error instead of leaving a half-rebase.
+    client = MagicMock()
+    client.run_commands = AsyncMock(
+        side_effect=[
+            _resp((_NON_FF_REJECT, 1)),
+            _resp(("", 0)),
+            _resp(("CONFLICT (content): merge", 1)),
+            _resp(("", 0)),
+        ]
+    )
+    gm = GitManager.for_sandbox(_backend_for(client))
+
+    with pytest.raises(GitPushStaleError):
+        await gm.push_head_to("b", integrate_on_reject=True)
+
+    issued = _issued(client)
+    assert any("rebase --abort" in command for command in issued)
+    # No retry push is attempted once the rebase is aborted.
+    assert sum(command.endswith("push origin HEAD:b") for command in issued) == 1
+
+
+async def test_push_head_to_raises_stale_when_retry_still_rejected() -> None:
+    # The remote advanced again between our fetch and the retry push -> still non-fast-forward.
+    # We do not loop forever; surface a typed stale error.
+    client = MagicMock()
+    client.run_commands = AsyncMock(
+        side_effect=[_resp((_NON_FF_REJECT, 1)), _resp(("", 0)), _resp(("", 0)), _resp((_NON_FF_REJECT, 1))]
+    )
+    gm = GitManager.for_sandbox(_backend_for(client))
+
+    with pytest.raises(GitPushStaleError):
+        await gm.push_head_to("b", integrate_on_reject=True)
+
+
+async def test_push_head_to_classifies_non_fast_forward_as_stale_without_integration() -> None:
+    # Default (integrate_on_reject=False, e.g. a fresh-branch push): a non-fast-forward rejection is
+    # still classified as a typed stale error rather than a raw GitCommandError, and we never
+    # fetch/rebase (there is no shared intent to add onto whatever sits on that ref).
+    gm, client = _sandbox_manager({"push origin HEAD:b": (1, _NON_FF_REJECT)})
+    with pytest.raises(GitPushStaleError):
+        await gm.push_head_to("b")
+    assert not client.ran("fetch origin")
+    assert not client.ran("rebase")
+
+
+async def test_push_head_to_auth_wins_over_stale_markers() -> None:
+    # A rejection whose output carries BOTH a non-fast-forward marker AND a 403 must classify as an
+    # auth failure, not a transient stale race — `_raise_for_push_failure` checks stale last, so a
+    # real permission problem is never masked as "re-trigger me".
+    gm, _ = _sandbox_manager({"push origin HEAD:b": (1, _NON_FF_REJECT + "\nThe requested URL returned error: 403")})
+    with pytest.raises(GitPushPermissionError):
+        await gm.push_head_to("b")
+
+
+async def test_push_head_to_network_wins_over_stale_markers() -> None:
+    # Likewise an unreachable-host failure must win over a co-occurring stale marker.
+    gm, _ = _sandbox_manager({
+        "push origin HEAD:b": (1, _NON_FF_REJECT + "\nfatal: unable to access: Could not resolve host: example.com")
+    })
+    with pytest.raises(GitPushNetworkError):
+        await gm.push_head_to("b")
+
+
+async def test_push_head_to_integrate_skips_fetch_when_failure_is_auth_not_stale() -> None:
+    # integrate_on_reject is on, but the first push failed for auth (no non-ff marker): the
+    # `_is_push_stale_error_text` gate must NOT fire, so no fetch/rebase round-trip happens — an
+    # auth failure won't change after a fetch+rebase — and the typed auth error surfaces directly.
+    gm, client = _sandbox_manager({"push origin HEAD:b": (128, "The requested URL returned error: 403")})
+    with pytest.raises(GitPushPermissionError):
+        await gm.push_head_to("b", integrate_on_reject=True)
+    assert not client.ran("fetch origin")
+    assert not client.ran("rebase")
+
+
+async def test_push_head_to_integrate_classifies_fetch_failure() -> None:
+    # A fetch failure during recovery is classified like a push failure (here: auth) so the typed,
+    # actionable error is preserved instead of degrading to a raw GitCommandError. No rebase is
+    # attempted and no retry push happens after a failed fetch.
+    client = MagicMock()
+    client.run_commands = AsyncMock(
+        side_effect=[_resp((_NON_FF_REJECT, 1)), _resp(("The requested URL returned error: 403", 128))]
+    )
+    gm = GitManager.for_sandbox(_backend_for(client))
+
+    with pytest.raises(GitPushPermissionError):
+        await gm.push_head_to("b", integrate_on_reject=True)
+
+    issued = _issued(client)
+    assert "fetch origin b" in issued[1]
+    assert not any("rebase" in command for command in issued)
+    assert sum(command.endswith("push origin HEAD:b") for command in issued) == 1
+
+
+async def test_push_head_to_classifies_stale_when_abort_fails() -> None:
+    # If `git rebase --abort` itself fails, HEAD can't be restored: the workspace is left mid-rebase.
+    # We still raise a typed stale error (so the failure is surfaced, not a raw crash) but the abort
+    # failure is logged at error level rather than silently swallowed.
+    client = MagicMock()
+    client.run_commands = AsyncMock(
+        side_effect=[
+            _resp((_NON_FF_REJECT, 1)),
+            _resp(("", 0)),
+            _resp(("CONFLICT (content): merge", 1)),
+            _resp(("fatal: could not abort", 1)),
+        ]
+    )
+    gm = GitManager.for_sandbox(_backend_for(client))
+
+    with pytest.raises(GitPushStaleError, match="inconsistent state"):
+        await gm.push_head_to("b", integrate_on_reject=True)
+
+    assert any("rebase --abort" in command for command in _issued(client))
+
+
+async def test_push_head_to_force_skips_integration_on_non_fast_forward() -> None:
+    # The `not force` guard: a forced push that still gets a non-ff rejection must never fetch/rebase
+    # (force is the deliberate overwrite path); it is classified as stale directly.
+    gm, client = _sandbox_manager({"push origin HEAD:b --force": (1, _NON_FF_REJECT)})
+    with pytest.raises(GitPushStaleError):
+        await gm.push_head_to("b", force=True, integrate_on_reject=True)
+    assert not client.ran("fetch origin")
+    assert not client.ran("rebase")
+
+
+@pytest.mark.parametrize(
+    ("output", "expected"),
+    [
+        ("hint: (fetch first)", True),
+        ("error: failed to push some refs ... ! [rejected] (non-fast-forward)", True),
+        ("hint: Updates were rejected because the remote contains work that you do not have locally.", True),
+        ("hint: tip of your current branch is behind its remote counterpart.", True),
+        ("fatal: some other push failure", False),
+        ("The requested URL returned error: 403", False),
+        ("fatal: unable to access: Could not resolve host: example.com", False),
+    ],
+)
+def test_is_push_stale_error_text_matches_each_marker(output: str, expected: bool) -> None:
+    # Lock each non-fast-forward marker individually (the aggregate-output tests above happen to carry
+    # two markers at once), plus negatives so an auth/network/other failure never reads as stale.
+    assert _is_push_stale_error_text(output) is expected
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit_tests/automation/agent/test_publishers.py
+++ b/tests/unit_tests/automation/agent/test_publishers.py
@@ -254,7 +254,8 @@ class TestPublishSuggestsContextFile:
             result = await publisher.publish(merge_request=None)
 
             gm.commit_all.assert_awaited_once()
-            gm.push_head_to.assert_awaited_once_with("feature")
+            # Fresh branch for a brand-new MR: no remote work to integrate, so no rebase-on-reject.
+            gm.push_head_to.assert_awaited_once_with("feature", integrate_on_reject=False)
             mock_suggest.assert_called_once_with(mr)
             assert result == PublishOutcome(merge_request=mr, published=True)
 
@@ -283,9 +284,9 @@ class TestPublishSuggestsContextFile:
             # Pre-check must run before _diff_to_metadata so the fallback path receives a
             # populated pr_metadata_diff (the new MR needs title/branch/description).
             assert mock_diff_to_metadata.call_args.kwargs["pr_metadata_diff"] is not None
-            # Fresh unique branch generated + pushed for the fallback MR.
+            # Fresh unique branch generated + pushed for the fallback MR (no remote work to integrate).
             gm.unique_branch_name.assert_called_once_with("feature-fix", [])
-            gm.push_head_to.assert_awaited_once_with("feature-fix")
+            gm.push_head_to.assert_awaited_once_with("feature-fix", integrate_on_reject=False)
             # The new MR is created with a back-link to the original protected MR.
             mock_create_mr.assert_called_once()
             assert mock_create_mr.call_args.kwargs["fallback_from_mr"] is existing_mr
@@ -372,7 +373,9 @@ class TestPublishSuggestsContextFile:
         ):
             await publisher.publish(merge_request=mr)
 
-            gm.push_head_to.assert_awaited_once_with("feature")
+            # Existing MR: push to its source branch, integrating remote work on a non-ff rejection
+            # (the branch may have moved under the run, e.g. a concurrent push).
+            gm.push_head_to.assert_awaited_once_with("feature", integrate_on_reject=True)
             mock_suggest.assert_not_called()
 
 


### PR DESCRIPTION
## Problem

When DAIV addresses review comments on an existing MR, `GitChangePublisher` pushes the agent's `HEAD` to the MR's source branch. If that branch advanced under the run — a **Dependabot force-push of its rebased PR branch**, or a concurrent human push — the plain `git push origin HEAD:<branch>` is rejected as non-fast-forward (`! [rejected] ... (fetch first)`). Previously this fell through to a raw `GitCommandError`, which **crashed the task and discarded the agent's work**.

Observed in production on `address_mr_comments_task` pushing to `dependabot/uv/redis-8.0.1`.

## Change

- **`push_head_to(..., integrate_on_reject=...)`** — on a non-fast-forward rejection, fetch the remote branch, rebase `HEAD` onto it, and retry the push once. This preserves the agent's commits (the rebase drops the now-duplicate stale commit via patch-id and replays the agent's work on the new tip). Gated to **existing-MR branches only** (`merge_request is not None`); a fresh unique branch leaves it off so the run's commits are never grafted onto unrelated history.
- **`GitPushStaleError`** — typed error raised when integration can't recover: a rebase conflict (rebase is aborted to restore `HEAD`), a *failed* abort (logged at `error`, flagged as an inconsistent workspace), or a remote that advanced again before the retry. Non-fast-forward rejections on the non-integrating path are classified as this too, instead of a raw crash.
- **`_raise_for_transport_failure`** — auth/network classification factored into an operation-neutral helper shared by the push and the recovery fetch, so a failed fetch keeps its typed `GitPushPermissionError`/`GitPushNetworkError` instead of degrading to a raw error (and a fetch can never raise a nonsensical non-fast-forward error).

## Tests

13 new cases in `test_git_manager.py`: integrate + retry success, rebase-conflict → abort + stale, retry-still-rejected → stale, failed-abort → stale (logged), `force=True`/non-integrating skip integration, auth/network win over co-occurring stale markers, fetch-failure classification, and per-marker coverage of `_is_push_stale_error_text`. Publisher tests pin `integrate_on_reject` per MR type.

## Follow-up (not in this PR)

`GitPushStaleError` still propagates through the review/issue addressors' blanket `except Exception` into the generic "unable to address" note (and `_recover_draft` re-publishes on the same session), so the actionable message doesn't reach the user. Surfacing the typed message — and not re-publishing a session left mid-rebase — is a separate, cross-module change.
