### PR TITLE
fix(core): tolerate lossy legacy _DeltaSnapshot on checkpoint read (DAIV-1T)

### DIFF
--- a/daiv/core/checkpointer.py
+++ b/daiv/core/checkpointer.py
@@ -191,9 +191,31 @@ async def open_checkpointer() -> AsyncIterator[AsyncRedisSaver]:
 
 
 def _unwrap_delta_snapshot(value: Any) -> Any:
-    """Unwrap a ``DeltaChannel`` snapshot to its stored value; pass anything else through."""
+    """Unwrap a ``DeltaChannel`` snapshot to its stored value; pass anything else through.
+
+    Two encodings are unwrapped:
+
+    * A live ``_DeltaSnapshot`` NamedTuple -- what the serializer round-trip (``_preprocess_interrupts``
+      / ``_revive_if_needed``) reconstructs for checkpoints written after that fix shipped -- yields
+      its ``.value``.
+    * The *lossy legacy* form from a checkpoint written BEFORE that fix: the stock serializer emitted
+      the single-field NamedTuple as a bare JSON array ``[value]``, so a ``messages`` snapshot comes
+      back doubly-nested as ``[[msg, ...]]`` with the wrapper lost. Such checkpoints still live in
+      Redis until their TTL expires, so reading one (e.g. rendering an old session in the dashboard)
+      must unwrap the inner list rather than feed ``[[msg, ...]]`` to ``add_messages`` -- which unpacks
+      the inner list as ``(role, template)`` and raises ``NotImplementedError: Message as a sequence
+      must be (role string, template)`` (Sentry DAIV-1S / DAIV-1T).
+
+    The lossy heuristic (length-1 list whose sole element is a list) is unambiguous for the ``messages``
+    channel this helper serves: a genuine messages list holds messages (objects or ``lc`` envelope
+    dicts), never lists, so it never misfires -- and a lossy empty snapshot ``[[]]`` correctly unwraps
+    to ``[]``. A genuine list is returned unchanged (identity preserved) so the inline fast-path caller
+    can keep returning it as-is.
+    """
     if _DeltaSnapshot is not None and isinstance(value, _DeltaSnapshot):
         return value.value
+    if isinstance(value, list) and len(value) == 1 and isinstance(value[0], list):
+        return value[0]
     return value
 
 

--- a/tests/unit_tests/core/test_checkpointer.py
+++ b/tests/unit_tests/core/test_checkpointer.py
@@ -298,6 +298,94 @@ async def test_resolve_messages_empty_history_returns_empty_list():
     assert result == []
 
 
+async def test_resolve_messages_tolerates_lossy_legacy_delta_snapshot_seed():
+    """Sentry DAIV-1T: a checkpoint written BEFORE the #1418 serializer fix stored the
+    ``_DeltaSnapshot`` seed as a bare JSON array, so it deserialises to a doubly-nested
+    ``[[msg, ...]]`` with the wrapper lost. Those checkpoints still live in Redis until their
+    TTL expires, so reading one (e.g. rendering an old session in the dashboard) must unwrap
+    the lost wrapper instead of feeding ``[[msg, ...]]`` to ``add_messages`` -- which unpacks
+    the inner list as ``(role, template)`` and raises ``NotImplementedError: Message as a
+    sequence must be (role string, template)``."""
+    from langchain_core.messages import AIMessage
+
+    from core.checkpointer import aresolve_thread_messages
+
+    inner = [HumanMessage(content="q", id="h1"), AIMessage(content="a", id="a1")]
+    lossy_seed = [inner]  # _DeltaSnapshot(value=inner) serialised pre-#1418 as a bare 1-element array
+    writes = [("task-3", "messages", [AIMessage(content="more", id="a2")])]
+    saver = _history_saver({"messages": {"seed": lossy_seed, "writes": writes}})
+
+    result = await aresolve_thread_messages(saver, {"configurable": {"thread_id": "t"}}, {})
+
+    assert [m.id for m in result] == ["h1", "a1", "a2"]
+
+
+async def test_resolve_messages_tolerates_lossy_legacy_snapshot_inline():
+    """The other legacy read path: the latest checkpoint IS a snapshot boundary written
+    pre-#1418, so ``channel_values['messages']`` itself holds the lossy ``[[msg, ...]]``.
+    Unwrap it rather than returning the malformed nested list to the caller."""
+    from core.checkpointer import aresolve_thread_messages
+
+    inner = [HumanMessage(content="q", id="h1")]
+    saver = _history_saver({})
+
+    result = await aresolve_thread_messages(saver, {"configurable": {"thread_id": "t"}}, {"messages": [inner]})
+
+    assert [m.id for m in result] == ["h1"]
+    saver.aget_delta_channel_history.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# _unwrap_delta_snapshot: tolerate the live wrapper AND its lossy legacy serialisation
+# ---------------------------------------------------------------------------
+
+
+def test_unwrap_delta_snapshot_unwraps_live_wrapper():
+    """A live ``_DeltaSnapshot`` (what the #1418 serializer round-trips) yields its ``.value``."""
+    from langgraph.checkpoint.serde.types import _DeltaSnapshot
+
+    from core.checkpointer import _unwrap_delta_snapshot
+
+    inner = [HumanMessage(content="q", id="h1")]
+    assert _unwrap_delta_snapshot(_DeltaSnapshot(inner)) is inner
+
+
+def test_unwrap_delta_snapshot_unwraps_lossy_legacy_form():
+    """Pre-#1418 lossy form: a bare 1-element list wrapping the messages list -> inner list."""
+    from core.checkpointer import _unwrap_delta_snapshot
+
+    inner = [HumanMessage(content="q", id="h1"), HumanMessage(content="q2", id="h2")]
+    assert _unwrap_delta_snapshot([inner]) is inner
+
+
+def test_unwrap_delta_snapshot_unwraps_lossy_empty_snapshot():
+    """A lossy empty snapshot ``_DeltaSnapshot([])`` -> ``[[]]`` unwraps to ``[]``."""
+    from core.checkpointer import _unwrap_delta_snapshot
+
+    assert _unwrap_delta_snapshot([[]]) == []
+
+
+def test_unwrap_delta_snapshot_passes_through_genuine_message_list():
+    """A genuine messages list is returned unchanged (identity), even a single-message one:
+    its elements are messages, never lists, so the lossy-form heuristic never misfires."""
+    from core.checkpointer import _unwrap_delta_snapshot
+
+    single = [HumanMessage(content="hi", id="h1")]
+    assert _unwrap_delta_snapshot(single) is single
+
+    many = [HumanMessage(content="a", id="h1"), HumanMessage(content="b", id="h2")]
+    assert _unwrap_delta_snapshot(many) is many
+
+
+def test_unwrap_delta_snapshot_passes_through_non_snapshot_values():
+    """Non-snapshot inputs (``None``, empty list) pass through untouched."""
+    from core.checkpointer import _unwrap_delta_snapshot
+
+    assert _unwrap_delta_snapshot(None) is None
+    empty: list = []
+    assert _unwrap_delta_snapshot(empty) is empty
+
+
 # ---------------------------------------------------------------------------
 # _DeltaSnapshot round-trip (Sentry DAIV-1S)
 #


### PR DESCRIPTION
## Problem (Sentry DAIV-1T)

`NotImplementedError: Message as a sequence must be (role string, template)` (← `ValueError: too many values to unpack (expected 2, got 63)`), **unhandled**, 500ing `/dashboard/sessions/<thread_id>/`. Same crash string as DAIV-1S but a different path — the **read** path, which is why the already-merged #1418 didn't stop it.

## Root cause

#1418 makes `DAIVRedisSerializer` round-trip `_DeltaSnapshot` as an `lc:2` envelope, so **new** checkpoint writes survive. But checkpoints written **before** #1418 deployed still live in Redis until TTL. The stock serializer had stored the single-field `_DeltaSnapshot(value=[msgs])` NamedTuple as a bare JSON array, so a `messages` snapshot deserialises to a doubly-nested `[[msg, ...]]` with the wrapper lost.

On read, `aresolve_thread_messages` (`SessionDetailView` → `ahydrate_thread` → here) gets that as `seed`. `_unwrap_delta_snapshot` only recognised a *live* `_DeltaSnapshot` instance — not the plain list — so `messages = list(seed)` stayed `[[msg, ...]]` and `add_messages` unpacked the inner 63-message list as `(role, template)` → the crash.

The DAIV-1S write-up assumed *"TTL bounds them; those runs already crashed/completed"* — wrong: **anyone opening an old session re-reads the legacy checkpoint and re-crashes** for the whole TTL window.

## Fix

Extend `_unwrap_delta_snapshot` to also unwrap the lossy legacy form — a length-1 list whose sole element is a list:

```python
if isinstance(value, list) and len(value) == 1 and isinstance(value[0], list):
    return value[0]
```

One chokepoint covers both read call-sites (inline `channel_values["messages"]` and the `seed` replay). The heuristic is unambiguous for the messages channel — a genuine messages list holds messages (objects/`lc` dicts), never lists; `[[]]` → `[]`; a genuine list is returned by identity so the inline fast-path is untouched. No catch-all was added at the hydration layer: root cause is fixed and a broad `except` would mask genuinely different future failures.

## Tests

- 2 read-path tests (lossy seed replay + lossy inline snapshot) and 5 `_unwrap_delta_snapshot` unit tests (live wrapper, lossy form, empty snapshot `[[]]`→`[]`, no-misfire on genuine lists, pass-through).
- `tests/unit_tests/core/test_checkpointer.py`: 29 passed; `core/` + `sessions/`: 884 passed. Ruff clean.

Builds on top of #1418 (already on `main`).
