### PR TITLE
feat(accounts): Epic 4 — the Needs-me Queue (Stories 4.1–4.2)

### DIFF
--- a/daiv/accounts/locale/pt/LC_MESSAGES/django.po
+++ b/daiv/accounts/locale/pt/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-21 10:45+0100\n"
+"POT-Creation-Date: 2026-07-21 15:27+0100\n"
 "PO-Revision-Date: 2026-04-04 22:34+0100\n"
 "Last-Translator: \n"
 "Language-Team: Portuguese <pt@li.org>\n"
@@ -335,8 +335,9 @@ msgstr "precisa de ti"
 msgid "%(ago)s ago"
 msgstr "há %(ago)s"
 
-msgid "stale"
-msgstr "parado"
+#, python-format
+msgid "stale · %(days)sd"
+msgstr "parado · %(days)sd"
 
 msgid "Review"
 msgstr "rever"
@@ -507,6 +508,18 @@ msgstr "Autorizar"
 
 msgid "Authorizing will grant this application access to your DAIV account"
 msgstr "Ao autorizar, irá conceder a esta aplicação acesso à sua conta DAIV"
+
+msgid "caught up"
+msgstr "em dia"
+
+#, python-format
+msgid "checked %(counter)s run"
+msgid_plural "checked %(counter)s runs"
+msgstr[0] "verificada %(counter)s execução"
+msgstr[1] "verificadas %(counter)s execuções"
+
+#~ msgid "stale"
+#~ msgstr "parado"
 
 #~ msgid "Activity"
 #~ msgstr "Atividade"

--- a/daiv/accounts/locale/pt/LC_MESSAGES/django.po
+++ b/daiv/accounts/locale/pt/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-20 05:23-0500\n"
+"POT-Creation-Date: 2026-07-21 10:45+0100\n"
 "PO-Revision-Date: 2026-04-04 22:34+0100\n"
 "Last-Translator: \n"
 "Language-Team: Portuguese <pt@li.org>\n"
@@ -105,11 +105,21 @@ msgstr "Entregas"
 msgid "Needs-me queue"
 msgstr "Fila de pendências"
 
+#, python-format
+msgid "you have %(n)s"
+msgid_plural "you have %(n)s"
+msgstr[0] "tens %(n)s"
+msgstr[1] "tens %(n)s"
+
 msgid "Feed"
 msgstr "Feed"
 
 msgid "what happened"
 msgstr "o que aconteceu"
+
+#, python-format
+msgid "last checked %(checked)s"
+msgstr "última verificação %(checked)s"
 
 #, python-format
 msgid "%(counter)s item"
@@ -169,10 +179,6 @@ msgstr[1] "%(counter)s execuções sem problemas"
 #, python-format
 msgid "next sweep %(sweep)s"
 msgstr "próxima verificação %(sweep)s"
-
-#, python-format
-msgid "last checked %(checked)s"
-msgstr "última verificação %(checked)s"
 
 msgid "No scheduled runs yet."
 msgstr "Ainda não há execuções agendadas."
@@ -312,6 +318,49 @@ msgstr "Vista de gestor."
 
 msgid "Review console."
 msgstr "Consola de revisão."
+
+msgid "found issues"
+msgstr "problemas encontrados"
+
+msgid "needs attention"
+msgstr "precisa de atenção"
+
+msgid "failed"
+msgstr "falhou"
+
+msgid "needs you"
+msgstr "precisa de ti"
+
+#, python-format
+msgid "%(ago)s ago"
+msgstr "há %(ago)s"
+
+msgid "stale"
+msgstr "parado"
+
+msgid "Review"
+msgstr "rever"
+
+msgid "Fix"
+msgstr "corrigir"
+
+msgid "Retry"
+msgstr "repetir"
+
+msgid "View run"
+msgstr "ver execução"
+
+msgid "DAIV checked your work — nothing is waiting on you."
+msgstr "O DAIV verificou o teu trabalho — nada está à tua espera."
+
+#, python-format
+msgid "checked %(counter)s run · last checked %(checked)s"
+msgid_plural "checked %(counter)s runs · last checked %(checked)s"
+msgstr[0] "verificada %(counter)s execução · última verificação %(checked)s"
+msgstr[1] "verificadas %(counter)s execuções · última verificação %(checked)s"
+
+msgid "No runs yet."
+msgstr "Ainda não há execuções."
 
 msgid "New"
 msgstr "Novo"

--- a/daiv/accounts/templates/accounts/_clickthrough.html
+++ b/daiv/accounts/templates/accounts/_clickthrough.html
@@ -17,15 +17,22 @@ Params:
   number       — the count/label this panel is behind (contract param; not force-rendered).
   how_computed — truthy renders the "how computed" AD-10 formula disclosure (AC2).
   panel_id     — the unique id the trigger's ``aria-controls`` points at (a11y, AC10).
+  testid_prefix — OPTIONAL, default ``"hero"``: prefixes the panel + how-computed ``data-testid``
+                  (``{prefix}-breakdown`` / ``{prefix}-howcomputed``) so a second consumer (Epic 4's
+                  Queue count → ``"queue"``) gets its own unique hooks. Omitted by the Hero includes,
+                  which therefore stay byte-compatible on ``hero-breakdown`` / ``hero-howcomputed``.
+  row_partial  — OPTIONAL: when set, each row is rendered via ``{% templatetag openblock %} include
+                  row_partial with row=row {% templatetag closeblock %}`` instead of the inline hero
+                  (merged-MR) row, letting the Queue supply its own row shape. Omitted → inline hero row.
 
 Flat INLINE surface (surface-2 + hairline) — NOT a floating popover, so no overlay shadow. Links
 are teal ``accent`` NAVIGATION — never a ``button-*`` action, never a status colour. Icons via
 ``{% templatetag openblock %} icon {% templatetag closeblock %}`` only (no inline ``<svg>``).
 {% endcomment %}
-<div id="{{ panel_id }}" data-testid="hero-breakdown"
+<div id="{{ panel_id }}" data-testid="{{ testid_prefix|default:'hero' }}-breakdown"
      class="rounded-md border border-border bg-surface-2 p-3">
   {% if how_computed %}
-  <div data-testid="hero-howcomputed" class="mb-3 border-b border-border pb-3">
+  <div data-testid="{{ testid_prefix|default:'hero' }}-howcomputed" class="mb-3 border-b border-border pb-3">
     <h3 class="font-mono text-[11px] font-medium uppercase tracking-[0.12em] text-text-faint">
       {% translate "What this counts" %}
     </h3>
@@ -37,6 +44,7 @@ are teal ``accent`` NAVIGATION — never a ``button-*`` action, never a status c
   <div class="overflow-x-auto">
     <ul role="list" class="flex min-w-0 flex-col divide-y divide-border">
       {% for row in rows %}
+      {% if row_partial %}{% include row_partial with row=row %}{% else %}
       <li data-testid="breakdown-row" class="flex flex-wrap items-center gap-x-3 gap-y-1 py-2">
         <span class="inline-flex shrink-0 items-center rounded bg-ground px-1.5 py-0.5 font-mono text-[11px] text-text-muted">&rsaquo; {{ row.repo_id }}</span>
         <span class="shrink-0 font-mono text-[12px] tabular-nums text-text-muted">MR !{{ row.merge_request_iid }}</span>
@@ -56,6 +64,7 @@ are teal ``accent`` NAVIGATION — never a ``button-*`` action, never a status c
           </a>
         </span>
       </li>
+      {% endif %}
       {% empty %}
       <li class="py-2 text-[13px] text-text-faint">{% translate "No changes shipped in this range." %}</li>
       {% endfor %}

--- a/daiv/accounts/templates/accounts/_console_body.html
+++ b/daiv/accounts/templates/accounts/_console_body.html
@@ -41,9 +41,12 @@ so assistive tech is never read empty rows.
                 style="color: var(--color-status-clear); background-color: color-mix(in srgb, var(--color-status-clear) 14%, transparent); border: 1px solid color-mix(in srgb, var(--color-status-clear) 30%, transparent)">
             {% blocktranslate count n=queue_count %}you have {{ n }}{% plural %}you have {{ n }}{% endblocktranslate %}
           </span>
+          {% comment %} "caught up" meta suffix (Task 5 / UX-DR12) — the zero pill's calm affirmation
+             beside the green "you have 0"; muted/faint so the pill stays the anchor. {% endcomment %}
+          <span class="ml-2 font-mono text-[11px] tabular-nums text-text-faint">{% translate "caught up" %}</span>
           {% else %}
           <button type="button" data-testid="queue-count-toggle"
-                  @click="open = !open" :aria-expanded="open.toString()" aria-controls="queue-breakdown"
+                  aria-expanded="false" @click="open = !open" :aria-expanded="open.toString()" aria-controls="queue-breakdown"
                   class="inline-flex items-center rounded-full px-2 py-0.5 font-mono text-[12px] tabular-nums transition-opacity hover:opacity-80"
                   style="color: var(--color-accent-bright); background-color: color-mix(in srgb, var(--color-accent) 14%, transparent); border: 1px solid color-mix(in srgb, var(--color-accent) 30%, transparent)">
             {% blocktranslate count n=queue_count %}you have {{ n }}{% plural %}you have {{ n }}{% endblocktranslate %}

--- a/daiv/accounts/templates/accounts/_console_body.html
+++ b/daiv/accounts/templates/accounts/_console_body.html
@@ -1,11 +1,10 @@
 {% load i18n %}
 {% comment %}
-Review Console main column — three stacked placeholder regions (Story 2.1).
-Structural skeletons only; Hero/Queue/Feed content and the "you have N" count
-are wired by later stories (Epic 3 / Epic 4 / Story 2.3). This partial carries
-NO job-creation control (FR-3). Reused verbatim as the HTMX body fragment.
-Each region is marked aria-busy while its content is pending; the decorative
-shimmer skeletons are aria-hidden so assistive tech is not read empty rows.
+Review Console main column — three stacked regions Hero → Queue → Feed (Story 2.1 shell, now
+live: Hero = Epic 3, Queue = Epic 4, Feed = Story 2.3). This partial carries NO job-creation
+control (FR-3). Reused verbatim as the HTMX body fragment. A server render always carries data,
+so no region claims a live ``aria-busy`` state; any decorative cold-load skeleton is aria-hidden
+so assistive tech is never read empty rows.
 {% endcomment %}
 <div class="flex flex-col gap-5">
   {# ── Hero (Story 3.1) ─────────────────────────────────────────────────── #}
@@ -23,20 +22,45 @@ shimmer skeletons are aria-hidden so assistive tech is not read empty rows.
     {% include "accounts/_hero.html" %}
   </section>
 
-  {# ── Needs-me queue ───────────────────────────────────────────────────── #}
-  <section data-testid="console-queue" aria-labelledby="console-queue-heading" aria-busy="true">
-    <header class="mb-3 flex flex-wrap items-baseline gap-x-3 gap-y-1">
-      <h2 id="console-queue-heading" class="text-[14px] font-semibold tracking-tight text-text">
-        {% translate "Needs-me queue" %}
-      </h2>
-      {# "you have N" count container — populated in Epic 4; announced politely. #}
-      <span data-testid="console-queue-count" aria-live="polite"
-            class="font-mono text-[12px] tabular-nums text-text-muted"></span>
-    </header>
-    <div class="overflow-hidden rounded-xl border border-border bg-surface-2" aria-hidden="true">
-      <div class="skeleton h-16 border-b border-border"></div>
-      <div class="skeleton h-16 border-b border-border"></div>
-      <div class="skeleton h-16"></div>
+  {# ── Needs-me queue (Story 4.1) ───────────────────────────────────────── #}
+  <section data-testid="console-queue" aria-labelledby="console-queue-heading">
+    <div x-data="{ open: false }" @keydown.escape.window="open = false">
+      <header class="mb-3 flex flex-wrap items-baseline gap-x-3 gap-y-1">
+        <h2 id="console-queue-heading" class="text-[14px] font-semibold tracking-tight text-text">
+          {% translate "Needs-me queue" %}
+        </h2>
+        {% comment %} The single "you have N" count pill — teal (recoloured status-clear green at zero),
+           mono/tabular, sized to content, announced politely via the PRESERVED aria-live span (fill it,
+           don't replace it). When the Queue is non-empty the pill is a <button> that reveals the
+           click-through breakdown; the disclosure is COLLAPSED by default (x-show/x-cloak →
+           display:none) so the reveal panel is not in the a11y tree until opened and the always-visible
+           list stays the single announced role="list". No dead aria-busy / no unsatisfiable guard. {% endcomment %}
+        <span data-testid="console-queue-count" aria-live="polite" class="inline-flex items-center">
+          {% if queue_zero %}
+          <span class="inline-flex items-center rounded-full px-2 py-0.5 font-mono text-[12px] tabular-nums"
+                style="color: var(--color-status-clear); background-color: color-mix(in srgb, var(--color-status-clear) 14%, transparent); border: 1px solid color-mix(in srgb, var(--color-status-clear) 30%, transparent)">
+            {% blocktranslate count n=queue_count %}you have {{ n }}{% plural %}you have {{ n }}{% endblocktranslate %}
+          </span>
+          {% else %}
+          <button type="button" data-testid="queue-count-toggle"
+                  @click="open = !open" :aria-expanded="open.toString()" aria-controls="queue-breakdown"
+                  class="inline-flex items-center rounded-full px-2 py-0.5 font-mono text-[12px] tabular-nums transition-opacity hover:opacity-80"
+                  style="color: var(--color-accent-bright); background-color: color-mix(in srgb, var(--color-accent) 14%, transparent); border: 1px solid color-mix(in srgb, var(--color-accent) 30%, transparent)">
+            {% blocktranslate count n=queue_count %}you have {{ n }}{% plural %}you have {{ n }}{% endblocktranslate %}
+          </button>
+          {% endif %}
+        </span>
+      </header>
+      {% if not queue_zero %}
+      {% comment %} Count click-through (AC6): reuses the generic ``_clickthrough.html`` via its
+         back-compatible ``testid_prefix`` + ``row_partial`` params, so the Queue supplies its own
+         (non-merged-MR) compact row shape without inheriting the hero-named / MR-only markup. Flat
+         inline surface below the header; collapsed by default. {% endcomment %}
+      <div x-show="open" x-cloak x-transition @click.outside="open = false" class="mb-3">
+        {% include "accounts/_clickthrough.html" with rows=queue_items number=queue_count how_computed=False panel_id="queue-breakdown" testid_prefix="queue" row_partial="accounts/_queue_clickthrough_row.html" %}
+      </div>
+      {% endif %}
+      {% include "accounts/_queue.html" %}
     </div>
   </section>
 

--- a/daiv/accounts/templates/accounts/_queue.html
+++ b/daiv/accounts/templates/accounts/_queue.html
@@ -1,0 +1,29 @@
+{% load i18n icon_tags %}
+{% comment %}
+Needs-me Queue region body (Story 4.1). Rendered inside the ``console-queue`` section of
+_console_body.html. Shows ONE list of the user's still-actionable terminal runs (built by
+``DashboardView._get_queue_data``); when nothing is actionable, the "nothing needs you." seal.
+Mirrors ``_feed.html``'s if/else region shape (``queue_zero`` is trustworthy — it equals
+``queue_count == 0`` over the FULLY reconciled candidate set, so there is no third "loading" state
+and no unsatisfiable guard).
+{% endcomment %}
+<div>
+  {% comment %} Cold-load skeleton substrate (AC11): rows matching the queue-row layout, aria-hidden
+     so assistive tech is never read empty rows. A server render always carries data, so it is
+     superseded by the real rows / seal below and stays hidden — retained as the loading substrate
+     for parity with the 2.1 shell. {% endcomment %}
+  <div class="overflow-hidden rounded-xl border border-border bg-surface-2" aria-hidden="true" hidden>
+    <div class="skeleton h-16 border-b border-border"></div>
+    <div class="skeleton h-16 border-b border-border"></div>
+    <div class="skeleton h-16"></div>
+  </div>
+  {% if queue_zero %}
+    {% include "accounts/_queue_zero_state.html" with audit=queue_audit %}
+  {% else %}
+    <div role="list" data-testid="queue-list" class="flex flex-col gap-2">
+      {% for item in queue_items %}
+        {% include "accounts/_queue_item.html" with item=item %}
+      {% endfor %}
+    </div>
+  {% endif %}
+</div>

--- a/daiv/accounts/templates/accounts/_queue_clickthrough_row.html
+++ b/daiv/accounts/templates/accounts/_queue_clickthrough_row.html
@@ -1,0 +1,32 @@
+{% load i18n icon_tags %}
+{% comment %}
+Queue count click-through row (Story 4.1, AC6) — the compact breakdown row supplied to the generic
+``_clickthrough.html`` via its ``row_partial`` param (``row`` is one ``_get_queue_data`` item dict).
+Unlike the hero row this is NOT a merged-MR record: it shows repo chip · title · created-at
+timestamp · an out-link ONLY when the run persisted BOTH a ``merge_request_web_url`` and a
+``merge_request_iid`` (the aria-label interpolates the iid, so a url without an iid would otherwise
+render "open MR !None") · and a same-tab drill-through to ``session_detail``. Handles a null
+``merge_request_iid`` gracefully (the MR chip and the out-link are simply omitted). Icons via
+``{% templatetag openblock %} icon {% templatetag closeblock %}`` only.
+{% endcomment %}
+<li data-testid="queue-breakdown-row" class="flex flex-wrap items-center gap-x-3 gap-y-1 py-2">
+  <span class="inline-flex shrink-0 items-center rounded bg-ground px-1.5 py-0.5 font-mono text-[11px] text-text-muted">&rsaquo; {{ row.repo_id }}</span>
+  {% if row.merge_request_iid %}
+  <span class="shrink-0 font-mono text-[12px] tabular-nums text-text-muted">MR !{{ row.merge_request_iid }}</span>
+  {% endif %}
+  <span class="min-w-0 flex-1 truncate text-[13px] text-text">{{ row.title }}</span>
+  <time class="shrink-0 font-mono text-[11px] tabular-nums text-text-faint">{{ row.created_at|date:"Y-m-d H:i" }}</time>
+  <span class="ml-auto flex shrink-0 items-center gap-3">
+    {% if row.merge_request_web_url and row.merge_request_iid %}
+    <a href="{{ row.merge_request_web_url }}" target="_blank" rel="noopener"
+       aria-label="{% blocktranslate with iid=row.merge_request_iid %}open MR !{{ iid }} on GitLab{% endblocktranslate %}"
+       class="inline-flex min-h-[44px] items-center gap-1 text-[12px] text-accent transition-colors hover:text-accent-bright md:min-h-0">
+      <span>MR</span>{% icon "arrow-right" "h-3.5 w-3.5" %}
+    </a>
+    {% endif %}
+    <a href="{% url 'session_detail' thread_id=row.thread_id %}"
+       class="inline-flex min-h-[44px] items-center gap-1 text-[12px] text-accent transition-colors hover:text-accent-bright md:min-h-0">
+      {% translate "view run" %}
+    </a>
+  </span>
+</li>

--- a/daiv/accounts/templates/accounts/_queue_item.html
+++ b/daiv/accounts/templates/accounts/_queue_item.html
@@ -1,0 +1,79 @@
+{% load i18n icon_tags %}
+{% comment %}
+Queue row (Story 4.1) — one still-actionable terminal run, built by ``_build_queue_item``. Three
+parts: a left ``border-l-2`` per-status stripe (accent applied inline as ``var(--color-status-*)``
+because not every status utility is compiled), a main column (title + a wrapping mono meta line:
+repo chip · status/impact word · relative timestamp · optional ``stale`` marker), and exactly ONE
+right-anchored action slot. v1 is NAVIGATE-ONLY: the verb button is a link, never a POST (Epic 5
+wires behaviour). The href MUST agree with the verb — only a REVIEW of a live MR links to the MR
+(new tab); RETRY / FIX / REVIEW-without-url / NONE all navigate to ``session_detail``.
+{% endcomment %}
+<div data-testid="queue-item"
+     data-status="{{ item.status_slug }}"
+     data-action="{{ item.offered_action }}"
+     role="listitem"
+     class="flex items-stretch overflow-hidden rounded-md border border-l-2 border-border bg-surface-2{% if item.status_slug == 'classifying' %} border-dashed{% endif %}"
+     style="{% if item.accent_var %}border-left-color: var({{ item.accent_var }});{% endif %}">
+  <div class="min-w-0 flex-1 p-4">
+    <p class="truncate text-[13px] font-medium text-text">{{ item.title }}</p>
+    <div class="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 font-mono text-[11px] tabular-nums text-text-faint">
+      <span class="inline-flex shrink-0 items-center rounded bg-ground px-1.5 py-0.5 text-text-muted">&rsaquo; {{ item.repo_id }}</span>
+      <span aria-hidden="true">&middot;</span>
+      <span>
+        {% if item.status_slug == "found-issues" %}{% translate "found issues" %}
+        {% elif item.status_slug == "needs-attention" %}{% translate "needs attention" %}
+        {% elif item.status_slug == "failed" %}{% translate "failed" %}
+        {% elif item.status_slug == "classifying" %}{% translate "classifying…" %}
+        {% else %}{% translate "needs you" %}{% endif %}
+      </span>
+      <span aria-hidden="true">&middot;</span>
+      <time datetime="{{ item.created_at|date:'c' }}">{% blocktranslate with ago=item.created_at|timesince %}{{ ago }} ago{% endblocktranslate %}</time>
+      {% if item.is_stale %}
+      <span aria-hidden="true">&middot;</span>
+      <span data-testid="queue-item-stale">{% translate "stale" %}</span>
+      {% endif %}
+    </div>
+  </div>
+  {% comment %} Exactly ONE right-anchored action slot. The href agrees with the verb: a REVIEW of a
+     live MR opens the MR in a new tab; every other verb (RETRY / FIX / REVIEW-without-url / NONE)
+     navigates to the run page — never derive the destination from a persisted url alone. {% endcomment %}
+  <div class="flex shrink-0 items-center py-4 pr-4 pl-2">
+    {% if item.offered_action == "review" and item.merge_request_web_url %}
+    <a data-testid="queue-item-action"
+       href="{{ item.merge_request_web_url }}" target="_blank" rel="noopener"
+       class="inline-flex min-h-[44px] items-center gap-1.5 rounded-md px-2.5 py-1.5 text-[12px] font-medium transition-opacity hover:opacity-80 md:min-h-0"
+       style="color: var(--color-status-attn); background-color: color-mix(in srgb, var(--color-status-attn) 12%, transparent); border: 1px solid color-mix(in srgb, var(--color-status-attn) 28%, transparent)">
+      {% icon "magnifying-glass" "h-3.5 w-3.5" %}<span>{% translate "Review" %}</span>
+    </a>
+    {% elif item.offered_action == "fix" %}
+    <a data-testid="queue-item-action"
+       href="{% url 'session_detail' thread_id=item.thread_id %}"
+       class="inline-flex min-h-[44px] items-center gap-1.5 rounded-md px-2.5 py-1.5 text-[12px] font-medium transition-opacity hover:opacity-80 md:min-h-0"
+       style="color: var(--color-status-found); background-color: color-mix(in srgb, var(--color-status-found) 12%, transparent); border: 1px solid color-mix(in srgb, var(--color-status-found) 28%, transparent)">
+      {% icon "bolt" "h-3.5 w-3.5" %}<span>{% translate "Fix" %}</span>
+    </a>
+    {% elif item.offered_action == "retry" %}
+    <a data-testid="queue-item-action"
+       href="{% url 'session_detail' thread_id=item.thread_id %}"
+       class="inline-flex min-h-[44px] items-center gap-1.5 rounded-md px-2.5 py-1.5 text-[12px] font-medium transition-opacity hover:opacity-80 md:min-h-0"
+       style="color: var(--color-status-fail); background-color: color-mix(in srgb, var(--color-status-fail) 12%, transparent); border: 1px solid color-mix(in srgb, var(--color-status-fail) 28%, transparent)">
+      {% icon "arrow-path" "h-3.5 w-3.5" %}<span>{% translate "Retry" %}</span>
+    </a>
+    {% elif item.offered_action == "review" %}
+    {% comment %} REVIEW without a persisted MR url → the review context lives on the run page. {% endcomment %}
+    <a data-testid="queue-item-action"
+       href="{% url 'session_detail' thread_id=item.thread_id %}"
+       class="inline-flex min-h-[44px] items-center gap-1.5 rounded-md px-2.5 py-1.5 text-[12px] font-medium transition-opacity hover:opacity-80 md:min-h-0"
+       style="color: var(--color-status-attn); background-color: color-mix(in srgb, var(--color-status-attn) 12%, transparent); border: 1px solid color-mix(in srgb, var(--color-status-attn) 28%, transparent)">
+      {% icon "magnifying-glass" "h-3.5 w-3.5" %}<span>{% translate "Review" %}</span>
+    </a>
+    {% else %}
+    {% comment %} NONE → a neutral teal "view run" navigation (e.g. a non-retryable failed run). {% endcomment %}
+    <a data-testid="queue-item-action"
+       href="{% url 'session_detail' thread_id=item.thread_id %}"
+       class="inline-flex min-h-[44px] items-center gap-1.5 rounded-md px-2.5 py-1.5 text-[12px] font-medium text-accent transition-colors hover:text-accent-bright md:min-h-0">
+      <span>{% translate "View run" %}</span>{% icon "arrow-right" "h-3.5 w-3.5" %}
+    </a>
+    {% endif %}
+  </div>
+</div>

--- a/daiv/accounts/templates/accounts/_queue_item.html
+++ b/daiv/accounts/templates/accounts/_queue_item.html
@@ -1,10 +1,13 @@
 {% load i18n icon_tags %}
 {% comment %}
-Queue row (Story 4.1) — one still-actionable terminal run, built by ``_build_queue_item``. Three
-parts: a left ``border-l-2`` per-status stripe (accent applied inline as ``var(--color-status-*)``
-because not every status utility is compiled), a main column (title + a wrapping mono meta line:
-repo chip · status/impact word · relative timestamp · optional ``stale`` marker), and exactly ONE
-right-anchored action slot. v1 is NAVIGATE-ONLY: the verb button is a link, never a POST (Epic 5
+Queue row (Story 4.1; impact chip + ordering added by Story 4.2) — one still-actionable terminal
+run, built by ``_build_queue_item``. Three parts: a left ``border-l-2`` per-status stripe (accent
+applied inline as ``var(--color-status-*)`` because not every status utility is compiled — kept
+per-STATUS, never repurposed as an impact-order hue, AC9), a main column (title + a wrapping mono
+meta line: repo chip · status/impact word · relative timestamp · optional passive-decay impact chip
+``stale · Nd`` + a reserved-but-empty who-waits slot), and exactly ONE right-anchored action slot.
+Rows render in ``order_queue`` sequence so DOM order == visual order (tab order == reading order,
+AC10); priority is position + chip only, never a rank number or a rank colour (AC9). v1 is NAVIGATE-ONLY: the verb button is a link, never a POST (Epic 5
 wires behaviour). The href MUST agree with the verb — only a REVIEW of a live MR links to the MR
 (new tab); RETRY / FIX / REVIEW-without-url / NONE all navigate to ``session_detail``.
 {% endcomment %}
@@ -27,11 +30,19 @@ wires behaviour). The href MUST agree with the verb — only a REVIEW of a live 
         {% else %}{% translate "needs you" %}{% endif %}
       </span>
       <span aria-hidden="true">&middot;</span>
-      <time datetime="{{ item.created_at|date:'c' }}">{% blocktranslate with ago=item.created_at|timesince %}{{ ago }} ago{% endblocktranslate %}</time>
+      {% comment %} Render the SAME age clock ``order_queue`` sorts on and the ``stale · Nd`` chip
+         flags (``age_at = finished_at or created_at``, Story 4.2 review) — not ``created_at`` — so the
+         visible "N ago" can never contradict the row's position or its stale label. {% endcomment %}
+      <time datetime="{{ item.age_at|date:'c' }}">{% blocktranslate with ago=item.age_at|timesince %}{{ ago }} ago{% endblocktranslate %}</time>
       {% if item.is_stale %}
       <span aria-hidden="true">&middot;</span>
-      <span data-testid="queue-item-stale">{% translate "stale" %}</span>
+      {% comment %} Passive-decay impact chip (Story 4.2, AC4/AC9): the only impact indication v1 can
+         honestly show — an item aging past the staleness threshold. Priority is conveyed by row
+         POSITION (order_queue) + this chip, never a rank number or a rank-specific colour. {% endcomment %}
+      <span data-testid="queue-item-stale">{% blocktranslate with days=item.stale_days %}stale · {{ days }}d{% endblocktranslate %}</span>
       {% endif %}
+      {% comment %} who-waits slot (DESIGN.md queue-row) — reserved for the deferred blocking classes
+         (SOMEONE_ELSE_BLOCKED / AGENT_IDLE); intentionally EMPTY in v1 (no blocking data — NFR1). {% endcomment %}
     </div>
   </div>
   {% comment %} Exactly ONE right-anchored action slot. The href agrees with the verb: a REVIEW of a

--- a/daiv/accounts/templates/accounts/_queue_zero_state.html
+++ b/daiv/accounts/templates/accounts/_queue_zero_state.html
@@ -1,0 +1,37 @@
+{% load i18n icon_tags %}
+{% comment %}
+Needs-me Queue zero-state seal (Story 4.1, AC9) — "nothing needs you." as a first-class positive
+state, never a blank/error panel. Mirrors ``_feed_zero_state.html``. Reads the ``audit`` dict
+(``DashboardView._queue_audit``). Two variants:
+  • audited-clean — the user has terminal runs but none are actionable. Honest audit meta:
+    "checked N runs · last checked <time>" (+ "next sweep <time>" when a schedule has one). When
+    ``checked_count`` is 0 the count clause is OMITTED (no candidate was even examined) — NEVER
+    "N runs all clear", which would mislabel the failed/merged runs the candidate filter never selects.
+  • never-ran — the user has no runs at all → distinct calm copy, no audit meta.
+{% endcomment %}
+<section data-testid="queue-zero-state"
+         data-variant="{{ audit.variant }}"
+         class="rounded-xl border border-border bg-surface-2 p-6 text-center">
+  <div class="mx-auto mb-4 flex h-10 w-10 items-center justify-center rounded-full"
+       style="background-color: color-mix(in srgb, var(--color-status-clear) 14%, transparent); color: var(--color-status-clear)">
+    {% icon "check-circle" "h-5 w-5" %}
+  </div>
+  <h3 class="text-[15px] font-semibold text-text">{% translate "nothing needs you." %}</h3>
+  {% if audit.variant == "audited-clean" %}
+    <p class="mx-auto mt-1.5 max-w-sm text-[13px] text-text-muted">
+      {% translate "DAIV checked your work — nothing is waiting on you." %}
+    </p>
+    <p class="mt-3 font-mono text-[12px] tabular-nums text-text-faint">
+      {% if audit.checked_count %}
+        {% blocktranslate with checked=audit.last_checked|date:"H:i" count counter=audit.checked_count %}checked {{ counter }} run · last checked {{ checked }}{% plural %}checked {{ counter }} runs · last checked {{ checked }}{% endblocktranslate %}
+      {% else %}
+        {% blocktranslate with checked=audit.last_checked|date:"H:i" %}last checked {{ checked }}{% endblocktranslate %}
+      {% endif %}
+      {% if audit.next_sweep %} · {% blocktranslate with sweep=audit.next_sweep|date:"H:i" %}next sweep {{ sweep }}{% endblocktranslate %}{% endif %}
+    </p>
+  {% else %}
+    <p class="mx-auto mt-1.5 max-w-sm text-[13px] text-text-muted">
+      {% translate "No runs yet." %}
+    </p>
+  {% endif %}
+</section>

--- a/daiv/accounts/templates/accounts/_queue_zero_state.html
+++ b/daiv/accounts/templates/accounts/_queue_zero_state.html
@@ -19,16 +19,21 @@ state, never a blank/error panel. Mirrors ``_feed_zero_state.html``. Reads the `
   <h3 class="text-[15px] font-semibold text-text">{% translate "nothing needs you." %}</h3>
   {% if audit.variant == "audited-clean" %}
     <p class="mx-auto mt-1.5 max-w-sm text-[13px] text-text-muted">
-      {% translate "DAIV checked your work — nothing is waiting on you." %}
+      {% translate "we checked — nothing needs you" %}
     </p>
+    {% comment %} Guard the whole meta line: when none of the three clauses has a value (no candidate
+       examined, no real ``last_checked``, no scheduled sweep) the <p> would otherwise render as an
+       empty styled paragraph with reserved margin (Story 4.2 review). {% endcomment %}
+    {% if audit.checked_count or audit.last_checked or audit.next_sweep %}
     <p class="mt-3 font-mono text-[12px] tabular-nums text-text-faint">
-      {% if audit.checked_count %}
-        {% blocktranslate with checked=audit.last_checked|date:"H:i" count counter=audit.checked_count %}checked {{ counter }} run · last checked {{ checked }}{% plural %}checked {{ counter }} runs · last checked {{ checked }}{% endblocktranslate %}
-      {% else %}
-        {% blocktranslate with checked=audit.last_checked|date:"H:i" %}last checked {{ checked }}{% endblocktranslate %}
-      {% endif %}
-      {% if audit.next_sweep %} · {% blocktranslate with sweep=audit.next_sweep|date:"H:i" %}next sweep {{ sweep }}{% endblocktranslate %}{% endif %}
+      {% if audit.checked_count %}{% blocktranslate count counter=audit.checked_count %}checked {{ counter }} run{% plural %}checked {{ counter }} runs{% endblocktranslate %}{% endif %}
+      {% comment %} Only render "last checked" when there is a REAL event time — a terminal run
+         missing its ``finished_at`` degrades ``last_checked`` to None; surfacing a dangling
+         "last checked " with an empty time would undercut the honest audit meta (NFR1). {% endcomment %}
+      {% if audit.last_checked %}{% if audit.checked_count %} · {% endif %}{% blocktranslate with checked=audit.last_checked|date:"H:i" %}last checked {{ checked }}{% endblocktranslate %}{% endif %}
+      {% if audit.next_sweep %}{% if audit.checked_count or audit.last_checked %} · {% endif %}{% blocktranslate with sweep=audit.next_sweep|date:"H:i" %}next sweep {{ sweep }}{% endblocktranslate %}{% endif %}
     </p>
+    {% endif %}
   {% else %}
     <p class="mx-auto mt-1.5 max-w-sm text-[13px] text-text-muted">
       {% translate "No runs yet." %}

--- a/daiv/accounts/views.py
+++ b/daiv/accounts/views.py
@@ -19,7 +19,7 @@ from django.views.generic import CreateView, DeleteView, ListView, TemplateView,
 from django_filters.views import FilterView
 from notifications.choices import EventType
 from notifications.models import Notification
-from sessions.models import EnvelopeStatus, Run, RunEnvelope, RunStatus, SessionOrigin
+from sessions.models import EnvelopeStatus, OfferedAction, Run, RunEnvelope, RunStatus, SessionOrigin
 from sessions.reconcile import still_actionable
 
 from accounts.context_processors import running_jobs_count
@@ -243,6 +243,11 @@ def get_velocity_data(cutoff_date: date | None, queryset=None) -> dict | None:
 # notifications ``paginate_by``). Render content comes from each run's live RunEnvelope.
 FEED_PAGE_SIZE = 20
 
+# Passive-decay INDICATION only (Story 4.1) — a Queue row older than this is tagged ``is_stale`` in
+# its meta line. It is NOT a separate query and NOT an ordering key: default order stays newest-first
+# (the single isolated seam Story 4.2 swaps for impact ordering).
+QUEUE_DECAY_DAYS = 7
+
 # Per-status accent applied inline as ``var(--color-status-*)`` — the status utility classes are
 # not all compiled and the Feed reuses existing tokens without a Tailwind rebuild. Classifying has
 # no accent (neutral/dashed). Keyed on the hyphenated ``EnvelopeStatus`` values.
@@ -390,6 +395,10 @@ class DashboardView(LoginRequiredMixin, TemplateView):
         # with nothing to reconcile must not claim a source-of-truth check that never happened
         # (review P2 / NFR1). Read-only / presentation-only: passed into context, never stored.
         context["reconciled_at"] = timezone.now() if reconciled else None
+
+        # The unified Needs-me Queue (Story 4.1) — one personal-scoped list of still-actionable
+        # terminal runs, fronted by the single "you have N" count. Presentation-only.
+        context.update(self._get_queue_data(user))
 
         return context
 
@@ -554,6 +563,150 @@ class DashboardView(LoginRequiredMixin, TemplateView):
             .values_list("next_run_at", flat=True)
             .first()
         )
+
+    def _get_queue_data(self, user: User) -> dict:
+        """Build the unified Needs-me Queue: the user's still-actionable TERMINAL runs (Story 4.1).
+
+        ONE personal-scoped list over the three actionable signal classes — (a) FAILED runs, (b)
+        open-MR runs, and (c) classifier-flagged runs (``FOUND_ISSUES``/``NEEDS_ATTENTION``, with or
+        without an MR) — each confirmed by the shared ``still_actionable`` predicate (the same one
+        the Feed and the nav badge use), so the Queue can never diverge from the attention badge.
+
+        The candidate filter is deliberately the union of those three classes, NOT a bare "all
+        terminal runs filtered by ``still_actionable``": that predicate treats a missing envelope as
+        "still classifying ⇒ actionable" (a Feed-context default), so an unfiltered set would flood
+        the Queue with plain successful non-schedule jobs that carry no envelope and no MR. The gate
+        to ``RunStatus.terminal()`` keeps in-flight webhook/job runs (which already carry a
+        ``merge_request_iid`` while RUNNING/QUEUED) out of "needs me". No ``.distinct()`` / no
+        ``seen``-set: a single-table OR that reaches the ``envelope`` reverse OneToOne cannot fan out.
+
+        Membership/count/seal reconcile the FULL candidate set (no cap) so the "nothing needs you."
+        seal is never a false negative and ``queue_count`` equals the rendered rows (NFR1). The
+        cold-cache cost of the per-candidate live MR read rides with the deferred resilience
+        follow-up (real batching), NOT a membership cap. Read-only / presentation-only.
+        """
+        candidates = list(
+            Run.objects
+            .filter(session__user=user)
+            .select_related("session")
+            .filter(status__in=RunStatus.terminal())
+            .filter(
+                Q(status=RunStatus.FAILED)
+                | Q(merge_request_iid__isnull=False)
+                | Q(envelope__status__in=[EnvelopeStatus.FOUND_ISSUES, EnvelopeStatus.NEEDS_ATTENTION])
+            )
+            # The ``-id`` tiebreak matches ``RunManager`` / ``RunEnvelope.Meta.ordering``
+            # (``("-created_at", "-id")``) so same-``created_at`` runs render in a deterministic
+            # order and never reorder between HTMX re-renders.
+            .order_by("-created_at", "-id")
+        )
+        # Batch the candidates' envelopes in one query (no per-row ``for_run``); ``None`` for a run
+        # with none is passed straight into ``still_actionable`` (its classifying default).
+        envelopes = {
+            str(env.run_id): env for env in RunEnvelope.objects.filter(run_id__in=[run.id for run in candidates])
+        }
+
+        stale_before = timezone.now() - timedelta(days=QUEUE_DECAY_DAYS)
+        items: list[dict] = []
+        for run in candidates:
+            envelope = envelopes.get(str(run.id))
+            if still_actionable(run, envelope):
+                items.append(self._build_queue_item(run, envelope, stale_before))
+        queue_count = len(items)
+
+        return {
+            "queue_items": items,
+            "queue_count": queue_count,
+            "queue_zero": queue_count == 0,
+            # The audit meta is only consulted by the zero-state seal; build it (one ``.exists()``)
+            # only when the Queue is actually empty.
+            "queue_audit": self._queue_audit(user, len(candidates)) if queue_count == 0 else None,
+        }
+
+    @staticmethod
+    def _build_queue_item(run: Run, envelope: RunEnvelope | None, stale_before) -> dict:
+        """Map ONE still-actionable run to a render-ready Queue row.
+
+        Presentation is decided by (envelope, status, origin) because a ``RunEnvelope`` exists ONLY
+        for ``SCHEDULE`` + terminal-SUCCESSFUL runs (``sessions/signals.py``, ``tasks.py``):
+
+        (a) envelope present → its ``status`` slug, the ``_FEED_ACCENT_VARS`` accent, and its
+            ``offered_action`` (``FOUND_ISSUES`` → FIX, ``NEEDS_ATTENTION`` → REVIEW);
+        (b) no envelope + FAILED → a failed run: RETRY only when ``run.is_retryable`` (which is
+            False for webhook/CHAT origins) else NONE — never advertise a retry the domain forbids;
+        (c) no envelope + SCHEDULE → genuinely still ``classifying`` (envelope pending in the brief
+            post-run window), neutral, NONE;
+        (d) no envelope + non-SCHEDULE → an open MR awaiting review (``NEEDS_ATTENTION`` / REVIEW),
+            NEVER a permanent "classifying…".
+        """
+        if envelope is not None:
+            status_slug = envelope.status
+            accent_var = _FEED_ACCENT_VARS.get(envelope.status, "")
+            offered_action = envelope.offered_action
+            # A FAILED envelope maps unconditionally to RETRY; enforce the same ``is_retryable``
+            # guard branch (b) applies so a domain-forbidden retry is never advertised — both FAILED
+            # paths share the guarantee. Latent today (FAILED envelopes only attach to retryable
+            # SCHEDULE runs) but removes the divergence between the two FAILED branches.
+            if offered_action == OfferedAction.RETRY and not run.is_retryable:
+                offered_action = OfferedAction.NONE
+        elif run.status == RunStatus.FAILED:
+            status_slug = EnvelopeStatus.FAILED
+            accent_var = _FEED_ACCENT_VARS[EnvelopeStatus.FAILED]
+            offered_action = OfferedAction.RETRY if run.is_retryable else OfferedAction.NONE
+        elif run.trigger_type == SessionOrigin.SCHEDULE:
+            status_slug = "classifying"
+            accent_var = ""
+            offered_action = OfferedAction.NONE
+        else:
+            status_slug = EnvelopeStatus.NEEDS_ATTENTION
+            accent_var = _FEED_ACCENT_VARS[EnvelopeStatus.NEEDS_ATTENTION]
+            offered_action = OfferedAction.REVIEW
+        return {
+            "run_id": run.id,
+            "repo_id": run.repo_id,
+            "title": run.title or run.repo_id,
+            "merge_request_iid": run.merge_request_iid,
+            "merge_request_web_url": run.merge_request_web_url,
+            "thread_id": run.session.thread_id,
+            "created_at": run.created_at,
+            "status_slug": status_slug,
+            "accent_var": accent_var,
+            "offered_action": offered_action,
+            "is_stale": run.created_at < stale_before,
+        }
+
+    def _queue_audit(self, user: User, checked_count: int) -> dict:
+        """The honest zero-state audit meta (Story 4.1, NFR1).
+
+        ``never-ran`` only when the user has NO TERMINAL runs — an in-flight (QUEUED/RUNNING/READY)
+        run is not a check that happened, so a user whose only run is still running gets ``never-ran``
+        rather than a false ``audited-clean`` seal. Otherwise ``audited-clean`` with the number of
+        candidates actually examined this render (may be 0 → the copy omits the count; NEVER "N runs
+        all clear", which would mislabel the failed/merged runs the candidate filter never even
+        selected).
+
+        ``last_checked`` is a REAL event time — the most-recent terminal run's ``finished_at`` for
+        this user (mirrors the Feed zero-state's ``latest_finished`` max-``finished_at`` idiom), NOT
+        ``timezone.now()`` (which advances on every reload and over-claims a check that never
+        happened). NULL-safe: the ``finished_at__isnull=False`` filter means a terminal run missing
+        its finish degrades ``last_checked`` to ``None`` rather than surfacing a null. ``next_sweep``
+        reuses the shared helper.
+        """
+        if not Run.objects.filter(session__user=user, status__in=RunStatus.terminal()).exists():
+            return {"variant": "never-ran"}
+        last_checked = (
+            Run.objects
+            .filter(session__user=user, status__in=RunStatus.terminal(), finished_at__isnull=False)
+            .order_by("-finished_at")
+            .values_list("finished_at", flat=True)
+            .first()
+        )
+        return {
+            "variant": "audited-clean",
+            "checked_count": checked_count,
+            "last_checked": last_checked,
+            "next_sweep": self._next_sweep(user),
+        }
 
     def _get_activity_data(self, cutoff_date: date | None, user: User) -> dict:
         visible = Run.objects.visible_to(user)

--- a/daiv/accounts/views.py
+++ b/daiv/accounts/views.py
@@ -20,6 +20,7 @@ from django_filters.views import FilterView
 from notifications.choices import EventType
 from notifications.models import Notification
 from sessions.models import EnvelopeStatus, OfferedAction, Run, RunEnvelope, RunStatus, SessionOrigin
+from sessions.queue import QUEUE_DECAY_STALE_AFTER, impact_class, order_queue
 from sessions.reconcile import still_actionable
 
 from accounts.context_processors import running_jobs_count
@@ -242,11 +243,6 @@ def get_velocity_data(cutoff_date: date | None, queryset=None) -> dict | None:
 # The console Feed lists the user's RUN_FEED rows newest-first; a single page (mirrors the
 # notifications ``paginate_by``). Render content comes from each run's live RunEnvelope.
 FEED_PAGE_SIZE = 20
-
-# Passive-decay INDICATION only (Story 4.1) — a Queue row older than this is tagged ``is_stale`` in
-# its meta line. It is NOT a separate query and NOT an ordering key: default order stays newest-first
-# (the single isolated seam Story 4.2 swaps for impact ordering).
-QUEUE_DECAY_DAYS = 7
 
 # Per-status accent applied inline as ``var(--color-status-*)`` — the status utility classes are
 # not all compiled and the Feed reuses existing tokens without a Tailwind rebuild. Classifying has
@@ -570,7 +566,11 @@ class DashboardView(LoginRequiredMixin, TemplateView):
         ONE personal-scoped list over the three actionable signal classes — (a) FAILED runs, (b)
         open-MR runs, and (c) classifier-flagged runs (``FOUND_ISSUES``/``NEEDS_ATTENTION``, with or
         without an MR) — each confirmed by the shared ``still_actionable`` predicate (the same one
-        the Feed and the nav badge use), so the Queue can never diverge from the attention badge.
+        the Feed and the nav badge use), so no surface can show a contradictory LIVE STATE for the
+        same item. That is a per-ITEM guarantee, NOT count equality: the nav badge counts unread,
+        schedule-only Feed rows while the Queue spans origins and ignores read-state, so the two
+        counts legitimately differ (e.g. a still-classifying successful schedule run can briefly
+        show a positive badge over a "nothing needs you." seal until its envelope resolves).
 
         The candidate filter is deliberately the union of those three classes, NOT a bare "all
         terminal runs filtered by ``still_actionable``": that predicate treats a missing envelope as
@@ -606,12 +606,16 @@ class DashboardView(LoginRequiredMixin, TemplateView):
             str(env.run_id): env for env in RunEnvelope.objects.filter(run_id__in=[run.id for run in candidates])
         }
 
-        stale_before = timezone.now() - timedelta(days=QUEUE_DECAY_DAYS)
+        now = timezone.now()
         items: list[dict] = []
         for run in candidates:
             envelope = envelopes.get(str(run.id))
             if still_actionable(run, envelope):
-                items.append(self._build_queue_item(run, envelope, stale_before))
+                items.append(self._build_queue_item(run, envelope, now))
+        # Story 4.2 — re-sequence by impact class then age (most-stale first), replacing 4.1's
+        # newest-first placeholder. A PURE re-sequence over the already-built items: membership and
+        # ``queue_count`` are untouched (AC6), and it adds no query / no live read (AC8).
+        items = order_queue(items)
         queue_count = len(items)
 
         return {
@@ -624,7 +628,7 @@ class DashboardView(LoginRequiredMixin, TemplateView):
         }
 
     @staticmethod
-    def _build_queue_item(run: Run, envelope: RunEnvelope | None, stale_before) -> dict:
+    def _build_queue_item(run: Run, envelope: RunEnvelope | None, now) -> dict:
         """Map ONE still-actionable run to a render-ready Queue row.
 
         Presentation is decided by (envelope, status, origin) because a ``RunEnvelope`` exists ONLY
@@ -661,6 +665,12 @@ class DashboardView(LoginRequiredMixin, TemplateView):
             status_slug = EnvelopeStatus.NEEDS_ATTENTION
             accent_var = _FEED_ACCENT_VARS[EnvelopeStatus.NEEDS_ATTENTION]
             offered_action = OfferedAction.REVIEW
+        # Story 4.2 — passive-decay age (AC4): ``finished_at`` (when the item became "done and
+        # awaiting you") falling back to ``created_at``. This single clock is BOTH the sort key
+        # (``order_queue``) and the staleness threshold, so the row's position and its "stale · Nd"
+        # chip can never disagree.
+        age_at = run.finished_at or run.created_at
+        age = now - age_at
         return {
             "run_id": run.id,
             "repo_id": run.repo_id,
@@ -672,7 +682,12 @@ class DashboardView(LoginRequiredMixin, TemplateView):
             "status_slug": status_slug,
             "accent_var": accent_var,
             "offered_action": offered_action,
-            "is_stale": run.created_at < stale_before,
+            # Impact class attached here so ``order_queue`` sorts on it and a deferred class can be
+            # emitted later without touching the sort (AC5). v1: always ``PASSIVE_DECAY``.
+            "impact_class": impact_class(run, envelope),
+            "age_at": age_at,
+            "is_stale": age >= QUEUE_DECAY_STALE_AFTER,
+            "stale_days": age.days,
         }
 
     def _queue_audit(self, user: User, checked_count: int) -> dict:

--- a/daiv/sessions/queue.py
+++ b/daiv/sessions/queue.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from datetime import timedelta
+from enum import IntEnum
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from codebase.base import MergeRequestState
+    from sessions.models import Run, RunEnvelope
+
+# Passive-decay staleness threshold (AC4). A Queue row whose age (``finished_at or created_at``) is
+# older than this surfaces a "stale · Nd" impact chip; a younger row carries no label. This is the
+# SINGLE source of the threshold — the view imports it, never re-declaring "7 days". It flags the
+# chip only; it NEVER excludes an item (membership stays Story 4.1's ``still_actionable`` job, AC6).
+QUEUE_DECAY_STALE_AFTER = timedelta(days=7)
+
+
+class QueueImpactClass(IntEnum):
+    """The Needs-me Queue's impact-class ordinal (FR-11, AD-5) — most-urgent first.
+
+    Ranks the four impact classes "by who or what is blocked, not by what failed loudest": a
+    blocking item always outranks a non-blocking failure. Rank is the enum VALUE (0 = most urgent),
+    so ``order_queue`` sorts on it directly. Presentation-only and NEVER persisted (AD-9 carries no
+    rank field), so this is a plain ``IntEnum`` — no model field, migration, or ``CheckConstraint`` —
+    mirroring the ``RunStatus.terminal()`` / ``MergeRequestState.resolved()`` classmethod idiom.
+
+    v1 reaches only ``PASSIVE_DECAY`` in production: the top three classes need signals DAIV does not
+    yet collect (reviewers/blocked-by, live pipeline status, a waiting-on-human run state), so
+    :func:`impact_class` never emits them (NFR1 — no fabricated blocking signal). Their ranks are
+    reserved so a deferred class lands by teaching :func:`impact_class` a new signal source, WITHOUT
+    touching the view, the sort, or the template (AC5).
+    """
+
+    SOMEONE_ELSE_BLOCKED = 0  # DEFERRED (AD-5): a teammate is blocked on this (reviewers/blocked-by)
+    MERGEABLE_BUT_BROKEN = 1  # DEFERRED (AD-5): an MR that would merge but its pipeline is red
+    AGENT_IDLE = 2  # DEFERRED (FR-12): the agent is paused waiting on a human decision
+    PASSIVE_DECAY = 3  # v1: an actionable item aging with nobody explicitly blocked
+
+    @property
+    def rank(self) -> int:
+        """The ordinal sort key — lower is more urgent (the enum value, named for the sort site)."""
+        return self.value
+
+    @classmethod
+    def ordered(cls) -> tuple[QueueImpactClass, ...]:
+        """The classes most-urgent-first — the canonical impact sequence (mirrors ``RunStatus.terminal()``)."""
+        return tuple(sorted(cls, key=lambda c: c.rank))
+
+
+def impact_class(run: Run, envelope: RunEnvelope | None, mr_state: MergeRequestState | None = None) -> QueueImpactClass:
+    """Map ONE still-actionable run to its impact class — pure, sync, read-only (AC5, AC8).
+
+    The single place that turns signals into an impact class: adding a deferred class = adding a
+    branch here fed by a new signal source, never editing the view, the sort, or the template (AC5).
+    v1 substantiates only ``PASSIVE_DECAY`` — the three higher classes need signals DAIV does not
+    collect, and emitting one without evidence would fabricate "someone is blocked" (NFR1). Each is
+    documented below as an explicit deferred seam — a reserved enum rank (see :class:`QueueImpactClass`)
+    plus the list below — rather than a dead ``if`` branch that lint/coverage would flag as unreachable,
+    so the seam stays visible without dead code:
+
+    - ``SOMEONE_ELSE_BLOCKED`` — DEFERRED (AD-5): needs reviewer / blocked-by data, via a new
+      ``RepoClient`` fetch + a persistence/caching surface (never a live call from the view).
+    - ``MERGEABLE_BUT_BROKEN`` — DEFERRED (AD-5): needs live pipeline / CI status (a new fetch).
+    - ``AGENT_IDLE`` — DEFERRED (FR-12): needs a "waiting-on-human" run state ``RunStatus`` lacks.
+
+    ``mr_state`` is accepted for the deferred ``MERGEABLE_BUT_BROKEN`` seam, which will read the batch
+    MR state already attached to the item — never a new per-row live read (AC8). v1 ignores it.
+    """
+    # v1: no reviewer / pipeline / waiting-on-human signal is available, so every actionable item is
+    # passive-decay and is ranked by age in ``order_queue``. Do NOT invent a higher class here (NFR1).
+    return QueueImpactClass.PASSIVE_DECAY
+
+
+def order_queue(items: list[dict]) -> list[dict]:
+    """Re-sequence the Queue by impact, most-urgent first — pure, stable, read-only (AC1, AC4, AC8).
+
+    A pure re-sequence of the item dicts Story 4.1's ``_build_queue_item`` produces (each carrying a
+    pre-computed ``impact_class`` and an ``age_at`` = ``finished_at or created_at``): it changes ONLY
+    the order — never membership or the count (AC6). Sorted by ``(impact_class.rank, age_at)``:
+    impact class first (a blocking item above a non-blocking failure — never failures-first, AC1/AC3),
+    then oldest-first within a class so the most-stale passive-decay item surfaces on top (AC4).
+
+    Python's sort is stable, so items tied on ``(rank, age_at)`` keep Story 4.1's incoming
+    ``("-created_at", "-id")`` order — deterministic across HTMX re-renders. Reads only the dict keys
+    already in memory: no DB query and no live MR read (AC8). Returns a new list; the input is
+    untouched.
+    """
+    return sorted(items, key=lambda it: (it["impact_class"].rank, it["age_at"]))

--- a/tests/unit_tests/accounts/test_dashboard_console.py
+++ b/tests/unit_tests/accounts/test_dashboard_console.py
@@ -1585,15 +1585,16 @@ class TestQueueClickthroughRowOutLink:
 @pytest.mark.django_db
 @pytest.mark.usefixtures("_clear_queue_cache")
 class TestQueueDeterministicOrdering:
-    """Patch 5: same-``created_at`` candidates order by the ``("-created_at", "-id")`` convention."""
+    """Same-age candidates keep the ``("-created_at", "-id")`` tiebreak under 4.2's impact sort."""
 
-    def test_same_created_at_rows_are_deterministic(self, member_client, member_user):
-        # Five FAILED API-job candidates sharing one ``created_at``. Without the ``-id`` tiebreak the
-        # DB order is unspecified and can reorder between HTMX re-renders; with it the order is stable
-        # and matches the explicit ``("-created_at", "-id")`` the rest of the codebase uses.
+    def test_same_age_rows_are_deterministic(self, member_client, member_user):
+        # Five FAILED API-job candidates sharing one age (created_at AND finished_at). All are the
+        # same impact class (passive-decay) with an identical age key, so ``order_queue``'s stable
+        # sort leaves them in Story 4.1's incoming ``("-created_at", "-id")`` order — deterministic
+        # across HTMX re-renders, never reshuffled by the impact re-sequence.
         runs = [_make_queue_run(member_user, trigger=SessionOrigin.API_JOB, status=RunStatus.FAILED) for _ in range(5)]
         pinned = timezone.now()
-        Run.objects.filter(pk__in=[r.pk for r in runs]).update(created_at=pinned)
+        Run.objects.filter(pk__in=[r.pk for r in runs]).update(created_at=pinned, finished_at=pinned)
 
         first = [item["run_id"] for item in member_client.get(reverse("dashboard")).context["queue_items"]]
         second = [item["run_id"] for item in member_client.get(reverse("dashboard")).context["queue_items"]]
@@ -1608,20 +1609,90 @@ class TestQueueDeterministicOrdering:
 
 @pytest.mark.django_db
 @pytest.mark.usefixtures("_clear_queue_cache")
+class TestQueueImpactOrdering:
+    """Story 4.2 — impact-based ordering. v1 (every item passive-decay) sorts most-stale first; the
+    re-sequence never changes membership or the count, and priority is position + chip only."""
+
+    @staticmethod
+    def _age(run, when):
+        # Age off BOTH timestamps so ``finished_at or created_at`` (the 4.2 clock) is unambiguous.
+        Run.objects.filter(pk=run.pk).update(created_at=when, finished_at=when)
+
+    def _failed(self, user, repo_id):
+        return _make_queue_run(user, trigger=SessionOrigin.API_JOB, status=RunStatus.FAILED, repo_id=repo_id)
+
+    def test_most_stale_first_inverts_newest_first(self, member_client, member_user):
+        # Three actionable failed runs of distinct ages. v1 orders them OLDEST-first — the observable
+        # inversion of Story 4.1's newest-first placeholder (AC1/AC4). A failure never ranks by
+        # loudness; within passive-decay, age decides.
+        now = timezone.now()
+        newest, middle, oldest = (self._failed(member_user, f"daiv/{n}") for n in ("newest", "middle", "oldest"))
+        self._age(newest, now - timedelta(days=1))
+        self._age(middle, now - timedelta(days=10))
+        self._age(oldest, now - timedelta(days=40))
+
+        items = member_client.get(reverse("dashboard")).context["queue_items"]
+        assert [it["run_id"] for it in items] == [oldest.pk, middle.pk, newest.pk]
+
+    def test_ordering_is_a_pure_resequence(self, member_client, member_user):
+        # AC6/AC7: ordering changes only the sequence — the SET of items and the honest count are
+        # unchanged, and ``queue_count`` still equals the rendered rows.
+        now = timezone.now()
+        runs = [self._failed(member_user, f"daiv/r{i}") for i in range(4)]
+        for i, run in enumerate(runs):
+            self._age(run, now - timedelta(days=i))
+
+        ctx = member_client.get(reverse("dashboard")).context
+        assert ctx["queue_count"] == 4
+        assert ctx["queue_count"] == len(ctx["queue_items"])  # honest count (AC7)
+        assert {it["run_id"] for it in ctx["queue_items"]} == {r.pk for r in runs}  # membership intact (AC6)
+
+    def test_dom_order_equals_context_order(self, member_client, member_user):
+        # AC10: rows render server-side in the ordered sequence, so DOM order == visual order ==
+        # context order (tab order == reading order). No CSS ``order`` reflow desyncs the two.
+        now = timezone.now()
+        for i in range(3):
+            self._age(self._failed(member_user, f"daiv/ord{i}"), now - timedelta(days=(3 - i)))
+
+        resp = member_client.get(reverse("dashboard"))
+        content = resp.content.decode()
+        ordered_repos = [it["repo_id"] for it in resp.context["queue_items"]]
+        dom_positions = [content.index(repo) for repo in ordered_repos]
+        assert dom_positions == sorted(dom_positions)  # the DOM follows the context order exactly
+        assert ordered_repos == ["daiv/ord0", "daiv/ord1", "daiv/ord2"]  # oldest-first
+
+    def test_no_rank_number_and_stripe_stays_per_status(self, member_client, member_user):
+        # AC9: priority is position + chip only — no ordinal rank number/badge; the left stripe stays
+        # per-STATUS (``--color-status-*``), never repurposed as an impact-order hue.
+        self._failed(member_user, "daiv/failed")
+        content = member_client.get(reverse("dashboard")).content.decode()
+        assert "border-left-color: var(--color-status-fail)" in content  # per-status stripe intact
+        assert 'data-testid="queue-item-rank"' not in content  # no rank badge/number rendered
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("_clear_queue_cache")
 class TestQueueStaleTag:
-    """Passive-decay indication: a row older than QUEUE_DECAY_DAYS is tagged is_stale (no extra query)."""
+    """Passive-decay indication: a row older than QUEUE_DECAY_STALE_AFTER surfaces a ``stale · Nd`` chip."""
 
     def test_old_actionable_run_is_tagged_stale(self, member_client, member_user):
         old = _make_queue_run(member_user, trigger=SessionOrigin.API_JOB, status=RunStatus.FAILED)
-        Run.objects.filter(pk=old.pk).update(created_at=timezone.now() - timedelta(days=30))
+        thirty_days_ago = timezone.now() - timedelta(days=30)
+        # Age off ``finished_at or created_at`` (the 4.2 clock, AC4): move BOTH so the item is stale.
+        Run.objects.filter(pk=old.pk).update(created_at=thirty_days_ago, finished_at=thirty_days_ago)
         response = member_client.get(reverse("dashboard"))
-        assert response.context["queue_items"][0]["is_stale"] is True
+        item = response.context["queue_items"][0]
+        assert item["is_stale"] is True
+        assert item["stale_days"] == 30
+        # The chip is enriched with the age (AC4) — no longer a bare "stale".
+        assert "stale · 30d" in response.content.decode()
         assert 'data-testid="queue-item-stale"' in response.content.decode()
 
     def test_recent_run_is_not_stale(self, member_client, member_user):
         _make_queue_run(member_user, trigger=SessionOrigin.API_JOB, status=RunStatus.FAILED)
         response = member_client.get(reverse("dashboard"))
         assert response.context["queue_items"][0]["is_stale"] is False
+        assert 'data-testid="queue-item-stale"' not in response.content.decode()
 
 
 @pytest.mark.django_db
@@ -1652,6 +1723,12 @@ class TestQueueI18n:
         assert '{% translate "Retry" %}' in src
         assert '{% translate "View run" %}' in src
         assert '{% translate "needs attention" %}' in src
+
+    def test_stale_impact_chip_is_translated(self):
+        # Story 4.2 (AC11): the new passive-decay chip is a blocktranslate with a ``days`` var,
+        # English as source. ``pt`` is produced via makemessages, never hand-authored here.
+        src = Path(get_template("accounts/_queue_item.html").origin.name).read_text(encoding="utf-8")
+        assert "{% blocktranslate with days=item.stale_days %}stale · {{ days }}d{% endblocktranslate %}" in src
 
     def test_queue_zero_state_is_translated(self):
         src = Path(get_template("accounts/_queue_zero_state.html").origin.name).read_text(encoding="utf-8")

--- a/tests/unit_tests/accounts/test_dashboard_console.py
+++ b/tests/unit_tests/accounts/test_dashboard_console.py
@@ -11,6 +11,7 @@ from datetime import timedelta
 from pathlib import Path
 from unittest.mock import patch
 
+from django.core.cache import cache
 from django.template.loader import get_template, render_to_string
 from django.test import Client
 from django.urls import reverse
@@ -19,10 +20,12 @@ from django.utils import timezone
 import pytest
 from notifications.choices import EventType
 from notifications.models import Notification
-from sessions.models import EnvelopeStatus, Run, RunEnvelope, RunStatus, Session, SessionOrigin
+from sessions.envelopes import build_actionable_item
+from sessions.models import EnvelopeStatus, OfferedAction, Run, RunEnvelope, RunStatus, Session, SessionOrigin
 
 from accounts.models import Role
 from accounts.views import get_velocity_data
+from codebase.base import MergeRequestState
 from codebase.clients import RepoClient
 from codebase.models import MergeMetric, PlatformType
 
@@ -854,7 +857,14 @@ class TestBreakdownMrLinkHonesty:
     def test_no_repo_client_instantiated_on_render(self, member_client, member_user):
         _make_merge_metric(iid=1)
         _make_shipping_run(member_user, iid=1, web_url="https://gitlab.example.com/daiv/test/-/merge_requests/1")
-        with patch.object(RepoClient, "create_instance") as mock_create_instance:
+        # Story 4.1: the open-MR shipping run is now a Queue candidate, so the Queue reconciles its
+        # live state through the cached ``mr_state`` module. Stub that read so this test isolates the
+        # HERO breakdown's own client-free render path (AC6/AC11) — the assertion below then proves the
+        # Hero instantiates no client, unclouded by the Queue's (independently-tested) live reconcile.
+        with (
+            patch(_LIVE_READ, return_value=MergeRequestState.OPEN),
+            patch.object(RepoClient, "create_instance") as mock_create_instance,
+        ):
             member_client.get(reverse("dashboard"))
             member_client.get(reverse("dashboard"), {"period": "all"})
         mock_create_instance.assert_not_called()
@@ -1080,3 +1090,570 @@ class TestConsoleReconcile:
             response = member_client.get(reverse("dashboard"))
         assert response.status_code == 200
         read.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Story 4.1 — The unified Needs-me Queue with a single count
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def _clear_queue_cache():
+    """Cold-cache isolation for the Queue tests (Story 4.1 review D9).
+
+    The live MR-state read (``codebase.mr_state.get_merge_request_state``) is backed by the real
+    Django cache keyed on ``(repo_id, iid)`` with a 60s TTL. ``@pytest.mark.django_db`` rolls the DB
+    back but never clears that cache, so a warm key from a sibling test could otherwise decide a
+    cold-cache assertion here. Clearing on both ends removes any iid/order coupling.
+    """
+    cache.clear()
+    yield
+    cache.clear()
+
+
+def _make_queue_run(
+    user,
+    *,
+    status=RunStatus.SUCCESSFUL,
+    trigger=SessionOrigin.SCHEDULE,
+    envelope_status=None,
+    actionable=None,
+    merge_request_iid=None,
+    merge_request_web_url="",
+    title="",
+    repo_id="daiv/test",
+):
+    """Build a Session (owned by ``user``) + a Run + optional RunEnvelope — a Queue candidate.
+
+    Parameterises status / trigger / envelope / MR so the terminal gate, the three candidate
+    classes, and the (envelope, status, origin) presentation branches can each be exercised. No
+    factory exists; mirrors ``_make_scheduled_feed_run``.
+    """
+    session = Session.objects.create(thread_id=str(uuid.uuid4()), origin=trigger, repo_id=repo_id, user=user)
+    run = Run.objects.create(
+        session=session,
+        trigger_type=trigger,
+        status=status,
+        repo_id=repo_id,
+        user=user,
+        title=title,
+        merge_request_iid=merge_request_iid,
+        merge_request_web_url=merge_request_web_url,
+        finished_at=timezone.now(),
+    )
+    if envelope_status is not None:
+        RunEnvelope.objects.create(run=run, status=envelope_status, actionable=actionable or [])
+    return run
+
+
+def _found_issues_items():
+    """A contract-valid single-item ``actionable[]`` for a FOUND_ISSUES envelope (offered_action=FIX)."""
+    return [build_actionable_item(id="f1", kind="finding", label="Null deref in auth", ref="app/auth.py:42")]
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("_clear_queue_cache")
+class TestQueueSingleCountAndList:
+    """AC1/AC2/AC3: exactly one count pill + one list; queue_count == rendered rows (honest count)."""
+
+    def test_one_count_pill_one_list_count_equals_rows(self, member_client, member_user):
+        for _ in range(3):
+            _make_queue_run(member_user, envelope_status=EnvelopeStatus.NEEDS_ATTENTION)
+        response = member_client.get(reverse("dashboard"))
+        content = response.content.decode()
+        assert response.context["queue_count"] == 3
+        # One count pill container, no per-type widgets ...
+        assert content.count('data-testid="console-queue-count"') == 1
+        # ... and the count equals the number of rendered rows (breakdown rows carry a distinct id).
+        assert content.count('data-testid="queue-item"') == 3
+        assert b'aria-live="polite"' in response.content
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("_clear_queue_cache")
+class TestQueueTerminalGate:
+    """Review C1 / edge-matrix: an in-flight (non-terminal) run carrying an MR iid is NOT 'needs me'."""
+
+    def test_running_mr_run_excluded_from_queue_and_count(self, member_client, member_user):
+        # A genuinely actionable schedule run keeps the queue non-empty ...
+        _make_queue_run(member_user, envelope_status=EnvelopeStatus.NEEDS_ATTENTION)
+        # ... and a RUNNING MR-webhook run (already carrying an iid) must be gated out.
+        running = _make_queue_run(
+            member_user, trigger=SessionOrigin.MR_WEBHOOK, status=RunStatus.RUNNING, merge_request_iid=42
+        )
+        response = member_client.get(reverse("dashboard"))
+        assert response.context["queue_count"] == 1
+        assert running.id not in {item["run_id"] for item in response.context["queue_items"]}
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("_clear_queue_cache")
+class TestQueueClassifierFlaggedNoMr:
+    """Intent-fix regression guard (AMENDED intent-contract): a FOUND_ISSUES-no-MR run is reachable."""
+
+    def test_found_issues_no_mr_appears_counted_and_no_false_seal(self, member_client, member_user):
+        run = _make_queue_run(
+            member_user,
+            trigger=SessionOrigin.SCHEDULE,
+            envelope_status=EnvelopeStatus.FOUND_ISSUES,
+            actionable=_found_issues_items(),
+        )
+        # No MR → no live read needed.
+        response = member_client.get(reverse("dashboard"))
+        content = response.content.decode()
+        assert response.context["queue_count"] == 1
+        assert 'data-testid="queue-item"' in content
+        assert 'data-status="found-issues"' in content
+        assert 'data-action="fix"' in content
+        # FIX navigates to the run page (the findings live there), never a new-tab MR link.
+        assert reverse("session_detail", kwargs={"thread_id": run.session_id}) in content
+        # The seal must NOT appear — this is the exact false-"nothing needs you" the widening closes.
+        assert 'data-testid="queue-zero-state"' not in content
+        assert response.context["queue_zero"] is False
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("_clear_queue_cache")
+class TestQueueAntiFlood:
+    """Design Notes (three-classes-not-a-flood): a plain done run is NOT flooded in as 'classifying'."""
+
+    def test_plain_successful_non_schedule_run_excluded(self, member_client, member_user):
+        # SUCCESSFUL, non-schedule, no envelope, no MR, not FAILED → none of the three classes.
+        _make_queue_run(member_user, trigger=SessionOrigin.MCP_JOB, status=RunStatus.SUCCESSFUL)
+        response = member_client.get(reverse("dashboard"))
+        content = response.content.decode()
+        assert response.context["queue_count"] == 0
+        assert response.context["queue_zero"] is True
+        assert 'data-testid="queue-item"' not in content
+        assert 'data-testid="queue-zero-state"' in content
+        # The user HAS run(s) → audited-clean, but zero candidates were examined → count clause omitted.
+        audit = response.context["queue_audit"]
+        assert audit["variant"] == "audited-clean"
+        assert audit["checked_count"] == 0
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("_clear_queue_cache")
+class TestQueueOriginAware:
+    """Review C1/D3: non-schedule open MR → REVIEW (never 'classifying…'); non-retryable → no RETRY."""
+
+    def test_non_schedule_open_mr_renders_review_never_classifying(self, member_client, member_user):
+        _make_queue_run(
+            member_user,
+            trigger=SessionOrigin.MR_WEBHOOK,
+            status=RunStatus.SUCCESSFUL,
+            merge_request_iid=7,
+            merge_request_web_url="https://gitlab.example.com/daiv/test/-/merge_requests/7",
+        )
+        with patch(_LIVE_READ, return_value=MergeRequestState.OPEN):
+            response = member_client.get(reverse("dashboard"))
+        content = response.content.decode()
+        assert response.context["queue_count"] == 1
+        assert 'data-status="needs-attention"' in content
+        assert 'data-action="review"' in content
+        # NEVER a permanent classifying row for a non-schedule open-MR run.
+        assert "classifying" not in content
+        # REVIEW of a live MR → the MR link opens in a new tab.
+        assert 'href="https://gitlab.example.com/daiv/test/-/merge_requests/7"' in content
+        assert 'target="_blank"' in content
+
+    def test_failed_non_retryable_run_offers_no_retry(self, member_client, member_user):
+        # A CHAT-origin FAILED run is terminal but NOT retryable (Run.is_retryable is False).
+        _make_queue_run(member_user, trigger=SessionOrigin.CHAT, status=RunStatus.FAILED)
+        response = member_client.get(reverse("dashboard"))
+        content = response.content.decode()
+        assert response.context["queue_count"] == 1
+        assert 'data-status="failed"' in content
+        # No RETRY verb the domain forbids; falls back to a neutral "view run" (NONE).
+        assert 'data-action="retry"' not in content
+        assert 'data-action="none"' in content
+
+    def test_failed_retryable_run_offers_retry(self, member_client, member_user):
+        # An API-job FAILED run IS retryable → RETRY verb.
+        _make_queue_run(member_user, trigger=SessionOrigin.API_JOB, status=RunStatus.FAILED)
+        response = member_client.get(reverse("dashboard"))
+        content = response.content.decode()
+        assert response.context["queue_count"] == 1
+        assert 'data-action="retry"' in content
+
+    def test_failed_envelope_on_non_retryable_run_downgrades_retry(self, member_client, member_user):
+        # Patch 3 (W2): a FAILED envelope maps unconditionally to RETRY. The envelope-present branch
+        # (a) must apply the SAME ``is_retryable`` guard branch (b) enforces, so a CHAT-origin FAILED
+        # run (not retryable) never advertises a RETRY the domain forbids — it downgrades to NONE.
+        _make_queue_run(
+            member_user, trigger=SessionOrigin.CHAT, status=RunStatus.FAILED, envelope_status=EnvelopeStatus.FAILED
+        )
+        response = member_client.get(reverse("dashboard"))
+        content = response.content.decode()
+        # The FAILED envelope keeps the run actionable (is_actionable → RETRY != NONE) so it stays ...
+        assert response.context["queue_count"] == 1
+        # ... but the rendered verb is downgraded to NONE, never a forbidden RETRY.
+        assert response.context["queue_items"][0]["offered_action"] == OfferedAction.NONE
+        assert 'data-action="retry"' not in content
+        assert 'data-action="none"' in content
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("_clear_queue_cache")
+class TestQueueReconcileLiveness:
+    """AC5: membership decided by the shared ``still_actionable`` — merged drops, open/failure stays."""
+
+    def test_open_mr_stays(self, member_client, member_user):
+        _make_queue_run(member_user, trigger=SessionOrigin.MR_WEBHOOK, status=RunStatus.SUCCESSFUL, merge_request_iid=7)
+        with patch(_LIVE_READ, return_value=MergeRequestState.OPEN):
+            response = member_client.get(reverse("dashboard"))
+        assert response.context["queue_count"] == 1
+
+    def test_externally_merged_mr_drops_and_seals(self, member_client, member_user):
+        _make_queue_run(member_user, trigger=SessionOrigin.MR_WEBHOOK, status=RunStatus.SUCCESSFUL, merge_request_iid=7)
+        with patch(_LIVE_READ, return_value=MergeRequestState.MERGED):
+            response = member_client.get(reverse("dashboard"))
+        assert response.context["queue_count"] == 0
+        assert 'data-testid="queue-zero-state"' in response.content.decode()
+
+    def test_live_read_failure_keeps_item_visible(self, member_client, member_user, mock_repo_client):
+        # A failing provider read is resolved to OPEN by the mr_state fail-safe (NOT patched here), so
+        # the item stays visible (AC6 under-claim). Exercises the real wrapper, not a stubbed return.
+        mock_repo_client.get_merge_request_state.side_effect = RuntimeError("boom")
+        _make_queue_run(member_user, trigger=SessionOrigin.MR_WEBHOOK, status=RunStatus.SUCCESSFUL, merge_request_iid=7)
+        response = member_client.get(reverse("dashboard"))
+        assert response.context["queue_count"] == 1
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("_clear_queue_cache")
+class TestQueueNoFalseSeal:
+    """Review D1: reconcile the FULL candidate set — an older actionable item past the newest is kept."""
+
+    def test_older_actionable_not_hidden_behind_a_cap(self, member_client, member_user):
+        # 25 NEWER open-MR candidates whose MRs merged externally (reconciled OUT) ...
+        for iid in range(1, 26):
+            _make_queue_run(
+                member_user, trigger=SessionOrigin.MR_WEBHOOK, status=RunStatus.SUCCESSFUL, merge_request_iid=iid
+            )
+        # ... plus ONE OLDER genuinely-actionable FAILED run (no MR → no live read → stays).
+        old = _make_queue_run(member_user, trigger=SessionOrigin.API_JOB, status=RunStatus.FAILED)
+        Run.objects.filter(pk=old.pk).update(created_at=timezone.now() - timedelta(days=10))
+
+        with patch(_LIVE_READ, return_value=MergeRequestState.MERGED):
+            response = member_client.get(reverse("dashboard"))
+        content = response.content.decode()
+        # A membership cap would have kept only the 25 newest (all merged → dropped) and sealed the
+        # queue with the old actionable item hidden. The full-set reconcile keeps it.
+        assert response.context["queue_count"] == 1
+        assert old.id in {item["run_id"] for item in response.context["queue_items"]}
+        assert 'data-testid="queue-zero-state"' not in content
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("_clear_queue_cache")
+class TestQueueHonestSeal:
+    """AC9 / NFR1: honest zero-state — never-ran vs audited-clean; never 'N runs all clear'."""
+
+    def test_never_ran_variant_when_no_runs(self, member_client, member_user):
+        response = member_client.get(reverse("dashboard"))
+        content = response.content.decode()
+        assert response.context["queue_zero"] is True
+        assert response.context["queue_audit"]["variant"] == "never-ran"
+        assert 'data-variant="never-ran"' in content
+        assert "nothing needs you." in content
+
+    def test_audited_clean_when_runs_exist_but_none_actionable(self, member_client, member_user):
+        # An all-clear scheduled run is not a candidate; a merged open-MR run reconciles out → both
+        # leave the queue empty while the user genuinely HAS terminal runs.
+        _make_queue_run(member_user, envelope_status=EnvelopeStatus.ALL_CLEAR)
+        _make_queue_run(member_user, trigger=SessionOrigin.MR_WEBHOOK, status=RunStatus.SUCCESSFUL, merge_request_iid=3)
+        with patch(_LIVE_READ, return_value=MergeRequestState.MERGED):
+            response = member_client.get(reverse("dashboard"))
+        content = response.content.decode()
+        assert response.context["queue_zero"] is True
+        assert response.context["queue_audit"]["variant"] == "audited-clean"
+        assert 'data-variant="audited-clean"' in content
+        # The audit meta must never label the examined runs "all clear" (they include a merged MR).
+        assert "all clear" not in content
+
+    def test_only_non_terminal_run_yields_never_ran_not_audited_clean(self, member_client, member_user):
+        # Patch 2: the never-ran probe is scoped to TERMINAL runs. A user whose only run is still
+        # RUNNING has NOT been checked yet — the seal must be ``never-ran``, not a false
+        # ``audited-clean`` ("DAIV checked your work … nothing waiting") over an in-flight run.
+        _make_queue_run(member_user, trigger=SessionOrigin.MR_WEBHOOK, status=RunStatus.RUNNING, merge_request_iid=5)
+        response = member_client.get(reverse("dashboard"))
+        content = response.content.decode()
+        assert response.context["queue_zero"] is True
+        assert response.context["queue_audit"]["variant"] == "never-ran"
+        assert 'data-variant="never-ran"' in content
+
+    def test_last_checked_is_a_stable_real_event_time_not_now(self, member_client, member_user):
+        # Patch 1: ``last_checked`` is the real most-recent terminal-run ``finished_at``, NOT
+        # ``timezone.now()``. An all-clear scheduled run is terminal but not a Queue candidate → the
+        # queue seals audited-clean while the user genuinely has a terminal run to date the check.
+        run = _make_queue_run(member_user, envelope_status=EnvelopeStatus.ALL_CLEAR)
+        finished = timezone.now() - timedelta(hours=3)
+        Run.objects.filter(pk=run.pk).update(finished_at=finished)
+
+        first = member_client.get(reverse("dashboard")).context["queue_audit"]
+        second = member_client.get(reverse("dashboard")).context["queue_audit"]
+
+        assert first["variant"] == "audited-clean"
+        # Stable across reloads — a ``timezone.now()`` stamp would differ between the two renders ...
+        assert first["last_checked"] == second["last_checked"]
+        # ... and it is the real terminal finish (~3h ago), never render time.
+        assert first["last_checked"] is not None
+        assert abs((first["last_checked"] - finished).total_seconds()) < 1
+        assert timezone.now() - first["last_checked"] > timedelta(minutes=1)
+
+    def test_pill_recolors_status_clear_at_zero(self, member_client, member_user):
+        response = member_client.get(reverse("dashboard"))
+        content = response.content.decode()
+        assert "you have 0" in content
+        # The zero pill uses the status-clear (green) token, not the teal accent.
+        assert "--color-status-clear" in content
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("_clear_queue_cache")
+class TestQueueAdminPersonalScope:
+    """AC8: the admin default Queue is personal — own items only, never by_owner/.all() org leak."""
+
+    def test_admin_sees_only_own_actionable_items(self, admin_client, admin_user, member_user):
+        mine = _make_queue_run(admin_user, envelope_status=EnvelopeStatus.NEEDS_ATTENTION)
+        _make_queue_run(
+            member_user, envelope_status=EnvelopeStatus.FOUND_ISSUES, actionable=_found_issues_items()
+        )  # another user's — must be excluded
+        response = admin_client.get(reverse("dashboard"))
+        assert response.context["queue_count"] == 1
+        thread_ids = {item["thread_id"] for item in response.context["queue_items"]}
+        assert thread_ids == {mine.session_id}
+
+    def test_personal_by_default_still_holds_with_queue(self, admin_client, admin_user):
+        _make_queue_run(admin_user, envelope_status=EnvelopeStatus.NEEDS_ATTENTION)
+        response = admin_client.get(reverse("dashboard"))
+        assert "velocity" not in response.context
+        assert "total_users" not in response.context
+        assert b'data-testid="manager-lens"' not in response.content
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("_clear_queue_cache")
+class TestQueueDedupe:
+    """Honest-count: a run in more than one class is counted exactly once (single-table OR)."""
+
+    def test_failed_run_with_open_mr_counted_once(self, member_client, member_user):
+        # FAILED AND open-MR → matches two OR arms, but a forward-FK/reverse-OneToOne OR cannot fan out.
+        _make_queue_run(member_user, trigger=SessionOrigin.API_JOB, status=RunStatus.FAILED, merge_request_iid=5)
+        with patch(_LIVE_READ, return_value=MergeRequestState.OPEN):
+            response = member_client.get(reverse("dashboard"))
+        assert response.context["queue_count"] == 1
+        assert response.content.decode().count('data-testid="queue-item"') == 1
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("_clear_queue_cache")
+class TestQueueDisclosure:
+    """AC6: the count is a <button> wired to the click-through panel, collapsed by default."""
+
+    def test_count_toggle_wired_to_collapsed_panel(self, member_client, member_user):
+        _make_queue_run(member_user, envelope_status=EnvelopeStatus.NEEDS_ATTENTION)
+        content = member_client.get(reverse("dashboard")).content.decode()
+        assert '<button type="button" data-testid="queue-count-toggle"' in content
+        assert 'aria-controls="queue-breakdown"' in content
+        assert ':aria-expanded="open.toString()"' in content
+        assert 'id="queue-breakdown"' in content
+        # Collapsed by default — the reveal is out of the a11y tree until opened.
+        assert "x-cloak" in content
+        assert "@click.outside" in content
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("_clear_queue_cache")
+class TestQueueClickthroughReuse:
+    """AC6 reuse: the Hero click-through stays byte-compatible; the Queue gets its own hooks."""
+
+    def test_hero_clickthrough_testids_preserved(self, member_client, member_user):
+        _make_merge_metric(iid=1)
+        _make_shipping_run(member_user, iid=1)
+        content = member_client.get(reverse("dashboard")).content.decode()
+        # The default testid_prefix keeps the hero hooks unchanged.
+        assert 'data-testid="hero-breakdown"' in content
+        assert 'data-testid="hero-howcomputed"' in content
+
+    def test_queue_clickthrough_uses_queue_prefix_and_row(self, member_client, member_user):
+        _make_queue_run(member_user, envelope_status=EnvelopeStatus.NEEDS_ATTENTION)
+        content = member_client.get(reverse("dashboard")).content.decode()
+        assert 'data-testid="queue-breakdown"' in content
+        # how_computed=False → the Queue count has no AD-10 "how computed" disclosure.
+        assert 'data-testid="queue-howcomputed"' not in content
+        # The Queue supplies its own compact row shape (not the hero merged-MR row).
+        assert 'data-testid="queue-breakdown-row"' in content
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("_clear_queue_cache")
+class TestQueueHtmxFragment:
+    """The Queue region re-renders inside the #console-main HTMX fragment with one count pill."""
+
+    def test_htmx_fragment_has_one_count_pill_and_no_chrome(self, member_client, member_user):
+        _make_queue_run(member_user, envelope_status=EnvelopeStatus.NEEDS_ATTENTION)
+        response = member_client.get(reverse("dashboard"), HTTP_HX_REQUEST="true")
+        content = response.content.decode()
+        assert response.status_code == 200
+        assert content.count('data-testid="console-queue-count"') == 1
+        assert 'data-testid="queue-item"' in content
+        # Fragment only — no shell chrome.
+        assert 'data-testid="app-sidebar"' not in content
+        assert 'data-testid="app-user-menu"' not in content
+        assert "<html" not in content
+
+
+class TestQueueVerbHref:
+    """Verb/href agreement (review C5, extended to FIX): the destination must not contradict the verb."""
+
+    def _render(self, *, offered_action, merge_request_web_url="", status_slug="needs-attention"):
+        item = {
+            "run_id": uuid.uuid4(),
+            "repo_id": "daiv/test",
+            "title": "boom",
+            "merge_request_iid": 9,
+            "merge_request_web_url": merge_request_web_url,
+            "thread_id": "thread-abc",
+            "created_at": timezone.now(),
+            "status_slug": status_slug,
+            "accent_var": "--color-status-attn",
+            "offered_action": offered_action,
+            "is_stale": False,
+        }
+        return render_to_string("accounts/_queue_item.html", {"item": item})
+
+    def test_review_with_url_links_to_mr_new_tab(self):
+        url = "https://gitlab.example.com/daiv/test/-/merge_requests/9"
+        html = self._render(offered_action=OfferedAction.REVIEW, merge_request_web_url=url)
+        assert f'href="{url}"' in html
+        assert 'target="_blank"' in html
+        assert 'data-action="review"' in html
+
+    def test_review_without_url_links_to_run_page(self):
+        html = self._render(offered_action=OfferedAction.REVIEW, merge_request_web_url="")
+        assert reverse("session_detail", kwargs={"thread_id": "thread-abc"}) in html
+        assert 'target="_blank"' not in html
+
+    def test_fix_links_to_run_page_not_mr(self):
+        url = "https://gitlab.example.com/daiv/test/-/merge_requests/9"
+        html = self._render(offered_action=OfferedAction.FIX, merge_request_web_url=url, status_slug="found-issues")
+        assert reverse("session_detail", kwargs={"thread_id": "thread-abc"}) in html
+        # FIX findings live on the run page — never the MR, even with a persisted url.
+        assert url not in html
+
+    def test_retry_links_to_run_page_not_mr(self):
+        url = "https://gitlab.example.com/daiv/test/-/merge_requests/9"
+        html = self._render(offered_action=OfferedAction.RETRY, merge_request_web_url=url, status_slug="failed")
+        assert reverse("session_detail", kwargs={"thread_id": "thread-abc"}) in html
+        assert url not in html
+        assert 'data-action="retry"' in html
+
+
+class TestQueueClickthroughRowOutLink:
+    """Patch 6: the MR out-link aria-label interpolates the iid, so it must never render '!None'."""
+
+    def _render(self, *, merge_request_iid, merge_request_web_url):
+        row = {
+            "repo_id": "daiv/test",
+            "title": "boom",
+            "merge_request_iid": merge_request_iid,
+            "merge_request_web_url": merge_request_web_url,
+            "thread_id": "thread-abc",
+            "created_at": timezone.now(),
+        }
+        return render_to_string("accounts/_queue_clickthrough_row.html", {"row": row})
+
+    def test_url_without_iid_omits_out_link_never_none(self):
+        # A web_url present but no iid must not render "open MR !None on GitLab" — the out-link is gated.
+        html = self._render(
+            merge_request_iid=None, merge_request_web_url="https://gitlab.example.com/daiv/test/-/merge_requests/9"
+        )
+        assert "!None" not in html
+        assert "open MR" not in html  # the whole out-link is omitted
+
+    def test_url_with_iid_still_renders_out_link(self):
+        # The healthy path is unchanged: url + iid → a real out-link with the iid in its aria-label.
+        url = "https://gitlab.example.com/daiv/test/-/merge_requests/9"
+        html = self._render(merge_request_iid=9, merge_request_web_url=url)
+        assert f'href="{url}"' in html
+        assert "open MR !9 on GitLab" in html
+        assert "!None" not in html
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("_clear_queue_cache")
+class TestQueueDeterministicOrdering:
+    """Patch 5: same-``created_at`` candidates order by the ``("-created_at", "-id")`` convention."""
+
+    def test_same_created_at_rows_are_deterministic(self, member_client, member_user):
+        # Five FAILED API-job candidates sharing one ``created_at``. Without the ``-id`` tiebreak the
+        # DB order is unspecified and can reorder between HTMX re-renders; with it the order is stable
+        # and matches the explicit ``("-created_at", "-id")`` the rest of the codebase uses.
+        runs = [_make_queue_run(member_user, trigger=SessionOrigin.API_JOB, status=RunStatus.FAILED) for _ in range(5)]
+        pinned = timezone.now()
+        Run.objects.filter(pk__in=[r.pk for r in runs]).update(created_at=pinned)
+
+        first = [item["run_id"] for item in member_client.get(reverse("dashboard")).context["queue_items"]]
+        second = [item["run_id"] for item in member_client.get(reverse("dashboard")).context["queue_items"]]
+
+        assert len(first) == 5
+        assert first == second  # stable across re-renders
+        expected = list(
+            Run.objects.filter(pk__in=[r.pk for r in runs]).order_by("-created_at", "-id").values_list("id", flat=True)
+        )
+        assert first == expected
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("_clear_queue_cache")
+class TestQueueStaleTag:
+    """Passive-decay indication: a row older than QUEUE_DECAY_DAYS is tagged is_stale (no extra query)."""
+
+    def test_old_actionable_run_is_tagged_stale(self, member_client, member_user):
+        old = _make_queue_run(member_user, trigger=SessionOrigin.API_JOB, status=RunStatus.FAILED)
+        Run.objects.filter(pk=old.pk).update(created_at=timezone.now() - timedelta(days=30))
+        response = member_client.get(reverse("dashboard"))
+        assert response.context["queue_items"][0]["is_stale"] is True
+        assert 'data-testid="queue-item-stale"' in response.content.decode()
+
+    def test_recent_run_is_not_stale(self, member_client, member_user):
+        _make_queue_run(member_user, trigger=SessionOrigin.API_JOB, status=RunStatus.FAILED)
+        response = member_client.get(reverse("dashboard"))
+        assert response.context["queue_items"][0]["is_stale"] is False
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("_clear_queue_cache")
+class TestQueueReadOnly:
+    """Presentation-only: rendering the Queue creates/mutates nothing (no model, no migration path)."""
+
+    def test_render_writes_nothing(self, member_client, member_user):
+        _make_queue_run(member_user, trigger=SessionOrigin.MR_WEBHOOK, status=RunStatus.SUCCESSFUL, merge_request_iid=7)
+        before = (Run.objects.count(), RunEnvelope.objects.count(), Session.objects.count())
+        with patch(_LIVE_READ, return_value=MergeRequestState.OPEN):
+            member_client.get(reverse("dashboard"))
+        after = (Run.objects.count(), RunEnvelope.objects.count(), Session.objects.count())
+        assert before == after
+
+
+class TestQueueI18n:
+    """AC7: every new Queue string is {% translate %}/{% blocktranslate %}-wrapped (source read)."""
+
+    def test_count_pill_is_translated(self):
+        src = Path(get_template("accounts/_console_body.html").origin.name).read_text(encoding="utf-8")
+        assert "{% blocktranslate count n=queue_count %}you have {{ n }}" in src
+
+    def test_queue_item_verbs_are_translated(self):
+        src = Path(get_template("accounts/_queue_item.html").origin.name).read_text(encoding="utf-8")
+        assert '{% translate "Review" %}' in src
+        assert '{% translate "Fix" %}' in src
+        assert '{% translate "Retry" %}' in src
+        assert '{% translate "View run" %}' in src
+        assert '{% translate "needs attention" %}' in src
+
+    def test_queue_zero_state_is_translated(self):
+        src = Path(get_template("accounts/_queue_zero_state.html").origin.name).read_text(encoding="utf-8")
+        assert '{% translate "nothing needs you." %}' in src
+        assert '{% translate "No runs yet." %}' in src

--- a/tests/unit_tests/accounts/test_views.py
+++ b/tests/unit_tests/accounts/test_views.py
@@ -752,4 +752,6 @@ class TestFeedRenderDelta:
         assert "text-text-muted" in badge  # neutral/muted, mono
         assert "teal" not in badge
         assert "accent" not in badge
-        assert "you have" not in content.lower()
+        # The "you have N" phrasing belongs to the Queue count pill (Story 4.1), which now renders on
+        # the same page — so scope the check to the badge: the FEED badge must not adopt that wording.
+        assert "you have" not in badge.lower()

--- a/tests/unit_tests/sessions/test_queue.py
+++ b/tests/unit_tests/sessions/test_queue.py
@@ -1,0 +1,128 @@
+"""Story 4.2 — the pure impact-class ranking framework (``sessions/queue.py``).
+
+Mirrors ``tests/unit_tests/sessions/test_reconcile.py``: a pure domain module, sync + read-only,
+tested with synthetic inputs. The top three impact classes are production-unreachable in v1 (their
+signals are deferred), so AC3 is proven at the **framework level** — constructing one item of each
+class directly and asserting the ordinal sequence holds — while the v1 classifier maps every real
+item to ``PASSIVE_DECAY`` (AC2, NFR1: no fabricated blocking signal).
+"""
+
+import uuid
+from datetime import timedelta
+from unittest.mock import patch
+
+from django.utils import timezone
+
+from sessions.models import EnvelopeStatus, Run, RunEnvelope, RunStatus
+from sessions.queue import QUEUE_DECAY_STALE_AFTER, QueueImpactClass, impact_class, order_queue
+
+from codebase.base import MergeRequestState
+
+# The single live-read seam (mirrors test_reconcile / the console tests): ``order_queue`` must never
+# reach it — ordering is pure over already-fetched data (AC8).
+_LIVE_READ = "codebase.mr_state.get_merge_request_state"
+
+
+def _item(impact: QueueImpactClass, age_at, run_id=None) -> dict:
+    """A minimal Queue item carrying only the two ordering keys ``_build_queue_item`` attaches."""
+    return {"run_id": run_id or uuid.uuid4(), "impact_class": impact, "age_at": age_at}
+
+
+class TestQueueImpactClassOrdinal:
+    """AC1: a first-class ordinal ranking, most-urgent first — never failures-first."""
+
+    def test_ordered_is_the_canonical_most_urgent_first_sequence(self):
+        assert QueueImpactClass.ordered() == (
+            QueueImpactClass.SOMEONE_ELSE_BLOCKED,
+            QueueImpactClass.MERGEABLE_BUT_BROKEN,
+            QueueImpactClass.AGENT_IDLE,
+            QueueImpactClass.PASSIVE_DECAY,
+        )
+
+    def test_rank_is_ascending_with_urgency(self):
+        ranks = [c.rank for c in QueueImpactClass.ordered()]
+        assert ranks == sorted(ranks)
+        # The load-bearing invariant (FR-11): a blocking class outranks the passive-decay floor.
+        assert QueueImpactClass.SOMEONE_ELSE_BLOCKED.rank < QueueImpactClass.PASSIVE_DECAY.rank
+
+
+class TestOrderQueue:
+    """AC1, AC3, AC4, AC8 — the pure re-sequence."""
+
+    def test_blocking_class_ranks_above_an_older_passive_decay_failure(self):
+        # AC3 (framework level): a blocking item outranks a non-blocking failure REGARDLESS of age —
+        # a fresh blocking item still beats a 30-day-old failed run. Proves "not failures-first".
+        now = timezone.now()
+        old_failure = _item(QueueImpactClass.PASSIVE_DECAY, now - timedelta(days=30))
+        fresh_blocking = _item(QueueImpactClass.SOMEONE_ELSE_BLOCKED, now)
+        ordered = order_queue([old_failure, fresh_blocking])
+        assert [it["run_id"] for it in ordered] == [fresh_blocking["run_id"], old_failure["run_id"]]
+
+    def test_full_class_sequence_holds(self):
+        # AC1/AC3: one item per class, shuffled in -> exact ordinal sequence out.
+        now = timezone.now()
+        items = [
+            _item(QueueImpactClass.PASSIVE_DECAY, now),
+            _item(QueueImpactClass.AGENT_IDLE, now),
+            _item(QueueImpactClass.SOMEONE_ELSE_BLOCKED, now),
+            _item(QueueImpactClass.MERGEABLE_BUT_BROKEN, now),
+        ]
+        assert [it["impact_class"] for it in order_queue(items)] == list(QueueImpactClass.ordered())
+
+    def test_passive_decay_sorts_most_aged_first(self):
+        # AC4: within a class, oldest (most-stale) on top — the v1 observable ordering.
+        now = timezone.now()
+        newer = _item(QueueImpactClass.PASSIVE_DECAY, now - timedelta(days=1))
+        older = _item(QueueImpactClass.PASSIVE_DECAY, now - timedelta(days=10))
+        ordered = order_queue([newer, older])
+        assert [it["run_id"] for it in ordered] == [older["run_id"], newer["run_id"]]
+
+    def test_sort_is_stable_for_ties(self):
+        # Equal (rank, age) keep incoming order (Python's stable sort) — deterministic re-renders.
+        now = timezone.now()
+        a, b, c = (_item(QueueImpactClass.PASSIVE_DECAY, now) for _ in range(3))
+        ordered = order_queue([a, b, c])
+        assert [it["run_id"] for it in ordered] == [a["run_id"], b["run_id"], c["run_id"]]
+
+    def test_order_queue_performs_no_live_read(self):
+        # AC8: ordering is pure — it must not reach the live MR-state read.
+        now = timezone.now()
+        items = [_item(QueueImpactClass.PASSIVE_DECAY, now - timedelta(days=i)) for i in range(3)]
+        with patch(_LIVE_READ) as read:
+            order_queue(items)
+        read.assert_not_called()
+
+    def test_order_queue_does_not_mutate_its_input(self):
+        now = timezone.now()
+        items = [_item(QueueImpactClass.PASSIVE_DECAY, now - timedelta(days=i)) for i in range(3)]
+        snapshot = list(items)
+        order_queue(items)
+        assert items == snapshot  # a new list is returned; the incoming order is untouched
+
+    def test_empty_queue_orders_to_empty(self):
+        assert order_queue([]) == []
+
+
+class TestImpactClassV1:
+    """AC2, NFR1 — v1 signals substantiate ONLY passive-decay; no fabricated top class."""
+
+    def test_failed_run_is_passive_decay(self):
+        assert impact_class(Run(status=RunStatus.FAILED), None) is QueueImpactClass.PASSIVE_DECAY
+
+    def test_open_mr_run_is_passive_decay(self):
+        run = Run(status=RunStatus.SUCCESSFUL, merge_request_iid=7)
+        env = RunEnvelope(status=EnvelopeStatus.NEEDS_ATTENTION)
+        # Even handed the live MR state, v1 must not promote an open MR to a blocking class.
+        assert impact_class(run, env, mr_state=MergeRequestState.OPEN) is QueueImpactClass.PASSIVE_DECAY
+
+    def test_found_issues_run_is_passive_decay(self):
+        run = Run(status=RunStatus.SUCCESSFUL)
+        env = RunEnvelope(status=EnvelopeStatus.FOUND_ISSUES)
+        assert impact_class(run, env) is QueueImpactClass.PASSIVE_DECAY
+
+
+class TestStalenessThreshold:
+    """AC4: the staleness threshold is a single module constant (the view imports it)."""
+
+    def test_threshold_is_seven_days(self):
+        assert timedelta(days=7) == QUEUE_DECAY_STALE_AFTER


### PR DESCRIPTION
## Epic 4 — the Needs-me Queue (Stories 4.1–4.2)

Stacked on `feat/epic-3-throughput-hero` (→ Epic 2 → `main`). This PR delivers **Stories 4.1–4.2**: the base Needs-me Queue, plus impact-based ordering and the passive-decay chip.

### What it does
One personal, prioritized **"you have N"** Needs-me Queue in the review console: the user's still-actionable **terminal** runs across three signal classes — **failed runs**, **DAIV-opened open MRs**, and **classifier-flagged** (`found-issues` / `needs-attention`) runs — each confirmed by Epic 3's shared `still_actionable` predicate, so the count, Queue, Feed, and bell badge cannot diverge.

- **Presentation-only** read over existing `Run`/`RunEnvelope` rows plus the Epic-3 cached live MR-state read — no new model, no migration.
- Single teal **count pill** (recolored `status-clear` green at zero) with a collapsed click-through reusing `_clickthrough.html`; per-status queue rows with exactly one **navigate-only** action slot (in-console actions arrive in Epic 5).
- First-class **"nothing needs you."** zero-state seal (`never-ran` vs `audited-clean`) with an honest, real-event-time audit line.
- **Impact-based ordering (Story 4.2)** behind one isolated sort seam, with a passive-decay chip so stale items visibly age.
- Personal scope via literal `session__user`; en + pt (pt-PT) strings.

### Scope boundaries (v1)
- View + click-through only — no in-console actions (Epic 5).
- The `someone-else-blocked`, `mergeable-but-broken`, and `agent-idle` (FR-12) classes stay empty by design.

### Review notes
Produced via the unattended dev loop, which caught and fixed several correctness issues over multiple review passes (terminal gate for in-flight runs; full-set reconciliation so the zero-state seal can't be a false negative; `is_retryable`-guarded RETRY; honest audit meta). **An independent follow-up review is recommended** given the turbulent history and the trust-surface nature of a couple of the fixes.

Four items were consciously **deferred** (tracked in `_bmad-output/implementation-artifacts/deferred-work.md`): the full-scan live-MR-read cost / real batching; the `session__user` vs `run.user` cross-surface scope question; a two-runs-one-MR over-count; and aria-live announce-on-swap for the count.
