### PR TITLE
fix(chat): skip redundant repaint on polled session turns

### DIFF
--- a/daiv/chat/static/chat/js/chat-stream.js
+++ b/daiv/chat/static/chat/js/chat-stream.js
@@ -190,6 +190,27 @@
       this.lockedAgentEffortDots = detail?.effort_dots || 0;
     },
 
+    applyPolledTurns(turns) {
+      // Background (non-chat) runs — schedules, webhooks, UI jobs — execute
+      // detached and never publish to the chat relay, so there is no live stream
+      // to join. The detail page polls the turns endpoint instead and re-emits
+      // the WHOLE transcript here every few seconds. Reassigning ``turns`` re-runs
+      // every x-html/x-text binding (re-rendered markdown, re-highlighted code,
+      // repaint) even when nothing changed — the visible every-poll flicker. Skip
+      // the swap when the transcript is byte-identical to what we already show, so
+      // steady-state polls during a long-running tool are free; only a genuine
+      // change repaints. Both sides come from the same server serializer
+      // (annotate_transcript(build_turns(...))), so key order is stable and the
+      // JSON compare is reliable. Alpine's keyed x-for reuses each turn's DOM node
+      // on reassignment, so open tool <details> survive a real change too.
+      if (JSON.stringify(turns) === JSON.stringify(this.turns)) return;
+      this.turns = turns;
+      // Mirror the live-stream path (dispatch() scrolls after every event): follow
+      // the tail once the new turns render. The no-force scrollToBottom() no-ops
+      // when the user has scrolled up to read, so it only auto-follows at bottom.
+      this.$nextTick(() => this.scrollToBottom());
+    },
+
     applySandboxEnvSelection(detail) {
       this.selectedSandboxEnvId = detail?.id || "";
       // ``daiv:env-changed`` payload is {id, name, scope}; empty id = Auto pick. An id

--- a/daiv/sessions/templates/sessions/session_detail.html
+++ b/daiv/sessions/templates/sessions/session_detail.html
@@ -69,7 +69,7 @@
        @daiv:chat-repo-changed.window="applyRepoSelection($event.detail.repos)"
        @daiv:env-changed.window="applySandboxEnvSelection($event.detail)"
        @daiv:agent-changed.window="applyAgentSelection($event.detail)"
-       @daiv:session-turns.window="turns = $event.detail.turns"
+       @daiv:session-turns.window="applyPolledTurns($event.detail.turns)"
        x-cloak
        class="chat-shell"
        :class="{ 'chat-shell--empty': !thread && turns.length === 0 }">


### PR DESCRIPTION
## What

Background (non-chat) runs — schedules, webhooks, UI jobs — execute detached and never publish to the chat relay, so the session detail page polls the turns endpoint and re-emits the **whole** transcript every few seconds.

Previously the binding was `turns = $event.detail.turns`, so every poll reassigned `turns` and re-ran every `x-html`/`x-text` binding: re-rendered markdown, re-highlighted code, and repainted — a visible every-poll flicker, even when nothing had changed.

## Change

Route polled turns through a new `applyPolledTurns()` method that:

- **Skips the swap** when the incoming transcript is byte-identical (`JSON.stringify` compare) to what is already shown, so steady-state polls during a long-running tool are free.
- **Follows the tail** on a genuine change via a no-force `scrollToBottom()`, mirroring the live-stream path (no-ops when the user has scrolled up to read).

Both sides come from the same server serializer (`annotate_transcript(build_turns(...))`), so key order is stable and the JSON compare is reliable. Alpine's keyed `x-for` reuses each turn's DOM node on reassignment, so open tool `<details>` survive a real change too.
