### PR TITLE
feat(chat): collapse tall user messages in the transcript

### DIFF
--- a/daiv/chat/static/chat/js/chat-stream.js
+++ b/daiv/chat/static/chat/js/chat-stream.js
@@ -938,7 +938,34 @@
     },
   });
 
+  // Collapse tall user-message bubbles. Measures the rendered height once on
+  // init: user text is immutable after creation, and Alpine's keyed x-for reuses
+  // the DOM node across the wholesale `turns` reassignment that polling performs,
+  // so a single measurement is stable. The line budget is read back from the
+  // --chat-user-clamp-lines CSS custom property so JS and CSS share one value.
+  const userClamp = () => ({
+    collapsed: false,
+    overflowing: false,
+    measure() {
+      this.$nextTick(() => {
+        const el = this.$el.querySelector(".chat-text");
+        if (!el) return;
+        const styles = getComputedStyle(el);
+        const maxLines =
+          parseInt(styles.getPropertyValue("--chat-user-clamp-lines"), 10) || 7;
+        const lineHeight = parseFloat(styles.lineHeight) || 26;
+        // +1 absorbs sub-pixel rounding so a bubble exactly maxLines tall is
+        // left alone rather than clamped.
+        if (el.scrollHeight > lineHeight * maxLines + 1) {
+          this.overflowing = true;
+          this.collapsed = true;
+        }
+      });
+    },
+  });
+
   document.addEventListener("alpine:init", () => {
     window.Alpine.data("chat", chat);
+    window.Alpine.data("userClamp", userClamp);
   });
 })();

--- a/daiv/chat/static/chat/js/chat-stream.js
+++ b/daiv/chat/static/chat/js/chat-stream.js
@@ -941,18 +941,27 @@
   // Collapse tall user-message bubbles. Measures the rendered height once on
   // init: user text is immutable after creation, and Alpine's keyed x-for reuses
   // the DOM node across the wholesale `turns` reassignment that polling performs,
-  // so a single measurement is stable. The line budget is read back from the
-  // --chat-user-clamp-lines CSS custom property so JS and CSS share one value.
-  const userClamp = () => ({
+  // so a single measurement is stable. Both inputs to the overflow test are read
+  // from CSS so the JS decision can't drift from the visible clamp: the line
+  // budget from the --chat-user-clamp-lines custom property, and the per-line
+  // height from the element's computed line-height (CSS clamps to the same
+  // budget * line-height, see .chat-text--clamped). `id` is the shared id the
+  // text region exposes and the toggle points its aria-controls at.
+  const userClamp = (id) => ({
+    id,
     collapsed: false,
     overflowing: false,
-    measure() {
+    init() {
       this.$nextTick(() => {
         const el = this.$el.querySelector(".chat-text");
         if (!el) return;
         const styles = getComputedStyle(el);
-        const maxLines =
-          parseInt(styles.getPropertyValue("--chat-user-clamp-lines"), 10) || 7;
+        // Guard against a falsy 0 slipping through `||`: a 0-line budget is
+        // nonsensical but would read back as the fallback 7 while the CSS clamp
+        // honours 0, diverging the two. Number.isFinite rejects NaN (unreadable
+        // property) too.
+        const parsedLines = parseInt(styles.getPropertyValue("--chat-user-clamp-lines"), 10);
+        const maxLines = Number.isFinite(parsedLines) && parsedLines > 0 ? parsedLines : 7;
         const lineHeight = parseFloat(styles.lineHeight) || 26;
         // +1 absorbs sub-pixel rounding so a bubble exactly maxLines tall is
         // left alone rather than clamped.

--- a/daiv/sessions/locale/pt/LC_MESSAGES/django.po
+++ b/daiv/sessions/locale/pt/LC_MESSAGES/django.po
@@ -434,3 +434,9 @@ msgstr "Alguns repositórios falharam ao submeter: %(ids)s"
 
 #~ msgid "You stopped this run."
 #~ msgstr "Parou esta execução."
+
+msgid "Show more"
+msgstr "Mostrar mais"
+
+msgid "Show less"
+msgstr "Mostrar menos"

--- a/daiv/sessions/templates/sessions/session_detail.html
+++ b/daiv/sessions/templates/sessions/session_detail.html
@@ -47,6 +47,11 @@
   {% translate "Auto" as locked_agent_fallback %}
   {% translate "Auto" as locked_env_fallback %}
 
+  {# Labels for the collapsible user-message toggle. Piped through ``escapejs`` #}
+  {# below so a translation containing a quote can't break the JS string literal. #}
+  {% translate "Show more" as show_more_label %}
+  {% translate "Show less" as show_less_label %}
+
   <div x-data='chat({
          endpoint: "{% url 'api:completions' %}",
          streamEndpoint: "{% url 'api:chat_run_stream' %}",
@@ -188,7 +193,16 @@
                           </template>
                         </template>
                         <template x-if="seg.type === 'text' && turn.role === 'user'">
-                          <span class="chat-text" x-text="seg.content"></span>
+                          <div class="chat-user-msg" x-data="userClamp()" x-init="measure()">
+                            <span class="chat-text"
+                                  :class="{ 'chat-user-msg--clamped': collapsed }"
+                                  x-text="seg.content"></span>
+                            <button type="button" class="chat-user-msg__toggle" x-cloak
+                                    x-show="overflowing"
+                                    :aria-expanded="(!collapsed).toString()"
+                                    @click="collapsed = !collapsed"
+                                    x-text="collapsed ? '{{ show_more_label|escapejs }}' : '{{ show_less_label|escapejs }}'"></button>
+                          </div>
                         </template>
 
                         <template x-if="seg.type === 'thinking'">

--- a/daiv/sessions/templates/sessions/session_detail.html
+++ b/daiv/sessions/templates/sessions/session_detail.html
@@ -193,12 +193,14 @@
                           </template>
                         </template>
                         <template x-if="seg.type === 'text' && turn.role === 'user'">
-                          <div class="chat-user-msg" x-data="userClamp()" x-init="measure()">
+                          <div class="chat-user-msg" x-data="userClamp(`chat-user-text-${turn.id}-${si}`)">
                             <span class="chat-text"
-                                  :class="{ 'chat-user-msg--clamped': collapsed }"
+                                  :id="id"
+                                  :class="{ 'chat-text--clamped': collapsed }"
                                   x-text="seg.content"></span>
                             <button type="button" class="chat-user-msg__toggle" x-cloak
                                     x-show="overflowing"
+                                    :aria-controls="id"
                                     :aria-expanded="(!collapsed).toString()"
                                     @click="collapsed = !collapsed"
                                     x-text="collapsed ? '{{ show_more_label|escapejs }}' : '{{ show_less_label|escapejs }}'"></button>

--- a/daiv/static_src/css/input.css
+++ b/daiv/static_src/css/input.css
@@ -836,6 +836,41 @@ main:has(.chat-shell) {
     overflow-wrap: break-word;
   }
 
+  /* Collapsible tall user messages: clamp to a line budget with a bottom fade
+     and a Show more/less toggle. --chat-user-clamp-lines is the single source of
+     truth for the budget; chat-stream.js reads it back so JS and CSS never drift.
+     1.7em matches the line-height set on .chat-segment--text, so the budget maps
+     to rendered text lines. The fade uses a mask (not a colour overlay) so it is
+     independent of the semi-transparent bubble background. */
+  .chat-user-msg {
+    --chat-user-clamp-lines: 7;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 4px;
+  }
+
+  .chat-text.chat-user-msg--clamped {
+    display: block;
+    max-height: calc(var(--chat-user-clamp-lines) * 1.7em);
+    overflow: hidden;
+    -webkit-mask-image: linear-gradient(to bottom, #000 68%, transparent);
+            mask-image: linear-gradient(to bottom, #000 68%, transparent);
+  }
+
+  .chat-user-msg__toggle {
+    padding: 0;
+    border: 0;
+    background: none;
+    font-size: 12px;
+    color: #93c5fd;
+    cursor: pointer;
+  }
+
+  .chat-user-msg__toggle:hover {
+    text-decoration: underline;
+  }
+
   .chat-turn-wrap { display: contents; }
 
   .chat-run-status {

--- a/daiv/static_src/css/input.css
+++ b/daiv/static_src/css/input.css
@@ -808,10 +808,14 @@ main:has(.chat-shell) {
   /* Text segments breathe: more above than below, same whether alone in a
      turn or followed by tool-call segments. */
   .chat-segment--text {
+    /* Single source of truth for the text line-height: the collapsible clamp
+       (.chat-text--clamped) multiplies it by the line budget, and
+       chat-stream.js reads it back via computed style. */
+    --chat-text-line-height: 1.7;
     margin-top: 0.5rem;
     margin-bottom: 0.25rem;
     font-size: 15.5px;
-    line-height: 1.7;
+    line-height: var(--chat-text-line-height);
   }
 
   /* User turn: no thread line, bubble hugs the right edge */
@@ -837,11 +841,12 @@ main:has(.chat-shell) {
   }
 
   /* Collapsible tall user messages: clamp to a line budget with a bottom fade
-     and a Show more/less toggle. --chat-user-clamp-lines is the single source of
-     truth for the budget; chat-stream.js reads it back so JS and CSS never drift.
-     1.7em matches the line-height set on .chat-segment--text, so the budget maps
-     to rendered text lines. The fade uses a mask (not a colour overlay) so it is
-     independent of the semi-transparent bubble background. */
+     and a Show more/less toggle. The clamp height is derived from two custom
+     properties so JS and CSS never drift: --chat-user-clamp-lines (the budget,
+     read back by chat-stream.js) and --chat-text-line-height (set on
+     .chat-segment--text, the source of truth for the rendered line height). The
+     fade uses a mask (not a colour overlay) so it is independent of the
+     semi-transparent bubble background. */
   .chat-user-msg {
     --chat-user-clamp-lines: 7;
     display: flex;
@@ -850,9 +855,9 @@ main:has(.chat-shell) {
     gap: 4px;
   }
 
-  .chat-text.chat-user-msg--clamped {
+  .chat-text--clamped {
     display: block;
-    max-height: calc(var(--chat-user-clamp-lines) * 1.7em);
+    max-height: calc(var(--chat-user-clamp-lines) * var(--chat-text-line-height) * 1em);
     overflow: hidden;
     -webkit-mask-image: linear-gradient(to bottom, #000 68%, transparent);
             mask-image: linear-gradient(to bottom, #000 68%, transparent);

--- a/daiv/static_src/css/input.css
+++ b/daiv/static_src/css/input.css
@@ -871,6 +871,12 @@ main:has(.chat-shell) {
     text-decoration: underline;
   }
 
+  .chat-user-msg__toggle:focus-visible {
+    outline: 2px solid rgba(147, 197, 253, 0.5);
+    outline-offset: 2px;
+    border-radius: 3px;
+  }
+
   .chat-turn-wrap { display: contents; }
 
   .chat-run-status {


### PR DESCRIPTION
## Summary

Collapses tall user messages in the chat transcript. When a user message
renders past a 7-line budget it clamps with a bottom mask-fade and a **Show
more / Show less** toggle, so long pasted prompts/logs no longer dominate the
transcript.

## How it works

- A small Alpine `userClamp` component measures the rendered height once on
  init (user text is immutable, and the keyed `x-for` reuses the node across
  the wholesale `turns` reassignment polling performs), and reveals the toggle
  only when the text actually overflows.
- The line budget (`--chat-user-clamp-lines`) and per-line height
  (`--chat-text-line-height`) are CSS custom properties read back by JS, so the
  JS overflow decision and the CSS clamp height cannot drift.
- The fade uses a `mask-image` (not a colour overlay) so it is independent of
  the semi-transparent bubble background.

## Accessibility

- Real `<button>` with `aria-expanded`, `aria-controls` pointing at the text
  region, and a `:focus-visible` ring.

## i18n

- "Show more" / "Show less" translated (pt), piped through `escapejs` so a
  translation containing a quote can't break the JS string literal.

## Notes

- Reusable styles live in `static_src/css/input.css` as classes; the compiled
  `styles.css` is gitignored and rebuilt at deploy, so no compiled artifact is
  committed.
