### PR TITLE
fix(codebase): dedupe repository listing by slug in the client

### DIFF
--- a/daiv/codebase/clients/base.py
+++ b/daiv/codebase/clients/base.py
@@ -152,7 +152,13 @@ class RepoClient(abc.ABC):
     def list_repositories(
         self, search: str | None = None, topics: list[str] | None = None, limit: int | None = None
     ) -> list[Repository]:
-        pass
+        """List repositories the bot can access, at most one entry per slug.
+
+        Callers treat the result as a set keyed on ``slug`` — the access-sync task upserts it in a
+        single ``ON CONFLICT`` statement (which rejects a duplicate conflict target) and other
+        callers act once per repo. A listing that can surface the same repo twice (e.g. GitLab's
+        iterator ordered by the mutable ``last_activity_at``) must dedupe before returning.
+        """
 
     @abc.abstractmethod
     def list_repository_members(self, repo_id: str) -> list[RepoMember]:

--- a/daiv/codebase/clients/github/client.py
+++ b/daiv/codebase/clients/github/client.py
@@ -109,6 +109,8 @@ class GitHubClient(RepoClient):
         Returns:
             The list of repositories.
         """
+        # No dedup pass (cf. the GitLab client): get_repos() lists the installation's repositories
+        # without a mutable-key ordering, so it has no structural source of duplicate slugs.
         repos: list[Repository] = []
         for repo in self.client_installation.get_repos():
             if topics is not None and not any(topic in repo.topics for topic in topics):

--- a/daiv/codebase/clients/gitlab/client.py
+++ b/daiv/codebase/clients/gitlab/client.py
@@ -174,7 +174,12 @@ class GitLabClient(RepoClient):
         if limit is not None:
             optional_kwargs["per_page"] = min(limit, 100)
 
+        # The listing is ordered by a mutable key (last_activity_at), so a paginated iterator can
+        # surface the same project on two pages when its activity shifts mid-iteration. Dedupe by
+        # slug as we go — in-loop rather than a post-hoc pass so `limit` bounds unique repos and the
+        # early break is preserved. Callers rely on one entry per slug (see abstract list_repositories).
         repos: list[Repository] = []
+        seen: set[str] = set()
         for project in self.client.projects.list(
             iterator=True,
             archived=False,
@@ -185,12 +190,16 @@ class GitLabClient(RepoClient):
             sort="desc",
             **optional_kwargs,
         ):
+            slug = project.path_with_namespace
+            if slug in seen:
+                continue
+            seen.add(slug)
             repos.append(
                 Repository(
                     pk=cast("int", project.get_id()),
-                    slug=project.path_with_namespace,
+                    slug=slug,
                     name=project.name,
-                    clone_url=f"{self.client.url}/{project.path_with_namespace}.git",
+                    clone_url=f"{self.client.url}/{slug}.git",
                     html_url=project.web_url,
                     default_branch=project.default_branch,
                     git_platform=self.git_platform,

--- a/tests/unit_tests/codebase/clients/gitlab/test_client.py
+++ b/tests/unit_tests/codebase/clients/gitlab/test_client.py
@@ -23,6 +23,18 @@ def _expected_clone_env(token: str) -> dict[str, str]:
     return GitAuthEnv.for_token(_CLONE_URL, token).as_env()
 
 
+def _gl_project(slug: str) -> Mock:
+    """A mock GitLab project shaped like what ``projects.list`` yields."""
+    project = Mock()
+    project.get_id.return_value = 1
+    project.path_with_namespace = slug
+    project.name = slug.split("/")[-1]
+    project.web_url = f"https://gitlab.com/{slug}"
+    project.default_branch = "main"
+    project.topics = []
+    return project
+
+
 def test_git_egress_credential_for_token_builds_basic_oauth2_header():
     import base64
 
@@ -649,6 +661,21 @@ class TestGitLabClient:
         _, kwargs = gitlab_client.client.projects.list.call_args
         assert kwargs["order_by"] == "last_activity_at"
         assert kwargs["sort"] == "desc"
+
+    @pytest.mark.parametrize(
+        ("slugs", "limit", "expected"),
+        [
+            # A listing ordered by a mutable key (last_activity_at) can surface the same project on
+            # two pages, so `list_repositories` returns one entry per slug.
+            pytest.param(["g/a", "g/b", "g/a"], None, ["g/a", "g/b"], id="dedupes-repeated-slugs"),
+            # `limit` bounds unique repos, not raw rows: a duplicate must not consume a slot.
+            pytest.param(["g/a", "g/a", "g/b"], 2, ["g/a", "g/b"], id="limit-counts-unique-slugs"),
+        ],
+    )
+    def test_list_repositories_dedupes_by_slug(self, gitlab_client, slugs, limit, expected):
+        gitlab_client.client.projects.list.return_value = iter([_gl_project(s) for s in slugs])
+
+        assert [r.slug for r in gitlab_client.list_repositories(limit=limit)] == expected
 
     def test_list_branches_passes_search_and_per_page(self, gitlab_client):
         """`list_branches` forwards `search` and caps `per_page` at `limit`."""


### PR DESCRIPTION
## Summary

GitLab's `list_repositories` paginates an iterator ordered by the mutable `last_activity_at`, so a project whose activity shifts mid-iteration can surface on two pages. The access-sync cron (`sync_repository_access_cron_task`) then handed those duplicate slugs to a single `ON CONFLICT` upsert, which Postgres rejects with *"ON CONFLICT DO UPDATE command cannot affect row a second time"* — failing the entire `RepositoryCatalog` refresh (Sentry **DAIV-9C**).

## Fix

- Dedupe by slug **in the GitLab client**, in-loop so `limit` still bounds unique repos and the early break is preserved (a post-hoc pass can't do both).
- Document the "at most one entry per slug" guarantee on the abstract `list_repositories`.
- Add a note on the GitHub client explaining why it needs no dedup (`get_repos()` has no mutable-key ordering, so no structural dup source).

Fixing this in the client rather than the cron task also protects the other callers that act once per repo — `clone_to_topic` (which would otherwise double-create an issue) and `setup_webhooks`.

## Tests

- New parametrized `test_list_repositories_dedupes_by_slug` covering both dedup and `limit`-counts-unique-slugs.
- `tests/unit_tests/codebase/` → 448 passed; `ruff check` + `format` clean.

Fixes DAIV-9C
