### PR TITLE
fix(sandbox): cap run-scoped httpx connection pool

### DIFF
--- a/daiv/core/sandbox/client.py
+++ b/daiv/core/sandbox/client.py
@@ -87,6 +87,16 @@ def is_transient_sandbox_error(exc: httpx.HTTPError) -> bool:
     return True
 
 
+# Cap the run-scoped sandbox connection pool. Sandbox calls within a run are near-sequential — the
+# bash and file tools run one at a time, and the widest fan-out is GitManager's small command batch —
+# so a handful of connections is ample. httpx's DEFAULT ``max_connections`` is 100; a single long run
+# (heavy merge request, high thinking budget) let one pool climb toward that ceiling, and combined
+# with the other per-run pools (LLM, git platform, Redis) against a low container fd limit it exhausted
+# file descriptors ("[Errno 24] Too many open files"). An explicit cap bounds one run's sandbox sockets
+# regardless of run length while leaving headroom for the legitimate concurrent calls above.
+SANDBOX_CONNECTION_LIMITS = httpx.Limits(max_connections=32, max_keepalive_connections=16)
+
+
 class DAIVSandboxClient:
     """
     Client to interact with the daiv-sandbox service.
@@ -106,7 +116,10 @@ class DAIVSandboxClient:
         if self._client is not None:
             raise RuntimeError("DAIVSandboxClient is already open; nested entry would leak the previous httpx client")
         self._client = httpx.AsyncClient(
-            base_url=self.url, headers=self._get_headers(), timeout=site_settings.sandbox_timeout
+            base_url=self.url,
+            headers=self._get_headers(),
+            timeout=site_settings.sandbox_timeout,
+            limits=SANDBOX_CONNECTION_LIMITS,
         )
         return self
 

--- a/tests/unit_tests/core/sandbox/test_client.py
+++ b/tests/unit_tests/core/sandbox/test_client.py
@@ -121,6 +121,30 @@ async def test_connection_pool_reused_across_calls_in_one_block(fake_settings, m
     assert len(set(mock_post["client_ids"])) == 1, "expected the same httpx.AsyncClient to handle all three calls"
 
 
+async def test_open_bounds_connection_pool(fake_settings, monkeypatch):
+    """open() must cap the pool below httpx's default (100) so one long run can't exhaust fds."""
+    from core.sandbox.client import SANDBOX_CONNECTION_LIMITS, DAIVSandboxClient
+
+    captured: dict = {}
+
+    class FakeAsyncClient:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+        async def aclose(self):
+            pass
+
+    monkeypatch.setattr("core.sandbox.client.httpx.AsyncClient", FakeAsyncClient)
+
+    client = DAIVSandboxClient()
+    await client.open()
+    await client.close()
+
+    assert captured["limits"] is SANDBOX_CONNECTION_LIMITS
+    assert SANDBOX_CONNECTION_LIMITS.max_connections is not None
+    assert SANDBOX_CONNECTION_LIMITS.max_connections < 100
+
+
 async def test_double_open_raises(fake_settings):
     """Re-entering an already-open client would leak the previous httpx.AsyncClient."""
     from core.sandbox.client import DAIVSandboxClient


### PR DESCRIPTION
## Problem

A production worker on the daivagent host hit `ConnectError: [Errno 24] Too many open files` during a long merge-request agent run, and the follow-up draft recovery failed too (Sentry issue 132496894).

Root cause: `DAIVSandboxClient` opened its `httpx.AsyncClient` with **default** connection limits (`max_connections=100`). The Sentry trace caught one run-scoped pool at **94 active / 0 idle** connections. A single heavy run (38 min, ~1700 sandbox calls, high thinking budget → long idle gaps that trip the sandbox uvicorn's 5s keep-alive) let that pool climb toward the 100 ceiling. Combined with the other per-run pools (LLM, git platform, Redis) against a low container fd limit, the process ran out of file descriptors — the checkpointed `redis.exceptions.ConnectionError` breadcrumb confirms the exhaustion was process-wide, not sandbox-only.

The client lifecycle itself is correct (`set_runtime_ctx`'s `finally` closes the client per run — fds recover after the run), so this is an **unbounded per-run pool**, not a leak.

## Change

Pass an explicit `httpx.Limits(max_connections=32, max_keepalive_connections=16)` when opening the sandbox client. Sandbox calls within a run are near-sequential (bash and file tools run one at a time; the widest fan-out is `GitManager`'s small command batch), so 32 is ample headroom while hard-bounding one run's sandbox sockets regardless of run length.

## Companion ops change (already applied to prod)

The container `nofile` soft limit was Docker's default **1024** (no `ulimits` in compose) — far too low for a service holding sandbox + LLM + Sentry + Langsmith + DB + Redis + git sockets during long runs. It has been raised to **65536** on the daivagent `docker-compose.yml` (`x-app-defaults` anchor → app/worker/scheduler) and the services recreated. That alone prevents recurrence; this PR is defense-in-depth that stops any single run from ballooning.

## Test

`test_open_bounds_connection_pool` asserts `open()` wires the bounded limits and that the cap is below httpx's default of 100.