### PR TITLE
fix(schedules): skip cron dispatch for schedules owned by inactive users

### DIFF
--- a/daiv/schedules/tasks.py
+++ b/daiv/schedules/tasks.py
@@ -46,6 +46,7 @@ def dispatch_scheduled_jobs_cron_task():
     from sessions.models import SessionOrigin
     from sessions.services import RepoTarget, submit_batch_runs
 
+    from accounts.models import User
     from codebase.authorization import RepositoryAccessDenied
 
     now = datetime.now(tz=UTC)
@@ -54,7 +55,16 @@ def dispatch_scheduled_jobs_cron_task():
 
     with transaction.atomic():
         due_schedules = list(
-            ScheduledJob.objects.select_for_update(skip_locked=True).filter(is_enabled=True, next_run_at__lte=now)
+            ScheduledJob.objects.select_for_update(skip_locked=True).filter(
+                is_enabled=True,
+                next_run_at__lte=now,
+                # Skip schedules owned by inactivated users. Expressed as a subquery rather
+                # than a ``user__is_active`` join so FOR UPDATE SKIP LOCKED locks only the
+                # ScheduledJob table. A join would pull the user table into the lock set, so a
+                # lock held on an owner's user row would make SKIP LOCKED drop that owner's due
+                # schedules even though the schedule rows themselves are free.
+                user_id__in=User.objects.filter(is_active=True).values("pk"),
+            )
         )
 
         for schedule in due_schedules:

--- a/tests/unit_tests/schedules/test_tasks.py
+++ b/tests/unit_tests/schedules/test_tasks.py
@@ -6,6 +6,7 @@ import pytest
 from django_tasks_db.models import DBTaskResult, get_date_max
 from sessions.models import Run, SessionOrigin
 
+from accounts.models import User
 from schedules.models import Frequency, ScheduledJob
 from schedules.tasks import dispatch_scheduled_jobs_cron_task
 
@@ -205,3 +206,159 @@ def test_dispatch_once_schedule_auto_disables_on_failure(member_user):
     schedule.refresh_from_db()
     assert schedule.is_enabled is False
     assert schedule.next_run_at is None
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.parametrize("owner_active,expected_runs", [(True, 1), (False, 0)])
+def test_dispatch_respects_owner_is_active(member_user, owner_active, expected_runs):
+    member_user.is_active = owner_active
+    member_user.save(update_fields=["is_active"])
+    past = datetime.now(tz=UTC) - timedelta(minutes=1)
+    schedule = ScheduledJob.objects.create(
+        user=member_user,
+        name="daily",
+        prompt="do stuff",
+        repos=[{"repo_id": "acme/repo", "ref": ""}],
+        frequency="daily",
+        time="09:00",
+        is_enabled=True,
+        next_run_at=past,
+    )
+
+    with patch("sessions.services.run_job_task") as mock_task:
+
+        async def _aenqueue(**kwargs):
+            return await _amake_task_result()
+
+        mock_task.aenqueue.side_effect = _aenqueue
+        dispatch_scheduled_jobs_cron_task.func()
+
+    schedule.refresh_from_db()
+    assert Run.objects.count() == expected_runs
+    if owner_active:
+        assert schedule.next_run_at > past  # advanced to next cron tick
+    else:
+        # Not advanced — the schedule can resume from here on reactivation.
+        assert schedule.next_run_at == past
+
+
+@pytest.mark.django_db(transaction=True)
+def test_dispatch_resumes_after_owner_reactivated(member_user):
+    member_user.is_active = False
+    member_user.save(update_fields=["is_active"])
+    past = datetime.now(tz=UTC) - timedelta(minutes=1)
+    schedule = ScheduledJob.objects.create(
+        user=member_user,
+        name="daily",
+        prompt="do stuff",
+        repos=[{"repo_id": "acme/repo", "ref": ""}],
+        frequency="daily",
+        time="09:00",
+        is_enabled=True,
+        next_run_at=past,
+    )
+
+    with patch("sessions.services.run_job_task") as mock_task:
+
+        async def _aenqueue(**kwargs):
+            return await _amake_task_result()
+
+        mock_task.aenqueue.side_effect = _aenqueue
+
+        # Inactive owner: skipped, no run, next_run_at untouched.
+        dispatch_scheduled_jobs_cron_task.func()
+        assert Run.objects.count() == 0
+        schedule.refresh_from_db()
+        assert schedule.next_run_at == past
+
+        # Reactivate: fires once and advances to the next cron tick.
+        member_user.is_active = True
+        member_user.save(update_fields=["is_active"])
+        dispatch_scheduled_jobs_cron_task.func()
+
+    assert Run.objects.count() == 1
+    schedule.refresh_from_db()
+    assert schedule.next_run_at > datetime.now(tz=UTC)
+
+
+@pytest.mark.django_db(transaction=True)
+def test_dispatch_skips_only_inactive_owner_in_mixed_run(member_user):
+    inactive_owner = User.objects.create_user(
+        username="inactive_owner",
+        email="inactive_owner@test.com",
+        password="testpass123",  # noqa: S106
+        is_active=False,
+    )
+    past = datetime.now(tz=UTC) - timedelta(minutes=1)
+    active_schedule = ScheduledJob.objects.create(
+        user=member_user,
+        name="active",
+        prompt="do stuff",
+        repos=[{"repo_id": "acme/repo", "ref": ""}],
+        frequency="daily",
+        time="09:00",
+        is_enabled=True,
+        next_run_at=past,
+    )
+    inactive_schedule = ScheduledJob.objects.create(
+        user=inactive_owner,
+        name="inactive",
+        prompt="do stuff",
+        repos=[{"repo_id": "acme/repo", "ref": ""}],
+        frequency="daily",
+        time="09:00",
+        is_enabled=True,
+        next_run_at=past,
+    )
+
+    with patch("sessions.services.run_job_task") as mock_task:
+
+        async def _aenqueue(**kwargs):
+            return await _amake_task_result()
+
+        mock_task.aenqueue.side_effect = _aenqueue
+        dispatch_scheduled_jobs_cron_task.func()
+
+    # Selectivity: only the active owner's schedule dispatched; the inactive
+    # owner's was skipped even though both were due in the same run.
+    assert Run.objects.count() == 1
+    assert Run.objects.filter(session__scheduled_job=active_schedule).count() == 1
+    assert Run.objects.filter(session__scheduled_job=inactive_schedule).count() == 0
+    active_schedule.refresh_from_db()
+    inactive_schedule.refresh_from_db()
+    assert active_schedule.next_run_at > past  # advanced
+    assert inactive_schedule.next_run_at == past  # untouched
+
+
+@pytest.mark.django_db(transaction=True)
+def test_dispatch_skips_once_schedule_of_inactive_owner_without_retiring(member_user):
+    member_user.is_active = False
+    member_user.save(update_fields=["is_active"])
+    past = datetime.now(tz=UTC) - timedelta(minutes=1)
+    schedule = ScheduledJob.objects.create(
+        user=member_user,
+        name="one-off",
+        prompt="do stuff",
+        repos=[{"repo_id": "acme/repo", "ref": ""}],
+        frequency=Frequency.ONCE,
+        run_at=past,
+        is_enabled=True,
+        next_run_at=past,
+    )
+
+    with patch("sessions.services.run_job_task") as mock_task:
+
+        async def _aenqueue(**kwargs):
+            return await _amake_task_result()
+
+        mock_task.aenqueue.side_effect = _aenqueue
+        dispatch_scheduled_jobs_cron_task.func()
+
+    schedule.refresh_from_db()
+    # Skipped, not retired: a ONCE schedule owned by an inactive user must keep
+    # is_enabled=True and its next_run_at intact so it fires exactly once when
+    # the owner is reactivated — not be consumed by the ONCE auto-disable path.
+    assert Run.objects.count() == 0
+    assert schedule.is_enabled is True
+    assert schedule.next_run_at == past
+    assert schedule.run_count == 0


### PR DESCRIPTION
## What

Inactivating a user account (`User.is_active = False`) already blocks every
*interactive* path — chat API-key auth, MCP OAuth-token auth, and Django session
auth all re-check `is_active` at authentication time. But one autonomous path
survived: the cron dispatcher kept firing scheduled jobs owned by inactivated
users, letting an account that can no longer log in still act on repositories.

This adds an owner-is-active guard to the single choke point — the
`dispatch_scheduled_jobs_cron_task` due-schedules query.

## How

```python
ScheduledJob.objects.select_for_update(skip_locked=True).filter(
    is_enabled=True,
    next_run_at__lte=now,
    user_id__in=User.objects.filter(is_active=True).values("pk"),
)
```

Expressed as a `user_id__in=<subquery>` rather than a `user__is_active` relation
join **on purpose**: a join would pull `accounts_user` into the
`FOR UPDATE ... SKIP LOCKED` lock set, so a lock held on an owner's user row
(e.g. a concurrent profile save) would make `SKIP LOCKED` silently drop that
owner's otherwise-free due schedules. The subquery keeps the row lock scoped to
`schedules_scheduledjob` only.

## Behavior on reactivation

Schedules stay `is_enabled=True` while their owner is inactive; they're simply
not selected, so `next_run_at` is never advanced. On reactivation the schedule
is due again and fires **once** (missed ticks collapse to a single catch-up run,
exactly like recovery from any dispatcher downtime), then advances normally.
`ONCE` schedules are skipped — not consumed by the auto-disable path — so they
still fire exactly once after reactivation. No manual re-enable required.

## Out of scope

API keys (already dormant since auth gates on `is_active`), in-flight/queued
runs, and sandbox environments — intentionally not touched. Run-now
(`ScheduleRunNowView`) is a `LoginRequiredMixin`-gated human action an inactive
user cannot reach.

## Tests

Five cases added to `tests/unit_tests/schedules/test_tasks.py`:

- `test_dispatch_respects_owner_is_active` (parametrized active/inactive → 1/0 runs)
- `test_dispatch_resumes_after_owner_reactivated` (skip → no-advance → reactivate → single catch-up fire)
- `test_dispatch_skips_only_inactive_owner_in_mixed_run` (selectivity: active + inactive owner in one dispatch, only the active one runs)
- `test_dispatch_skips_once_schedule_of_inactive_owner_without_retiring` (ONCE stays enabled, `run_count == 0`)

All 178 `tests/unit_tests/schedules/` tests pass; lint clean.
