### PR TITLE
ci: add continuous deployment to production server

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,73 @@
+name: Deploy
+
+# Continuous deployment to the production server (daivagent).
+#
+# Runs after the "Docker" workflow finishes building & pushing
+# ghcr.io/srtab/daiv:main for a push to main, then SSHes into the server and
+# rolls the app/worker/scheduler containers onto the new image. Can also be run
+# manually from the Actions tab to re-deploy or roll back the current :main image.
+on:
+  workflow_run:
+    workflows: ["Docker"]
+    types:
+      - completed
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Never let two deploys touch the server at the same time.
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: deploy
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # Deploy only on a manual run, or when the Docker build succeeded for a
+    # push to main (skips PR builds and tag builds — the server tracks :main).
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.event == 'push' &&
+       github.event.workflow_run.head_branch == 'main' &&
+       github.event.workflow_run.conclusion == 'success')
+
+    steps:
+      - name: Deploy over SSH
+        uses: appleboy/ssh-action@v1.2.5
+        with:
+          host: ${{ secrets.DEPLOY_HOST }}
+          username: ${{ secrets.DEPLOY_USER }}
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          fingerprint: ${{ secrets.DEPLOY_FINGERPRINT }}
+          command_timeout: 8m
+          script: |
+            set -e
+            cd /home/daiv
+
+            echo "Pulling latest images..."
+            docker compose pull app worker scheduler
+
+            echo "Recreating containers..."
+            docker compose up -d app worker scheduler
+
+            echo "Pruning dangling images..."
+            docker image prune -f
+
+            echo "Waiting for app to become healthy..."
+            for i in $(seq 1 30); do
+              if curl -fsS http://127.0.0.1:8000/-/alive/ >/dev/null 2>&1; then
+                echo "App is healthy."
+                docker compose ps app worker scheduler
+                exit 0
+              fi
+              echo "  not ready yet ($i/30); retrying in 5s..."
+              sleep 5
+            done
+
+            echo "ERROR: app did not become healthy within 150s" >&2
+            docker compose ps app worker scheduler
+            docker compose logs --tail=50 app >&2 || true
+            exit 1


### PR DESCRIPTION
## What

Adds `.github/workflows/deploy.yml` — continuous deployment of the production server (`daivagent`, plain `docker compose` at `/home/daiv`).

## How it works

```
push to main
  └─ Docker workflow builds & pushes ghcr.io/srtab/daiv:main   (existing)
       └─ Deploy workflow (workflow_run, on success) SSHes in as `daiv`:
            docker compose pull app worker scheduler
            docker compose up -d app worker scheduler   # app self-runs migrations on start
            docker image prune -f
            poll /-/alive/ for ~150s → fail (red X + email) if unhealthy
```

- **Trigger:** `workflow_run` after the **Docker** workflow completes, gated to `event == 'push'`, `head_branch == 'main'`, `conclusion == 'success'`. A failed/PR/tag build never deploys (the job shows as *skipped*). Plus a `workflow_dispatch` button for manual re-deploys / rollbacks.
- **Scope:** only `app`, `worker`, `scheduler` (all share `ghcr.io/srtab/daiv:main`); the stack's pinned `db`/`redis` and the `:latest` MCP/sandbox images are left untouched.
- **Auth:** deploys as the non-root `daiv` user (already in the `docker` group) via `appleboy/ssh-action`, with host-key verification by fingerprint.
- **Safety:** health-gated on the app's `/-/alive/` endpoint; no auto-rollback (migrations can't be auto-reverted), so a bad image fails loudly instead.

## Required repository secrets (already configured)

`DEPLOY_HOST`, `DEPLOY_USER`, `DEPLOY_FINGERPRINT`, `DEPLOY_SSH_KEY` — set via `gh secret`. The matching public key is installed in `/home/daiv/.ssh/authorized_keys` on the server.

## Activation

`workflow_run` / `workflow_dispatch` only become active once this file is on `main`. After merge, the next push to `main` auto-deploys; it can also be triggered manually from the Actions tab.
