### PR TITLE
fix(core): round-trip _DeltaSnapshot in checkpoint serializer

### DIFF
--- a/daiv/core/checkpointer.py
+++ b/daiv/core/checkpointer.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, Any
 
@@ -18,14 +19,37 @@ if TYPE_CHECKING:
 
     from langchain_core.runnables import RunnableConfig
 
+logger = logging.getLogger("daiv.checkpointer")
+
 # ``_DeltaSnapshot`` wraps a full channel value when ``DeltaChannel`` writes a periodic
-# snapshot into ``channel_values`` (see ``aresolve_thread_messages``). It is a beta
-# langgraph type; import defensively so a future relocation degrades to the write-replay
-# path rather than breaking module import.
+# snapshot into ``channel_values`` (see ``aresolve_thread_messages`` and the serializer's
+# round-trip overrides below). It is a beta langgraph type; import defensively so a relocation
+# can't break module import. But the degradation is NOT free: with ``_DeltaSnapshot`` (and thus
+# ``_DELTA_SNAPSHOT_ID``) ``None`` the round-trip overrides below no-op, so if langgraph still
+# emits the wrapper the encode path silently reverts to the stock bare-array behaviour that
+# caused Sentry DAIV-1S. We therefore log loudly at import so a disabled fix is visible rather
+# than resurfacing later as an untraceable ``NotImplementedError`` crash.
 try:
     from langgraph.checkpoint.serde.types import _DeltaSnapshot
 except ImportError:  # pragma: no cover - defensive against langgraph beta churn
     _DeltaSnapshot = None  # ty: ignore[invalid-assignment]
+    logger.error(
+        "langgraph._DeltaSnapshot is no longer importable from langgraph.checkpoint.serde.types; "
+        "DAIVRedisSerializer's _DeltaSnapshot round-trip is DISABLED. If DeltaChannel still emits "
+        "it, checkpoints regress to the Sentry DAIV-1S 'Message as a sequence must be (role "
+        "string, template)' crash. Update the import path."
+    )
+
+# The ``lc:2`` constructor ``id`` that ``_encode_constructor_envelope(_DeltaSnapshot, ...)`` emits on
+# encode -- module split into parts, matching the base builder's format (NOT the dotted 2-element
+# form ``_default_handler`` uses, which exists only to match the class-based ``allowed_json_modules``
+# entry -- a concern ``_DeltaSnapshot`` doesn't share). Kept as a module constant purely for the
+# decode-side matcher ``_is_delta_snapshot_envelope``: the saver's ``_recursive_deserialize`` routes
+# ONLY ``lc``-constructor dicts to ``serde._revive_if_needed``, so this exact id is what the
+# channel-values read path hands back to us to reconstruct.
+_DELTA_SNAPSHOT_ID: list[str] | None = (
+    [*_DeltaSnapshot.__module__.split("."), _DeltaSnapshot.__name__] if _DeltaSnapshot is not None else None
+)
 
 
 # Domain pydantic models that may live in checkpointed agent state. Listing a model
@@ -51,6 +75,22 @@ class DAIVRedisSerializer(JsonPlusRedisSerializer):
     used to carry is gone. ``tests/unit_tests/core/test_checkpointer.py`` guards the round-trip
     (mechanism detailed there) so a downgrade or upstream regression fails loudly rather than
     nulling production sets.
+
+    **``_DeltaSnapshot`` needs an override.** deepagents >= 0.6 stores ``messages`` in a
+    langgraph ``DeltaChannel`` whose periodic snapshot blob is a ``_DeltaSnapshot`` NamedTuple
+    living in ``channel_values``. The stock redis serializer has no ``_DeltaSnapshot`` support:
+    its ``_preprocess_interrupts`` treats the NamedTuple as a plain tuple, orjson serialises it
+    as a bare JSON array ``[value]``, and the read path returns a nested list ``[[msg, ...]]``
+    with the wrapper lost. langgraph later feeds that value to ``DeltaChannel.from_checkpoint``
+    as a seed, the double-nesting survives, and ``convert_to_messages([[msg, ...]])`` raises
+    ``NotImplementedError: Message as a sequence must be (role string, template)`` (Sentry
+    DAIV-1S). The overrides below round-trip ``_DeltaSnapshot`` through an ``lc:2`` constructor
+    envelope: ``_preprocess_interrupts`` emits it on encode, and ``_revive_if_needed``
+    reconstructs it on decode. One decode override covers both read paths, because the saver's
+    ``_recursive_deserialize`` routes inline ``channel_values`` ``lc`` dicts to
+    ``serde._revive_if_needed`` and ``loads_typed`` calls it directly for blobs. This is an
+    upstream gap in ``langgraph-checkpoint-redis`` 0.5.1 -- worth reporting -- but the fix
+    belongs here so production stops crashing regardless of upstream timing.
 
     On the happy path decode round-trips: the redis read path (``_revive_if_needed``)
     reconstructs the ``lc:2`` envelope for any importable class by delegating to the base
@@ -87,6 +127,52 @@ class DAIVRedisSerializer(JsonPlusRedisSerializer):
                 "kwargs": obj.model_dump(mode="json"),
             }
         return super()._default_handler(obj)
+
+    def _preprocess_interrupts(self, obj: Any) -> Any:
+        # ``_DeltaSnapshot`` is a NamedTuple, so the stock pre-pass would fall into its
+        # ``(list, tuple)`` branch and rebuild it as a plain tuple -- orjson then emits a bare
+        # JSON array and the read path returns a nested list, silently dropping the wrapper
+        # (Sentry DAIV-1S). Intercept it here, BEFORE delegating to the parent, and emit an
+        # ``lc:2`` constructor envelope via the inherited ``_encode_constructor_envelope`` (the same
+        # builder the parent uses for its own ``set``/dataclass branches): that is the ONLY dict
+        # shape the saver's ``_recursive_deserialize`` hands back to ``serde._revive_if_needed``
+        # (below) on the channel-values read path. The wrapped value is processed recursively so the
+        # messages it holds still encode through the parent path.
+        if _DeltaSnapshot is not None and isinstance(obj, _DeltaSnapshot):
+            return self._encode_constructor_envelope(
+                _DeltaSnapshot, kwargs={"value": self._preprocess_interrupts(obj.value)}
+            )
+        return super()._preprocess_interrupts(obj)
+
+    def _revive_if_needed(self, obj: Any) -> Any:
+        # Reconstruct the ``_DeltaSnapshot`` envelope emitted above before the parent's generic
+        # ``lc`` handling runs (which would route this id through the base reviver). This single
+        # override covers BOTH decode paths: the saver's ``_recursive_deserialize`` delegates
+        # ``lc`` dicts here for inline ``channel_values``, and ``loads_typed`` calls it for blobs.
+        if self._is_delta_snapshot_envelope(obj):
+            return _DeltaSnapshot(self._revive_if_needed(obj["kwargs"]["value"]))
+        return super()._revive_if_needed(obj)
+
+    @staticmethod
+    def _is_delta_snapshot_envelope(obj: Any) -> bool:
+        """True if ``obj`` is the ``lc:2`` constructor envelope produced for a ``_DeltaSnapshot``.
+
+        Encode always emits ``lc:2``; ``lc:1`` is accepted only to mirror the base reviver's own
+        ``revived.get("lc") in (1, 2)`` tolerance and the saver's ``_recursive_deserialize`` routing
+        gate. The exact ``_DELTA_SNAPSHOT_ID`` match is what actually discriminates -- and its
+        ``is not None`` short-circuit is load-bearing: without it a ``None`` id (langgraph relocated
+        ``_DeltaSnapshot``, see the import guard) would match any id-less envelope and route it to
+        ``_DeltaSnapshot(...)`` == ``None(...)``.
+        """
+        return (
+            _DELTA_SNAPSHOT_ID is not None
+            and isinstance(obj, dict)
+            and obj.get("lc") in (1, 2)
+            and obj.get("type") == "constructor"
+            and obj.get("id") == _DELTA_SNAPSHOT_ID
+            and isinstance(obj.get("kwargs"), dict)
+            and "value" in obj["kwargs"]
+        )
 
 
 @asynccontextmanager

--- a/tests/unit_tests/core/test_checkpointer.py
+++ b/tests/unit_tests/core/test_checkpointer.py
@@ -296,3 +296,145 @@ async def test_resolve_messages_empty_history_returns_empty_list():
     result = await aresolve_thread_messages(saver, {"configurable": {"thread_id": "t"}}, {})
 
     assert result == []
+
+
+# ---------------------------------------------------------------------------
+# _DeltaSnapshot round-trip (Sentry DAIV-1S)
+#
+# deepagents >= 0.6 declares ``messages`` as a langgraph ``DeltaChannel`` with
+# ``snapshot_frequency=50``. Every 50 message updates ``create_checkpoint`` writes a
+# ``_DeltaSnapshot(value=[msg, ...])`` into ``channel_values["messages"]``. The stock
+# ``JsonPlusRedisSerializer`` has NO ``_DeltaSnapshot`` support -- it treats the NamedTuple
+# as a plain tuple, orjson serialises it as a bare JSON array ``[value]``, and the read path
+# returns a nested list ``[[msg, ...]]`` with the wrapper lost. When langgraph later feeds
+# that value to ``DeltaChannel.from_checkpoint`` as a seed, the double-nesting survives and
+# ``_messages_delta_reducer`` -> ``convert_to_messages([[msg, ...]])`` raises
+# ``NotImplementedError: Message as a sequence must be (role string, template)``.
+# ``DAIVRedisSerializer`` must round-trip ``_DeltaSnapshot`` losslessly.
+# ---------------------------------------------------------------------------
+
+
+def _recursive_deserialize(serde, doc):
+    """Decode ``doc`` via the real ``BaseRedisSaver._recursive_deserialize`` bound onto a minimal
+    object carrying only ``.serde`` -- the channel-values read path a stored snapshot actually
+    takes, without a live Redis. (The ``__bytes__`` branch that would touch ``_decode_blob`` is
+    unused for our input.) Exercising the real method guards the ``lc``-dict delegation contract."""
+    from langgraph.checkpoint.redis.base import BaseRedisSaver
+
+    class _SaverStub:
+        _recursive_deserialize = BaseRedisSaver._recursive_deserialize
+
+        def __init__(self, serde):
+            self.serde = serde
+
+    return _SaverStub(serde)._recursive_deserialize(doc)
+
+
+def test_delta_snapshot_round_trips_through_serde_contract():
+    """Through the public serde API the saver calls (``dumps_typed``/``loads_typed``): the
+    ``_DeltaSnapshot`` wrapper and its inner message list must both survive."""
+    from langchain_core.messages import AIMessage
+    from langgraph.checkpoint.serde.types import _DeltaSnapshot
+
+    serde = DAIVRedisSerializer()
+    snap = _DeltaSnapshot([HumanMessage(content="q", id="h1"), AIMessage(content="a", id="a1")])
+
+    restored = serde.loads_typed(serde.dumps_typed({"messages": snap}))["messages"]
+
+    assert isinstance(restored, _DeltaSnapshot)
+    assert [m.id for m in restored.value] == ["h1", "a1"]
+    assert [m.content for m in restored.value] == ["q", "a"]
+
+
+def test_delta_snapshot_round_trips_through_redis_read_path():
+    """Encode exactly as the RedisJSON checkpoint dump does, then revive via the channel-values
+    read path a stored snapshot actually takes: ``BaseRedisSaver._recursive_deserialize``, which
+    routes ``lc`` constructor dicts to ``serde._revive_if_needed``. Exercising the real saver
+    method (bound onto a minimal stub -- no Redis needed) guards the delegation contract."""
+    from langgraph.checkpoint.serde.types import _DeltaSnapshot
+
+    serde = DAIVRedisSerializer()
+    snap = _DeltaSnapshot([HumanMessage(content="q", id="h1")])
+
+    # As stored in RedisJSON: the whole checkpoint's channel_values dict, encoded via the dump path.
+    raw = orjson.dumps(serde._preprocess_interrupts({"messages": snap}), default=serde._default_handler)
+
+    revived = _recursive_deserialize(serde, orjson.loads(raw))
+
+    assert isinstance(revived["messages"], _DeltaSnapshot)
+    assert [m.id for m in revived["messages"].value] == ["h1"]
+
+
+def test_round_tripped_delta_snapshot_seed_reconstructs_without_crash():
+    """The exact Sentry DAIV-1S crash, end-to-end through the production chain: a snapshot is
+    stored + read back via the channel-values path (``_recursive_deserialize``), then used as a
+    ``DeltaChannel`` seed. ``from_checkpoint`` + ``replay_writes`` must fold cleanly and NOT raise
+    ``NotImplementedError`` from a double-nested value."""
+    from deepagents._messages_reducer import _messages_delta_reducer
+    from langchain_core.messages import AIMessage
+    from langgraph.channels.delta import DeltaChannel
+    from langgraph.checkpoint.serde.types import _DeltaSnapshot
+
+    serde = DAIVRedisSerializer()
+    snap = _DeltaSnapshot([HumanMessage(content="q", id="h1")])
+
+    # Store + read back exactly as the checkpoint save/load does: dump channel_values to
+    # RedisJSON, then decode via the saver's channel-values path (which yields the delta seed).
+    raw = orjson.dumps(serde._preprocess_interrupts({"messages": snap}), default=serde._default_handler)
+    seed = _recursive_deserialize(serde, orjson.loads(raw))["messages"]
+
+    channel = DeltaChannel(_messages_delta_reducer, list, snapshot_frequency=50)
+    channel.key = "messages"
+    replay = channel.from_checkpoint(seed)
+    replay.replay_writes([("task-0", "messages", [AIMessage(content="a", id="a1")])])
+
+    assert [m.id for m in replay.get()] == ["h1", "a1"]
+
+
+def test_delta_snapshot_nested_alongside_model_and_set_round_trips(merge_request):
+    """A realistic snapshot checkpoint: ``messages`` as a ``_DeltaSnapshot`` sitting next to a
+    domain model and a set in the same ``channel_values`` must all survive together."""
+    from langgraph.checkpoint.serde.types import _DeltaSnapshot
+
+    serde = DAIVRedisSerializer()
+    payload = {
+        "messages": _DeltaSnapshot([HumanMessage(content="q", id="h1")]),
+        "merge_request": merge_request,
+        "loaded_tool_names": {"Read", "Edit"},
+    }
+
+    restored = serde.loads_typed(serde.dumps_typed(payload))
+
+    assert isinstance(restored["messages"], _DeltaSnapshot)
+    assert [m.id for m in restored["messages"].value] == ["h1"]
+    assert restored["merge_request"] == merge_request
+    assert restored["loaded_tool_names"] == {"Read", "Edit"}
+
+
+def test_delta_snapshot_overrides_degrade_safely_when_type_unimportable(monkeypatch):
+    """If langgraph relocates ``_DeltaSnapshot`` (import guard trips -> both module refs ``None``),
+    the overrides must cleanly no-op -- never call ``_DeltaSnapshot(...)`` == ``None(...)``. Coverage
+    can't catch this: the guarded lines execute either way, so pin the two guards explicitly.
+
+    * decode: ``_is_delta_snapshot_envelope`` short-circuits on the ``None`` id, so an id-less
+      constructor look-alike is rejected instead of routed to ``None(...)`` -- drop the
+      ``_DELTA_SNAPSHOT_ID is not None`` clause and this assertion ``TypeError``s.
+    * encode: ``_preprocess_interrupts`` falls through to the stock ``(list, tuple)`` branch, so our
+      ``lc:2`` envelope is NOT produced (the fix silently disables -- hence the loud import log).
+    """
+    from langgraph.checkpoint.serde.types import _DeltaSnapshot
+
+    import core.checkpointer as cp
+
+    serde = DAIVRedisSerializer()
+    real_snap = _DeltaSnapshot([HumanMessage(content="q", id="h1")])
+
+    monkeypatch.setattr(cp, "_DeltaSnapshot", None)
+    monkeypatch.setattr(cp, "_DELTA_SNAPSHOT_ID", None)
+
+    # The exact shape that would hit ``None(...)`` if the id short-circuit were ever dropped.
+    idless_lookalike = {"lc": 2, "type": "constructor", "kwargs": {"value": [HumanMessage(content="q", id="h1")]}}
+    assert serde._is_delta_snapshot_envelope(idless_lookalike) is False
+
+    # Real wrapper no longer intercepted -> stock tuple output, not our dict envelope.
+    assert isinstance(serde._preprocess_interrupts(real_snap), tuple)


### PR DESCRIPTION
deepagents >= 0.6 stores `messages` in a langgraph DeltaChannel whose periodic snapshot is a _DeltaSnapshot NamedTuple living in channel_values. The stock JsonPlusRedisSerializer had no _DeltaSnapshot support: it encoded the NamedTuple as a bare JSON array and read it back as a nested list, so the DeltaChannel seed was doubly-nested and convert_to_messages() raised NotImplementedError on long chats (Sentry DAIV-1S).

DAIVRedisSerializer now round-trips _DeltaSnapshot through an lc:2 constructor envelope (built via the inherited _encode_constructor_envelope): _preprocess_interrupts emits it on encode, _revive_if_needed reconstructs it on both decode paths. The import guard logs loudly if langgraph relocates the beta type, so a disabled fix is visible rather than silently regressing.