### PR TITLE
docs(deployment): document nofile ulimit requirement

### DIFF
--- a/docs/getting-started/deployment.md
+++ b/docs/getting-started/deployment.md
@@ -63,6 +63,19 @@ docker secret create django_secret_key <secret_key>
 !!! warning "Customize Environment Variables"
     **Replace all annotated values with your own configuration**. See the [Environment Variables](../reference/env-variables.md) page for complete configuration options.
 
+!!! warning "Raise the open-file limit (`nofile`)"
+    Each DAIV agent run holds many concurrent sockets (sandbox, LLM API, tracing, database, Redis, git-over-HTTPS). Docker's default soft limit of **1024** open files is too low and surfaces under load as `[Errno 24] Too many open files`. Swarm **ignores** service-level `ulimits`, so raise it on the Docker daemon of **each node** — add to `/etc/docker/daemon.json`:
+
+    ```json
+    {
+      "default-ulimits": {
+        "nofile": { "Name": "nofile", "Soft": 65536, "Hard": 524288 }
+      }
+    }
+    ```
+
+    then restart Docker (e.g. `systemctl restart docker`).
+
 <div class="annotate" markdown>
 
 ```yaml
@@ -378,6 +391,10 @@ Your DAIV deployment is running. Follow the [Reverse Proxy](#reverse-proxy) guid
 x-app-defaults: &x_app_default
   image: ghcr.io/srtab/daiv:latest
   restart: unless-stopped
+  ulimits: # (18)!
+    nofile:
+      soft: 65536
+      hard: 524288
   environment:
     DJANGO_SETTINGS_MODULE: daiv.settings.production
     DJANGO_SECRET_KEY: secret-key (1)
@@ -574,6 +591,7 @@ volumes:
 15.  **Scaling**: Increase `replicas` to handle more concurrent tasks (e.g., `replicas: 3`). Each worker processes tasks independently from the shared queue, so adding replicas scales DAIV's throughput with no architecture changes
 16.  Built-in MCP tools connect over streamable HTTP at the `/mcp` path. Set these explicitly so the hyphenated service names resolve — the built-in defaults assume `mcp_sentry` / `mcp_context7` (underscores). See [MCP Tools](../customization/mcp-tools.md)
 17.  **Optional**: Uncomment to mount [custom global skills](../customization/agent-skills.md#custom-global-skills) that are available across all repositories
+18.  **Raise the open-file limit**: each agent run holds many concurrent sockets (sandbox, LLM API, tracing, database, Redis, git-over-HTTPS). Docker's default soft limit of 1024 open files is too low and surfaces under load as `[Errno 24] Too many open files`. This raises `nofile` for the `app`, `worker`, and `scheduler` services (which share this anchor)
 
 ### Step 2: Run the compose file
 


### PR DESCRIPTION
## Why

Follow-up to the sandbox connection-pool cap (#1367). That capped one contributor to the `[Errno 24] Too many open files` incident, but the **process-wide** fd limit still needs raising at deploy time — and none of the deployment templates set it, so every self-hosted deployment ships at Docker's default **1024** soft `nofile` and will hit the same exhaustion under load (a single agent run holds many concurrent sockets: sandbox, LLM API, tracing, DB, Redis, git-over-HTTPS).

## Changes to `docs/getting-started/deployment.md`

- **Docker Compose template**: add `ulimits: nofile` (soft 65536 / hard 524288) to the shared `x_app_default` anchor — covers `app`, `worker`, and `scheduler` in one place. Plus annotation (18) explaining why.
- **Docker Swarm**: Swarm **ignores** service-level `ulimits`, so a service-level entry would be misleading. Instead, an admonition documents setting `default-ulimits` in `/etc/docker/daemon.json` on each node (the reliable, version-independent mechanism), with the symptom (`[Errno 24] Too many open files`) called out for searchability.

## Validation

`mkdocs build --strict` produces no warnings for this page (the only strict warnings are in gitignored local-only `docs/superpowers/` design docs, which CI doesn't see). Verified the admonition + nested JSON block and the anchor `ulimits` render correctly in the built HTML.