### PR TITLE
fix(chat): render OpenAI Responses API tool calls in session transcripts

### DIFF
--- a/daiv/chat/turns.py
+++ b/daiv/chat/turns.py
@@ -13,7 +13,10 @@ from typing import Any
 
 logger = logging.getLogger("daiv.chat")
 
-_TOOL_USE_BLOCK_TYPES = frozenset({"tool_use", "tool_call"})
+# Tool-call content-block types across providers: Anthropic emits ``tool_use``, the
+# LangChain standard ``tool_call``, and the OpenAI Responses API (gpt-5.x / codex via
+# langchain-openai) ``function_call``.
+_TOOL_CALL_BLOCK_TYPES = frozenset({"tool_use", "tool_call", "function_call"})
 _THINKING_BLOCK_TYPES = frozenset({"thinking", "reasoning"})
 _SKILL_TOOL_NAME = "skill"
 
@@ -87,6 +90,15 @@ def _fold_skill_body(m: Any, turns: list[dict[str, Any]], tool_index: dict[str, 
     turns[t_idx]["segments"][s_idx]["result"] = str(content or "")
 
 
+def _join_text_items(items: Any) -> str:
+    """Join the ``text`` fields of an OpenAI ``[{"text": ...}, ...]`` reasoning list (the
+    ``summary`` / ``content`` shape) with blank lines, dropping empty/blank entries."""
+    if not isinstance(items, list):
+        return ""
+    joined = "\n\n".join(str(it.get("text", "")) for it in items if isinstance(it, dict) and it.get("text"))
+    return joined if joined.strip() else ""
+
+
 def _reasoning_from_additional_kwargs(additional_kwargs: Any) -> str:
     """Extract reasoning text from an AIMessage's ``additional_kwargs``.
 
@@ -100,14 +112,25 @@ def _reasoning_from_additional_kwargs(additional_kwargs: Any) -> str:
     if isinstance(rc, str) and rc.strip():
         return rc
     reasoning = additional_kwargs.get("reasoning")
-    if isinstance(reasoning, dict):
-        summary = reasoning.get("summary") or []
-        if isinstance(summary, list):
-            joined = "\n\n".join(
-                str(item.get("text", "")) for item in summary if isinstance(item, dict) and item.get("text")
-            )
-            if joined.strip():
-                return joined
+    if isinstance(reasoning, dict) and (joined := _join_text_items(reasoning.get("summary"))):
+        return joined
+    return ""
+
+
+def _thinking_from_block(block: dict) -> str:
+    """Extract reasoning text from a thinking/reasoning content block across shapes.
+
+    Anthropic ``thinking`` / the LangChain standard ``reasoning`` / a generic ``text``
+    are plain strings. The OpenAI Responses API ``reasoning`` block instead nests text in
+    ``summary`` / ``content`` lists of ``{"text": ...}`` items and keeps the raw trace only
+    in ``encrypted_content`` (not renderable) — so an empty summary yields no segment.
+    """
+    direct = block.get("thinking") or block.get("reasoning") or block.get("text")
+    if isinstance(direct, str) and direct.strip():
+        return direct
+    for key in ("summary", "content"):
+        if joined := _join_text_items(block.get(key)):
+            return joined
     return ""
 
 
@@ -122,13 +145,21 @@ def _build_user_turn(m: Any) -> dict[str, Any]:
     return {"id": getattr(m, "id", "") or "", "role": "user", "segments": [{"type": "text", "content": text}]}
 
 
+def _tc_id(obj: Any) -> str | None:
+    """Canonical tool-call id. OpenAI ``function_call`` blocks key the call on ``call_id``
+    (their ``id`` is an unrelated ``fc_...`` handle); normalized ``tool_calls`` entries and
+    Anthropic ``tool_use`` blocks carry only ``id``. ToolMessage.tool_call_id matches this."""
+    if isinstance(obj, dict):
+        return obj.get("call_id") or obj.get("id")
+    return getattr(obj, "call_id", None) or getattr(obj, "id", None)
+
+
 def _build_assistant_turn(m: Any) -> dict[str, Any]:
     content = getattr(m, "content", "")
     tool_calls = getattr(m, "tool_calls", None) or []
     tc_by_id: dict[str, Any] = {}
     for tc in tool_calls:
-        tc_id = tc.get("id") if isinstance(tc, dict) else getattr(tc, "id", None)
-        if tc_id:
+        if tc_id := _tc_id(tc):
             tc_by_id[tc_id] = tc
 
     segments: list[dict[str, Any]] = []
@@ -142,6 +173,7 @@ def _build_assistant_turn(m: Any) -> dict[str, Any]:
         segments.append({"type": "thinking", "content": extra_thought})
 
     if isinstance(content, list):
+        emitted_tc_ids: set[str] = set()
         for block in content:
             btype = block.get("type") if isinstance(block, dict) else getattr(block, "type", None)
             if btype == "text":
@@ -149,18 +181,25 @@ def _build_assistant_turn(m: Any) -> dict[str, Any]:
                 if text:
                     segments.append({"type": "text", "content": text})
             elif btype in _THINKING_BLOCK_TYPES:
-                # Anthropic uses ``thinking``; the newer LangChain standard uses ``reasoning``.
-                thought = (
-                    (block.get("thinking") or block.get("reasoning") or block.get("text") or "")
-                    if isinstance(block, dict)
-                    else ""
-                )
+                thought = _thinking_from_block(block) if isinstance(block, dict) else ""
                 if thought:
                     segments.append({"type": "thinking", "content": thought})
-            elif btype in _TOOL_USE_BLOCK_TYPES:
-                tc_id = block.get("id") if isinstance(block, dict) else getattr(block, "id", None)
-                canonical = tc_by_id.get(tc_id, block)
-                segments.append(_tool_call_segment(canonical))
+            elif btype in _TOOL_CALL_BLOCK_TYPES:
+                # Blocks carry the ordering; the normalized ``tool_calls`` entry (looked up
+                # by canonical id) carries clean id/name/args. Fall back to the raw block
+                # only if the call is absent from ``tool_calls`` (shouldn't happen).
+                seg = _tool_call_segment(tc_by_id.get(_tc_id(block), block))
+                segments.append(seg)
+                if seg["id"]:
+                    emitted_tc_ids.add(seg["id"])
+        # Defensive: a provider may populate ``tool_calls`` without emitting a block shape
+        # we recognise. Surface any such call so it is never silently dropped — a dropped
+        # tool call would also orphan its ToolMessage and vanish from the transcript.
+        for tc in tool_calls:
+            tc_id = _tc_id(tc)
+            if tc_id and tc_id not in emitted_tc_ids:
+                segments.append(_tool_call_segment(tc))
+                emitted_tc_ids.add(tc_id)
     else:
         if isinstance(content, str) and content.strip():
             segments.append({"type": "text", "content": content})
@@ -171,12 +210,11 @@ def _build_assistant_turn(m: Any) -> dict[str, Any]:
 
 
 def _tool_call_segment(tc: Any, *, status: str = "done") -> dict[str, Any]:
+    tc_id = _tc_id(tc) or ""
     if isinstance(tc, dict):
-        tc_id = tc.get("id") or ""
         tc_name = tc.get("name") or ""
         args = tc.get("args", tc.get("input", tc.get("arguments", "")))
     else:
-        tc_id = getattr(tc, "id", "") or ""
         tc_name = getattr(tc, "name", "") or ""
         args = getattr(tc, "args", None) or getattr(tc, "input", None) or ""
 

--- a/tests/unit_tests/chat/test_turns.py
+++ b/tests/unit_tests/chat/test_turns.py
@@ -231,3 +231,185 @@ def test_build_turns_mixed_order_human_ai_tool_ai_tool_human():
     assert [t["role"] for t in result] == ["user", "assistant", "assistant", "user"]
     assert result[1]["segments"][1]["result"] == "result-1"
     assert result[2]["segments"][1]["result"] == "result-2"
+
+
+# --- OpenAI Responses API shape (gpt-5.x / codex via langchain-openai) ------------------
+#
+# These models return content as a list of ``reasoning`` / ``function_call`` / ``text``
+# blocks (not Anthropic ``thinking`` / ``tool_use``). Tool calls carry their canonical id
+# under ``call_id`` (the value ToolMessage.tool_call_id matches), args as a JSON *string*
+# under ``arguments``, and the block's own ``id`` is an unrelated ``fc_...`` handle. The
+# normalized ``AIMessage.tool_calls`` attribute mirrors each call keyed on ``id`` = call_id.
+
+
+def test_build_turns_openai_function_call_block_emits_tool_segment():
+    m = AIMessage(
+        content=[
+            {"id": "rs_1", "type": "reasoning", "summary": [], "content": [], "encrypted_content": "x"},
+            {
+                "type": "function_call",
+                "call_id": "call_abc",
+                "name": "rt_get_ticket",
+                "arguments": '{"id": 1160298}',
+                "id": "fc_1",
+                "status": "completed",
+            },
+        ],
+        id="a-1",
+        tool_calls=[{"id": "call_abc", "name": "rt_get_ticket", "args": {"id": 1160298}, "type": "tool_call"}],
+    )
+    result = build_turns([m])
+    assert result[0]["segments"] == [
+        {
+            "type": "tool_call",
+            "id": "call_abc",
+            "name": "rt_get_ticket",
+            "args": '{"id": 1160298}',
+            "result": None,
+            "status": "done",
+        }
+    ]
+
+
+def test_build_turns_openai_tool_result_attaches_by_call_id():
+    ai = AIMessage(
+        content=[
+            {
+                "type": "function_call",
+                "call_id": "call_abc",
+                "name": "rt_get_current_user",
+                "arguments": "{}",
+                "id": "fc_1",
+                "status": "completed",
+            }
+        ],
+        id="a-1",
+        tool_calls=[{"id": "call_abc", "name": "rt_get_current_user", "args": {}, "type": "tool_call"}],
+    )
+    tool = ToolMessage(content=[{"type": "text", "text": "user=daiv"}], tool_call_id="call_abc", id="t-1")
+    result = build_turns([ai, tool])
+    assert len(result) == 1  # ToolMessage does not create its own turn
+    assert result[0]["segments"][0]["result"] == "user=daiv"
+
+
+def test_build_turns_openai_full_turn_keeps_tools_and_final_text():
+    # Reproduces the "3 messages, no tools" collapse: before the fix every function_call
+    # block was ignored, every ToolMessage orphaned, and the transcript flattened to the
+    # user prompt + final text only.
+    msgs = [
+        HumanMessage(content="/rt-work-ticket 1160298", id="h-1"),
+        AIMessage(
+            content=[
+                {"id": "rs_1", "type": "reasoning", "summary": [], "content": [], "encrypted_content": "x"},
+                {
+                    "type": "function_call",
+                    "call_id": "call_1",
+                    "name": "rt_get_ticket",
+                    "arguments": '{"id": 1160298}',
+                    "id": "fc_1",
+                    "status": "completed",
+                },
+            ],
+            id="a-1",
+            tool_calls=[{"id": "call_1", "name": "rt_get_ticket", "args": {"id": 1160298}, "type": "tool_call"}],
+        ),
+        ToolMessage(content=[{"type": "text", "text": "ticket data"}], tool_call_id="call_1", id="t-1"),
+        AIMessage(
+            content=[
+                {"id": "rs_2", "type": "reasoning", "summary": [], "content": [], "encrypted_content": "y"},
+                {"type": "text", "text": "Done.", "annotations": [], "id": "msg_1", "phase": "final_answer"},
+            ],
+            id="a-2",
+        ),
+    ]
+    result = build_turns(msgs)
+    assert [t["role"] for t in result] == ["user", "assistant", "assistant"]
+    tool_seg = result[1]["segments"][0]
+    assert tool_seg["type"] == "tool_call"
+    assert tool_seg["name"] == "rt_get_ticket"
+    assert tool_seg["result"] == "ticket data"
+    assert result[2]["segments"] == [{"type": "text", "content": "Done."}]
+
+
+def test_build_turns_openai_skill_injection_folds_body():
+    msgs = [
+        HumanMessage(content="/plan", id="h-1"),
+        AIMessage(
+            content=[
+                {
+                    "type": "function_call",
+                    "call_id": "call_skill",
+                    "name": "skill",
+                    "arguments": '{"skill": "plan"}',
+                    "id": "fc_1",
+                    "status": "completed",
+                }
+            ],
+            id="a-1",
+            tool_calls=[{"id": "call_skill", "name": "skill", "args": {"skill": "plan"}, "type": "tool_call"}],
+        ),
+        ToolMessage(content="Launching skill 'plan'...", tool_call_id="call_skill", id="t-1"),
+        HumanMessage(content="# Plan skill body", id="h-syn"),
+        AIMessage(content=[{"type": "text", "text": "Here is the plan.", "id": "msg_2"}], id="a-2"),
+    ]
+    result = build_turns(msgs)
+    # The injected skill body folds into the skill call's result, not a spurious user turn.
+    assert [t["role"] for t in result] == ["user", "assistant", "assistant"]
+    skill_seg = result[1]["segments"][0]
+    assert skill_seg["name"] == "skill"
+    assert skill_seg["result"] == "# Plan skill body"
+
+
+def test_build_turns_openai_reasoning_summary_emits_thinking_segment():
+    m = AIMessage(
+        content=[
+            {
+                "type": "reasoning",
+                "id": "rs_1",
+                "summary": [{"type": "summary_text", "text": "First…"}, {"type": "summary_text", "text": "Then…"}],
+                "content": [],
+                "encrypted_content": "x",
+            },
+            {"type": "text", "text": "Answer.", "id": "msg_1"},
+        ],
+        id="a-1",
+    )
+    result = build_turns([m])
+    assert result[0]["segments"] == [
+        {"type": "thinking", "content": "First…\n\nThen…"},
+        {"type": "text", "content": "Answer."},
+    ]
+
+
+def test_build_turns_openai_empty_reasoning_omits_thinking_segment():
+    # summary/content empty (reasoning only in encrypted_content) → nothing to render.
+    m = AIMessage(
+        content=[
+            {"type": "reasoning", "id": "rs_1", "summary": [], "content": [], "encrypted_content": "x"},
+            {"type": "text", "text": "Answer.", "id": "msg_1"},
+        ],
+        id="a-1",
+    )
+    result = build_turns([m])
+    assert result[0]["segments"] == [{"type": "text", "content": "Answer."}]
+
+
+def test_build_turns_list_content_falls_back_to_tool_calls_attr_when_no_tool_block():
+    # Defensive net: a provider emits only reasoning/text blocks yet still populates the
+    # normalized tool_calls attribute — the call must not be silently dropped.
+    m = AIMessage(
+        content=[{"type": "reasoning", "id": "rs_1", "summary": [], "content": [], "encrypted_content": "x"}],
+        id="a-1",
+        tool_calls=[{"id": "call_z", "name": "grep", "args": {"pattern": "x"}, "type": "tool_call"}],
+    )
+    result = build_turns([m])
+    assert result[0]["segments"] == [
+        {
+            "type": "tool_call",
+            "id": "call_z",
+            "name": "grep",
+            "args": '{"pattern": "x"}',
+            "result": None,
+            "status": "done",
+        }
+    ]


### PR DESCRIPTION
## Problem

Session transcripts for runs executed on an **OpenAI Responses API model** (gpt-5.x / codex via `langchain-openai`) collapsed to a handful of text-only bubbles with **every tool call and reasoning step missing**. The reported session showed just 3 "messages" — the user prompt, the injected skill body, and the final answer — despite a fully intact 59-message checkpoint rich with tool calls.

## Root cause

`chat/turns.py::build_turns` only understood Anthropic-style content blocks:

- Tool calls from the Responses API arrive as `type: "function_call"` blocks (identity under `call_id`, args as a JSON string under `arguments`) — not in `_TOOL_USE_BLOCK_TYPES = {"tool_use", "tool_call"}`, so **no tool-call segment was emitted**.
- The list-content branch never fell back to the correctly-populated top-level `AIMessage.tool_calls` attribute.
- With nothing registered in `tool_index`, **every `ToolMessage` was then dropped as an orphan**, and the empty assistant turns were hidden by `isTurnVisible` — leaving only plain-text turns.
- Reasoning arrived as `reasoning` blocks with text under `summary`/`content` (or only `encrypted_content`), so no thinking segment either.

This is a reload/hydration-path bug only; live streaming builds turns from AG-UI events, not `build_turns`.

## Fix

- Recognise `function_call` blocks; resolve `call_id` → the normalized `tool_calls` entry so segment ids line up with their `ToolMessage` results.
- Add a defensive fallback that surfaces any `tool_calls` not represented by a recognised block, so a tool call can never be silently dropped.
- Extract reasoning text from Responses API `summary`/`content` lists (empty ones yield no segment, matching the encrypted-only case).

## Verification

- 7 new unit tests covering the Responses API shapes (`function_call`, `reasoning` summary, skill-body fold, defensive fallback); full `test_turns.py` green (24 tests).
- Ran the **fixed** `build_turns` against the reported session's real 59-message checkpoint: **33/33 tool calls now render with results attached, 0 orphans**, vs 3 visible turns / 0 tool calls before.
