### PR TITLE
feat(agent): support Claude 5 models (sonnet-5, fable-5)

### DIFF
--- a/daiv/automation/agent/base.py
+++ b/daiv/automation/agent/base.py
@@ -31,14 +31,29 @@ CLAUDE_MAX_TOKENS = 16_384
 CLAUDE_THINKING_MODELS = (
     "claude-sonnet-4-5",
     "claude-sonnet-4-6",
+    "claude-sonnet-5",
     "claude-opus-4-5",
     "claude-opus-4-6",
     "claude-haiku-4-5",
+    "claude-fable-5",
     "anthropic/claude-sonnet-4.5",
     "anthropic/claude-sonnet-4.6",
+    "anthropic/claude-sonnet-5",
     "anthropic/claude-opus-4.5",
     "anthropic/claude-opus-4.6",
     "anthropic/claude-haiku-4.5",
+    "anthropic/claude-fable-5",
+)
+
+# Claude 5-generation models removed support for the ``temperature`` sampling
+# parameter — sending it returns a 400 ``invalid_request_error`` ("`temperature` is
+# deprecated for this model"). Matched as prefixes so dated variants (e.g.
+# ``claude-sonnet-5-20260101``) are covered; includes the OpenRouter slugs.
+CLAUDE_NO_TEMPERATURE_MODELS = (
+    "claude-sonnet-5",
+    "claude-fable-5",
+    "anthropic/claude-sonnet-5",
+    "anthropic/claude-fable-5",
 )
 
 OPENAI_THINKING_MODELS = ("gpt-5.2", "gpt-5.3-codex", "openai/gpt-5.2", "openai/gpt-5.3-codex")
@@ -120,6 +135,17 @@ def _apply_openrouter_thinking(kw: dict, thinking_level: ThinkingLevel | None, m
         # passes the kwarg through to the upstream Anthropic API.
         kw["temperature"] = 1
         kw["max_tokens"] = _OPENROUTER_ANTHROPIC_MAX_TOKENS[thinking_level]
+
+
+def _apply_temperature_support(kw: dict, model_name: str) -> None:
+    """Drop ``temperature`` for models that no longer accept it.
+
+    The base kwargs always seed ``temperature`` (and the thinking helpers may override
+    it to ``1``), but Claude 5-generation models deprecated the parameter and reject any
+    request that includes it. Run this last so it wins over every provider/thinking
+    branch and any caller-supplied ``temperature``."""
+    if model_name.startswith(CLAUDE_NO_TEMPERATURE_MODELS):
+        kw.pop("temperature", None)
 
 
 @dataclass(frozen=True)
@@ -341,6 +367,8 @@ class BaseAgent(ABC, Generic[T]):  # noqa: UP046
             existing = kw["model_kwargs"].setdefault("extra_headers", {})
             for name, value in sdk_kw["default_headers"].items():
                 existing.setdefault(name, value)
+
+        _apply_temperature_support(kw, resolved.model_name)
 
         return kw
 

--- a/tests/unit_tests/automation/agent/test_base.py
+++ b/tests/unit_tests/automation/agent/test_base.py
@@ -137,6 +137,23 @@ class TestGetModelKwargs:
         assert kw["api_key"] == "sk-a"
         assert kw["base_url"] == "https://proxy.example.com"
         assert kw["model"] == "claude-haiku-4-5"
+        # Models that still accept ``temperature`` keep the seeded default.
+        assert kw["temperature"] == 0
+
+    @pytest.mark.parametrize(
+        ("slug", "provider_type", "model_name"),
+        [
+            ("anth5", ProviderType.ANTHROPIC, "claude-sonnet-5"),
+            ("or5", ProviderType.OPENROUTER, "anthropic/claude-sonnet-5"),
+        ],
+    )
+    def test_claude5_omits_temperature(self, slug, provider_type, model_name):
+        """Claude 5-generation models reject ``temperature`` (400 invalid_request_error), so it
+        must be stripped — covers direct-Anthropic and OpenRouter slug forms. See Sentry DAIV-9P."""
+        Provider.objects.create(slug=slug, display_name=slug, provider_type=provider_type, api_key="sk")
+        kw = BaseAgent.get_model_kwargs(resolved=parse_model_spec(f"{slug}:{model_name}"))
+        assert kw["model"] == model_name
+        assert "temperature" not in kw
 
     def test_openai_compatible_with_custom_base_url_defaults_to_chat_completions(self):
         """Custom OpenAI-compatible rows default to ``use_responses_api=False`` because
@@ -342,3 +359,28 @@ class TestGetModelKwargs:
         assert kw["max_tokens"] == 64_000
         assert kw["thinking"]["type"] == "enabled"
         assert kw["thinking"]["budget_tokens"] == 64_000 - 16_384
+
+    @pytest.mark.parametrize("model_name", ["claude-sonnet-5", "claude-fable-5"])
+    def test_claude5_thinking_enables_budget_without_temperature(self, model_name):
+        """Claude 5 models are thinking-capable, so a thinking level enables the extended-
+        thinking budget. Anthropic normally pairs that with temperature=1, but Claude 5
+        rejects temperature, so it must be stripped from the final kwargs."""
+        self._enable_seed("anthropic", "sk-a")
+        kw = BaseAgent.get_model_kwargs(
+            resolved=parse_model_spec(f"anthropic:{model_name}"), thinking_level=ThinkingLevelChoices.MEDIUM
+        )
+        assert kw["thinking"] == {"type": "enabled", "budget_tokens": 25_600}
+        assert kw["max_tokens"] == 16_384 + 25_600
+        assert "temperature" not in kw
+
+    def test_claude5_openrouter_thinking_enables_without_temperature(self):
+        """The OpenRouter Anthropic path also seeds temperature=1 for Claude thinking
+        models; Claude 5 must still end up with it stripped."""
+        self._enable_seed("openrouter", "sk-or")
+        kw = BaseAgent.get_model_kwargs(
+            resolved=parse_model_spec("openrouter:anthropic/claude-sonnet-5"),
+            thinking_level=ThinkingLevelChoices.MEDIUM,
+        )
+        assert kw["extra_body"]["reasoning"]["enabled"] is True
+        assert kw["extra_body"]["reasoning"]["effort"] == ThinkingLevelChoices.MEDIUM
+        assert "temperature" not in kw


### PR DESCRIPTION
## What

Adds first-class support for the Claude 5 generation (`claude-sonnet-5`, `claude-fable-5`) in the agent model config.

## Changes

**1. Enable extended thinking.** `claude-sonnet-5` and `claude-fable-5` (plus their `anthropic/…` OpenRouter slugs) are added to `CLAUDE_THINKING_MODELS`, so selecting a thinking level enables the extended-thinking budget for them on both the direct-Anthropic and OpenRouter paths — matching how Claude 4.5/4.6 are treated.

**2. Drop the deprecated `temperature` parameter.** Claude 5 removed `temperature` and returns `400 invalid_request_error` when it's sent (Sentry **DAIV-9P**). Two code paths would otherwise send it: the base kwargs seed `temperature`, and the thinking helpers override it to `1` (Anthropic requires that when thinking is enabled). A final `_apply_temperature_support` pass runs after every provider/thinking branch and strips `temperature` for these models (matched as prefixes, so dated variants like `claude-sonnet-5-20260101` and the OpenRouter slugs are covered).

These two are coupled: enabling thinking sets `temperature=1`, and the temperature strip is what keeps that legal for Claude 5. They're shipped together so the combined behavior is correct.

## Tests

- `test_claude5_thinking_enables_budget_without_temperature` (sonnet-5 + fable-5, direct Anthropic): thinking budget enabled, `temperature` absent.
- `test_claude5_openrouter_thinking_enables_without_temperature`: OpenRouter path enables reasoning and still strips `temperature`.
- `test_claude5_omits_temperature`: non-thinking requests also omit `temperature`; a model that still accepts it keeps the seeded default.
- Full `test_base.py` green (44 tests).
