### PR TITLE
fix(chat): continue on default branch when a thread's pinned ref is deleted, and stop async DB tests leaking rows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,13 @@ make makemessages && make compilemessages
 
 - Unit tests live in `tests/unit_tests/` mirroring `daiv/` structure.
 - `asyncio_mode = "auto"` — no need for `@pytest.mark.asyncio`.
+- **An async test that writes to the DB needs `django_db(transaction=True)`** (or the
+  `transactional_db` fixture), never plain `django_db`. Async ORM writes run on a thread-local
+  connection, not the one pytest-django wrapped in a rollback-only atomic block, so under plain
+  `django_db` they commit for real: the rows outlive the test and stay visible to every later test
+  in that xdist worker (breaking table-wide `.count()` assertions) until some later transactional
+  test's flush. The same collision can instead surface as `OperationalError: database table is
+  locked`, depending on what ran before — so treat either symptom as this bug.
 - Python **3.14 only** (`requires-python = ">=3.14,<3.15"`).
 - Never edit `pyproject.toml` directly; use `uv add <pkg>==<version>` / `uv remove <pkg>`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed a chat thread becoming permanently unusable once the merge request it opened was merged with source-branch deletion (GitLab's default). The thread stayed pinned to the deleted branch, so every later turn failed to clone it with an opaque "Run failed"; the branch pill is read-only on an existing thread, leaving no way to recover. Such a thread now continues on the repository default branch — where the merged work lives — and says so in the conversation. A branch the platform API still reports as present is treated as a transient advertisement miss and left as a hard error rather than silently retargeted.
 - Fixed the configured GitLab PAT being embedded in clone URLs, leaking the full-access credential into the workspace's `.git/config` and the sandbox: git clone/push now uses a short-lived, project-scoped token (see the GitLab token entry under Changed).
 - Fixed the agent failing to publish after a non-fast-forward push rejection, and failing when the source branch is protected (it now opens a new MR).
 - Fixed `web_fetch` to limit same-host redirects (max 5) and re-validate SSRF protection on each redirect, preventing redirect loops and DNS rebinding.

--- a/daiv/automation/agent/middlewares/git.py
+++ b/daiv/automation/agent/middlewares/git.py
@@ -202,11 +202,26 @@ class GitMiddleware(AgentMiddleware[GitState, RuntimeCtx]):
             # In this case, ignore the branch name and merge request ID from the state,
             # and use the source branch and merge request ID from the merge request.
             merge_request = runtime.context.merge_request
-        elif merge_request is None:
-            # Surface any pre-existing open MR on the current branch so the chat
-            # composer pill reflects reality from the very first turn. Issue-scope
-            # runs always start on the default branch, where this lookup short-circuits.
-            merge_request = await self._alookup_open_mr(runtime.context)
+        else:
+            current_ref = get_repo_ref(runtime.context.gitrepo)
+            if merge_request is not None and merge_request.source_branch != current_ref:
+                # The checkpointed MR belongs to a branch this run is not on — e.g. a chat thread
+                # whose pinned branch was deleted when that very MR merged, so the run fell back
+                # to the default branch. Carrying it forward would re-pin the session to the dead
+                # branch and make the publisher push HEAD to it (recreating it, silently attached
+                # to a merged MR). Same staleness rule ``_effective_mr_iid`` applies to the prompt.
+                logger.warning(
+                    "Dropping stale state MR #%s (source branch %s) — this run is on %s",
+                    merge_request.merge_request_id,
+                    merge_request.source_branch,
+                    current_ref,
+                )
+                merge_request = None
+            if merge_request is None:
+                # Surface any pre-existing open MR on the current branch so the chat
+                # composer pill reflects reality from the very first turn. Issue-scope
+                # runs always start on the default branch, where this lookup short-circuits.
+                merge_request = await self._alookup_open_mr(runtime.context)
 
         update: dict[str, Any] = {
             "merge_request": merge_request,

--- a/daiv/chat/api/streaming.py
+++ b/daiv/chat/api/streaming.py
@@ -20,6 +20,7 @@ from automation.agent.usage_tracking import build_usage_summary, track_usage_met
 from automation.agent.utils import build_langsmith_config, get_daiv_agent_kwargs
 from codebase.base import Scope
 from codebase.context import set_runtime_ctx
+from codebase.exceptions import RepositoryRefNotFoundError
 from core.checkpointer import open_checkpointer
 from core.constants import CANCELLED_BY_USER_MESSAGE, INTERRUPTED_MESSAGE, RUN_FAILED_MESSAGE
 
@@ -29,6 +30,7 @@ from .threads import ChatSessionService
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
+    from contextlib import AbstractAsyncContextManager
 
     from ag_ui.core import RunAgentInput
     from ag_ui.core.events import BaseEvent
@@ -138,6 +140,10 @@ class ChatRunStreamer:
     sandbox_environment_id: str | None = None
     agent_model: str | None = None
     agent_thinking_level: str | None = None
+    # True when this run created the ``Session`` row, i.e. it is the thread's first turn. Gates
+    # the missing-ref fallback: a ref the caller just chose is theirs to correct, only a ref the
+    # thread inherited (pinned by ``persist_ref``) is worth healing behind their back.
+    session_created: bool = False
     # When set, ``{id, name, scope}`` of the env the view auto-resolved for this run.
     # The chat composer's locked pill is still showing "Auto" on the client; the
     # streamer's first emit swaps it to the real name without waiting for a page
@@ -152,9 +158,28 @@ class ChatRunStreamer:
         if self.run_id != self.input_data.run_id:
             raise ValueError(f"run_id mismatch: {self.run_id!r} vs input_data {self.input_data.run_id!r}")
 
+    def _open_runtime_ctx(self, ref: str | None) -> AbstractAsyncContextManager[RuntimeCtx]:
+        """Open this run's runtime context at ``ref``; ``None`` means "resolve the default branch".
+
+        Delegating the ``None`` case to ``set_runtime_ctx`` keeps a single default-branch
+        resolution path — the streamer never re-derives it.
+        """
+        return set_runtime_ctx(
+            repo_id=self.repo_id,
+            scope=Scope.GLOBAL,
+            ref=ref,
+            sandbox_env_id=self.sandbox_environment_id,
+            acting_user_id=self.user_id,
+        )
+
     async def events(self) -> AsyncIterator[BaseEvent]:
         last_mr: MergeRequest | None = None
         clean_run = False
+        # The branch this turn actually runs on. Diverges from ``self.ref`` only when the pinned
+        # ref turns out to be gone from the remote and the run falls back to the default branch;
+        # ``missing_ref`` then names the dead branch so the end-of-run persist can't re-pin it.
+        effective_ref = self.ref
+        missing_ref: str | None = None
         # Set when the agent surfaces a failure. ``ag_ui_langgraph`` reports a LangGraph
         # stream error as a RUN_ERROR *event* and then returns normally (it does not raise),
         # so a clean loop exit is not sufficient proof of success — this flag is folded into
@@ -175,23 +200,62 @@ class ChatRunStreamer:
             # what would have run even if agent setup fails.
             if self.auto_resolved_env is not None:
                 yield CustomEvent(type=EventType.CUSTOM, name="resolved_env", value=self.auto_resolved_env)
-            async with (
-                open_checkpointer() as checkpointer,
-                set_runtime_ctx(
-                    repo_id=self.repo_id,
-                    scope=Scope.GLOBAL,
-                    ref=self.ref,
-                    sandbox_env_id=self.sandbox_environment_id,
-                    acting_user_id=self.user_id,
-                ) as runtime_ctx,
-            ):
+            async with contextlib.AsyncExitStack() as stack:
+                checkpointer = await stack.enter_async_context(open_checkpointer())
+                try:
+                    runtime_ctx = await stack.enter_async_context(self._open_runtime_ctx(effective_ref))
+                except RepositoryRefNotFoundError as err:
+                    if self.session_created:
+                        # First turn of a thread: the caller chose this ref moments ago and can
+                        # simply choose another, so an honest failure beats silently running
+                        # somewhere else. Surfaces through the generic handler (Sentry included),
+                        # which is what we want for a ref that never existed.
+                        raise
+                    # An established thread is pinned to a branch the remote no longer has —
+                    # overwhelmingly because the MR this thread opened was merged with
+                    # source-branch deletion (GitLab's default), so the work now lives on the
+                    # default branch. Retarget it for this turn and heal the stored ref: without
+                    # this, *every* later turn dies here, and the composer's branch pill is
+                    # read-only on an existing thread, so the user cannot repoint it themselves.
+                    # A second miss (the default branch is gone too) is a normal run failure.
+                    logger.warning(
+                        "chat: ref %s no longer exists in %s (thread_id=%s run_id=%s); falling back to the "
+                        "default branch. git said: %s",
+                        effective_ref,
+                        self.repo_id,
+                        self.thread_id,
+                        self.run_id,
+                        getattr(err.__cause__, "stderr", None) or err.__cause__,
+                        exc_info=err,
+                    )
+                    runtime_ctx = await stack.enter_async_context(self._open_runtime_ctx(None))
+                    if not (default_branch := runtime_ctx.config.default_branch):
+                        # Nothing to fall back *to* (e.g. an empty repository). Keep the original
+                        # error rather than inventing a ref name and persisting it.
+                        raise
+                    effective_ref = default_branch
+                    missing_ref = self.ref
+                    # The pill must not claim a heal that didn't land: on a write failure the
+                    # client keeps showing the old ref and words the notice as this-turn-only.
+                    ref_persisted = True
+                    try:
+                        await ChatSessionService.repoint_ref(self.thread_id, effective_ref)
+                    except Exception:
+                        ref_persisted = False
+                        # The turn can still run on the fallback branch; only the healing is lost.
+                        logger.exception("chat: failed to repoint session ref for thread_id=%s", self.thread_id)
+                    yield CustomEvent(
+                        type=EventType.CUSTOM,
+                        name="ref_fallback",
+                        value={"ref": effective_ref, "previous_ref": self.ref, "persisted": ref_persisted},
+                    )
                 # Record the turn as a RUNNING Run once we're committed to executing.
                 chat_run = await start_chat_run(
                     session_id=self.thread_id,
                     user_id=self.user_id,
                     prompt=self.prompt,
                     repo_id=self.repo_id,
-                    ref=self.ref,
+                    ref=effective_ref,
                     message_id=self.message_id,
                 )
                 agent_kwargs = get_daiv_agent_kwargs(
@@ -318,7 +382,9 @@ class ChatRunStreamer:
             succeeded = clean_run and run_error_message is None
             if succeeded:
                 try:
-                    await ChatSessionService.persist_ref(self.thread_id, self.ref, last_mr)
+                    await ChatSessionService.persist_ref(
+                        self.thread_id, effective_ref, last_mr, missing_ref=missing_ref
+                    )
                 except Exception:
                     logger.exception("chat: failed to persist session ref for thread_id=%s", self.thread_id)
             if chat_run is not None:

--- a/daiv/chat/api/threads.py
+++ b/daiv/chat/api/threads.py
@@ -112,15 +112,34 @@ class ChatSessionService:
         return session, created
 
     @staticmethod
-    async def persist_ref(thread_id: str, original_ref: str, mr: MergeRequest | dict | None) -> None:
+    async def persist_ref(
+        thread_id: str, original_ref: str, mr: MergeRequest | dict | None, *, missing_ref: str | None = None
+    ) -> None:
         """Sync ``Session.ref`` with the agent's final ``merge_request``.
 
         Accepts both a live ``MergeRequest`` instance and a dict (the snapshot
         gets rehydrated through the checkpointer as a plain dict, so resumed
         runs land here in dict shape).
+
+        ``missing_ref`` is a branch this run already proved absent from the remote; an MR pointing
+        at it is stale by definition and must never be pinned. ``GitMiddleware`` drops such an MR
+        before it can stream, so this is the belt-and-braces at the write itself — re-pinning it
+        would undo the very heal :meth:`repoint_ref` just performed.
         """
         if mr is None:
             return
         new_ref = mr.get("source_branch") if isinstance(mr, dict) else getattr(mr, "source_branch", None)
-        if new_ref and new_ref != original_ref:
+        if new_ref and new_ref != original_ref and new_ref != missing_ref:
             await Session.objects.filter(thread_id=thread_id).aupdate(ref=new_ref)
+
+    @staticmethod
+    async def repoint_ref(thread_id: str, ref: str) -> None:
+        """Retarget ``Session.ref`` at ``ref`` because the stored one is unusable.
+
+        Unlike :meth:`persist_ref` — which records where a *successful* run ended up — this heals
+        a ref the remote has already rejected as missing, so it is written immediately rather than
+        gated on the turn succeeding: the pinned branch is gone either way, and leaving it in place
+        would wedge every later turn (the composer's branch pill is read-only on an existing
+        thread, so the user could not repoint it themselves).
+        """
+        await Session.objects.filter(thread_id=thread_id).aupdate(ref=ref)

--- a/daiv/chat/api/views.py
+++ b/daiv/chat/api/views.py
@@ -278,6 +278,7 @@ async def create_chat_completion(request: HttpRequest, input_data: RunAgentInput
         agent_model=session.agent_model or None,
         agent_thinking_level=session.agent_thinking_level or None,
         auto_resolved_env=auto_resolved_env,
+        session_created=created,
     )
     # The run is detached from this request: it executes as a background task
     # and publishes to the relay, so a client disconnect no longer kills it.

--- a/daiv/chat/static/chat/js/chat-stream.js
+++ b/daiv/chat/static/chat/js/chat-stream.js
@@ -411,7 +411,11 @@
     // ---------- Derived getters (right rail) ---------------------------
 
     get runStatus() {
-      const last = this.turns[this.turns.length - 1];
+      // Skip trailing notices: they are informational, never a run outcome, so they must
+      // neither paint the rail red nor reach the segment scan below (they carry no segments).
+      let i = this.turns.length - 1;
+      while (i >= 0 && this.turns[i].status === "notice") i--;
+      const last = this.turns[i];
       if (last?.role === "run_status") {
         return last.status === "aborted"
           ? { tone: "idle", label: "stopped" }
@@ -853,6 +857,24 @@
         } else if (this.selectedSandboxEnvId) {
           console.debug("chat: ignored resolved_env (user picked %o)", this.selectedSandboxEnvId, v);
         }
+      } else if (type === AGUI.CUSTOM && evt.name === "ref_fallback") {
+        // The branch this thread was pinned to is gone from the remote (usually its own MR
+        // was merged with source-branch deletion) and the run retargeted the default branch.
+        // Move the pill to match what actually ran and say why — the pill alone changing
+        // would look like the agent silently switched branches.
+        const v = evt.value || {};
+        if (v.ref) {
+          // Move the pill only when the server persisted the new ref; otherwise the pill would
+          // claim a heal the DB doesn't have and silently revert on the next page load.
+          if (v.persisted !== false) {
+            this._applyRepoState({ ref: v.ref });
+            this._pushNotice(`Branch ${v.previous_ref || "?"} no longer exists — continuing on ${v.ref}.`);
+          } else {
+            this._pushNotice(
+              `Branch ${v.previous_ref || "?"} no longer exists — running this turn on ${v.ref}.`,
+            );
+          }
+        }
       } else if (type === AGUI.STATE_SNAPSHOT) {
         // Snapshots fire on every node exit and almost always carry an
         // unchanged merge_request. Dedupe on identity so we don't churn
@@ -914,6 +936,19 @@
     _hasRunStatusMarker() {
       const runId = this._activeRun ? this._activeRun.runId : null;
       return runId != null && this.turns.some((t) => t.id === `run-status-${runId}`);
+    },
+
+    _pushNotice(message) {
+      // Informational sibling of `_pushRunStatus`, deliberately keyed apart from
+      // `run-status-${runId}`: a notice must neither be overwritten by this run's terminal
+      // status nor count as the run-status marker `_finishTurn` looks for. Client-only —
+      // it explains a mid-run decision and is not replayed on reload (the composer pill,
+      // which the server persisted, carries the outcome across refreshes).
+      const runId = this._activeRun ? this._activeRun.runId : uuid();
+      const id = `run-notice-${runId}`;
+      if (this.turns.some((t) => t.id === id)) return;
+      this.turns.push({ id, role: "run_status", status: "notice", message });
+      this.scrollToBottom();
     },
 
     _appendTextSegment(turn, content) {

--- a/daiv/codebase/clients/base.py
+++ b/daiv/codebase/clients/base.py
@@ -209,6 +209,23 @@ class RepoClient(abc.ABC):
         pass
 
     @abc.abstractmethod
+    def branch_exists(self, repo_id: str, branch: str) -> bool | None:
+        """
+        Return whether ``branch`` currently exists on the remote.
+
+        Three-valued on purpose: ``None`` means the platform could not answer (API or transport
+        failure) and must not be read as either presence or absence. Callers that act
+        destructively on absence — see :func:`codebase.clients.utils.translate_missing_ref` —
+        require the definite ``False``, so an unreachable platform is never mistaken for a
+        deleted branch.
+
+        Args:
+            repo_id: The repository ID.
+            branch: The branch name to check.
+        """
+        pass
+
+    @abc.abstractmethod
     def list_branches(self, repo_id: str, search: str | None = None, limit: int = 20) -> list[str]:
         """
         Return up to ``limit`` branch names for ``repo_id``.

--- a/daiv/codebase/clients/github/client.py
+++ b/daiv/codebase/clients/github/client.py
@@ -182,6 +182,26 @@ class GitHubClient(RepoClient):
             logger.warning("Failed to check protection for %s@%s; assuming unprotected", repo_id, branch, exc_info=True)
             return False
 
+    def branch_exists(self, repo_id: str, branch: str) -> bool | None:
+        """
+        Resolve existence via ``GET /repos/{owner}/{repo}/branches/{branch}``.
+
+        Only a 404 counts as "absent"; any other failure returns ``None`` (unknown) so callers
+        never read an API outage as a deleted branch.
+        """
+        repo = self.client.get_repo(repo_id, lazy=True)
+        try:
+            repo.get_branch(branch)
+        except GithubException as e:
+            if e.status == 404:
+                return False
+            logger.warning("Could not determine whether %s@%s exists", repo_id, branch, exc_info=True)
+            return None
+        except Exception:  # noqa: BLE001 — transport errors (TLS, DNS, reset) are also "unknown"
+            logger.warning("Could not determine whether %s@%s exists", repo_id, branch, exc_info=True)
+            return None
+        return True
+
     def list_branches(self, repo_id: str, search: str | None = None, limit: int = 20) -> list[str]:
         """
         Return up to ``limit`` branch names. GitHub's branches endpoint has no server-side
@@ -280,9 +300,12 @@ class GitHubClient(RepoClient):
 
         Yields:
             The repository object cloned to the temporary directory.
+
+        Raises:
+            RepositoryRefNotFoundError: If ``sha`` is a branch the remote no longer has.
         """
         from codebase.clients.base import GitAuthEnv
-        from codebase.clients.utils import safe_slug
+        from codebase.clients.utils import safe_slug, translate_missing_ref
 
         with tempfile.TemporaryDirectory(prefix=f"{safe_slug(repository.slug)}-{repository.pk}") as tmpdir:
             logger.debug("Cloning repository %s to %s", repository.clone_url, tmpdir)
@@ -293,12 +316,13 @@ class GitHubClient(RepoClient):
             token = self._mint_installation_token(repository)
             clone_dir = Path(tmpdir) / "repo"
             clone_dir.mkdir(exist_ok=True)
-            repo = Repo.clone_from(
-                repository.clone_url,
-                clone_dir,
-                branch=sha,
-                env=GitAuthEnv.for_token(repository.clone_url, token).as_env(),
-            )
+            with translate_missing_ref(self, repository.slug, sha):
+                repo = Repo.clone_from(
+                    repository.clone_url,
+                    clone_dir,
+                    branch=sha,
+                    env=GitAuthEnv.for_token(repository.clone_url, token).as_env(),
+                )
             self._configure_commit_identity(repo)
             yield repo
 

--- a/daiv/codebase/clients/gitlab/client.py
+++ b/daiv/codebase/clients/gitlab/client.py
@@ -268,6 +268,26 @@ class GitLabClient(RepoClient):
             logger.warning("Failed to check protection for %s@%s; assuming unprotected", repo_id, branch, exc_info=True)
             return False
 
+    def branch_exists(self, repo_id: str, branch: str) -> bool | None:
+        """
+        Resolve existence via ``GET /projects/:id/repository/branches/:branch``.
+
+        Only a 404 counts as "absent"; any other failure returns ``None`` (unknown) so callers
+        never read an API outage as a deleted branch.
+        """
+        project = self.client.projects.get(repo_id, lazy=True)
+        try:
+            project.branches.get(branch)
+        except GitlabError as e:
+            if e.response_code == 404:
+                return False
+            logger.warning("Could not determine whether %s@%s exists", repo_id, branch, exc_info=True)
+            return None
+        except Exception:  # noqa: BLE001 — transport errors (TLS, DNS, reset) are also "unknown"
+            logger.warning("Could not determine whether %s@%s exists", repo_id, branch, exc_info=True)
+            return None
+        return True
+
     def list_branches(self, repo_id: str, search: str | None = None, limit: int = 20) -> list[str]:
         """
         Return up to ``limit`` branch names, optionally filtered by server-side substring ``search``.
@@ -394,14 +414,18 @@ class GitLabClient(RepoClient):
 
         Yields:
             The repository object cloned to the temporary directory.
+
+        Raises:
+            RepositoryRefNotFoundError: If ``sha`` is a branch the remote no longer has.
         """
-        from codebase.clients.utils import safe_slug
+        from codebase.clients.utils import safe_slug, translate_missing_ref
 
         with tempfile.TemporaryDirectory(prefix=f"{safe_slug(repository.slug)}-{repository.pk}") as tmpdir:
             logger.debug("Cloning repository %s to %s", repository.clone_url, tmpdir)
 
             clone_dir = Path(tmpdir) / "repo"
-            repo = self._clone(repository, sha, clone_dir)
+            with translate_missing_ref(self, repository.slug, sha):
+                repo = self._clone(repository, sha, clone_dir)
             self._configure_commit_identity(repo)
             yield repo
 

--- a/daiv/codebase/clients/swe.py
+++ b/daiv/codebase/clients/swe.py
@@ -112,6 +112,10 @@ class SWERepoClient(RepoClient):
         """SWE sandbox repos have no remote branch protection."""
         return False
 
+    def branch_exists(self, repo_id: str, branch: str) -> bool | None:
+        """Unknown: SWE eval clones are SHA-pinned and have no branch API to consult."""
+        return None
+
     def list_branches(self, repo_id: str, search: str | None = None, limit: int = 20) -> list[str]:
         """List branches is not supported for SWE client."""
         raise NotImplementedError("SWERepoClient does not support listing branches")

--- a/daiv/codebase/clients/utils.py
+++ b/daiv/codebase/clients/utils.py
@@ -1,9 +1,70 @@
 import re
+from contextlib import contextmanager
+from typing import TYPE_CHECKING
+
+from git import GitCommandError
 
 from codebase.base import GitPlatform
+from codebase.exceptions import RepositoryRefNotFoundError
 
 from .github.utils import extract_last_command_from_github_logs, strip_iso_timestamps
 from .gitlab.utils import extract_last_command_from_gitlab_logs, replace_section_start_and_end_markers
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from codebase.clients.base import RepoClient
+
+
+_COMMIT_SHA_RE = re.compile(r"[0-9a-f]{7,40}")
+
+
+def _is_missing_ref_error(error: GitCommandError) -> bool:
+    """True when a clone failed because the requested ref was absent from the remote's advertisement.
+
+    ``git clone --branch=<ref>`` reports the miss as ``fatal: Remote branch <ref> not found in
+    upstream origin``, sometimes preceded by ``warning: Could not find remote branch <ref> to
+    clone.`` — match both wordings, and neither the ref name nor the remote name, so the check
+    survives git's phrasing differences across versions and transports. Only ``stderr`` is
+    searched: ``str(error)`` also carries the cmdline (which embeds ``--branch=<ref>``) and
+    stdout, and widening the haystack buys nothing these two markers don't already cover.
+    """
+    lowered = (error.stderr or "").lower()
+    return "not found in upstream" in lowered or "could not find remote branch" in lowered
+
+
+@contextmanager
+def translate_missing_ref(client: RepoClient, repo_id: str, ref: str) -> Iterator[None]:
+    """Re-raise a *confirmed* missing-branch clone failure as :class:`RepositoryRefNotFoundError`.
+
+    Wraps the clone in both platform clients so a vanished ref reaches callers as an actionable,
+    recoverable condition (retarget the default branch) rather than an opaque git failure. Every
+    other ``GitCommandError`` — notably auth rejections, which have their own propagation-retry
+    and token self-heal path in the GitLab client — propagates untouched.
+
+    git's wording is necessary but **not sufficient** evidence: it says the ref was absent from
+    the advertisement this credential received, which is also what a replication lag, a
+    restricted ref view, or a stale proxy looks like. This instance is already known to report a
+    just-pushed branch as missing for a window (see
+    ``MERGE_REQUEST_BRANCH_VISIBILITY_RETRY_BACKOFF_SECONDS``), and acting on a false positive is
+    destructive — the chat fallback rewrites the session's stored ref. So the platform API must
+    also say the branch is gone; an unknown answer (``None``, i.e. the API could not be reached)
+    keeps the raw git error.
+
+    A SHA-shaped ref is excluded too: ``--branch`` resolves branches and tags but never a commit
+    SHA, so the same message there means "that isn't a branch", not "it was deleted" — and
+    callers may legitimately pin a SHA (the MCP ``submit_job`` contract allows one).
+    """
+    try:
+        yield
+    except GitCommandError as e:
+        if (
+            _is_missing_ref_error(e)
+            and _COMMIT_SHA_RE.fullmatch(ref) is None
+            and client.branch_exists(repo_id, ref) is False
+        ):
+            raise RepositoryRefNotFoundError(repo_id, ref) from e
+        raise
 
 
 def _clean_ansi_codes(log: str) -> str:

--- a/daiv/codebase/exceptions.py
+++ b/daiv/codebase/exceptions.py
@@ -1,3 +1,19 @@
+class RepositoryRefNotFoundError(Exception):
+    """Raised when a clone targets a ref the remote no longer has.
+
+    Kept distinct from the raw ``GitCommandError`` so callers can act on "the branch is gone"
+    instead of treating it as an opaque git failure. The case that motivated it: a chat session
+    is pinned to the source branch of the MR it opened (``ChatSessionService.persist_ref``), and
+    merging that MR with source-branch deletion — GitLab's default — leaves every later turn
+    cloning a branch that no longer exists.
+    """
+
+    def __init__(self, repo_id: str, ref: str) -> None:
+        super().__init__(f"Ref {ref!r} no longer exists in repository {repo_id!r}.")
+        self.repo_id = repo_id
+        self.ref = ref
+
+
 class SingleRepoRequiredError(RuntimeError):
     """Raised when a ``RuntimeCtx`` is constructed or accessed without exactly one repo handle.
 

--- a/daiv/sessions/templates/sessions/session_detail.html
+++ b/daiv/sessions/templates/sessions/session_detail.html
@@ -177,7 +177,8 @@
                 <div class="chat-run-status" :class="`chat-run-status--${turn.status}`" role="status" aria-live="polite">
                   <span class="chat-run-status__icon" aria-hidden="true">
                     <template x-if="turn.status === 'aborted'">{% icon "x-mark" "h-4 w-4" %}</template>
-                    <template x-if="turn.status !== 'aborted'">{% icon "exclamation-triangle" "h-4 w-4" %}</template>
+                    <template x-if="turn.status === 'notice'">{% icon "information-circle" "h-4 w-4" %}</template>
+                    <template x-if="turn.status !== 'aborted' && turn.status !== 'notice'">{% icon "exclamation-triangle" "h-4 w-4" %}</template>
                   </span>
                   <span class="chat-run-status__text" x-text="turn.message"></span>
                 </div>

--- a/daiv/sessions/transcript.py
+++ b/daiv/sessions/transcript.py
@@ -19,9 +19,12 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger("daiv.sessions")
 
-# Closed value set for a run-status marker's ``status`` key: ``failed`` renders the red
-# error chip, ``aborted`` the neutral "stopped" one. Mirrored client-side in
-# ``chat-stream.js`` (``_pushRunStatus``) — keep the two in sync. (Markers stay plain
+# Closed value set for a *replayed* run-status marker's ``status`` key: ``failed`` renders the
+# red error chip, ``aborted`` the neutral "stopped" one. Mirrored client-side in
+# ``chat-stream.js`` (``_pushRunStatus``) — keep the two in sync. The client has one further
+# status, ``notice`` (``_pushNotice``), which is deliberately absent here: notices explain a
+# decision taken mid-run and are not reconstructible from a ``Run`` row, so they are live-only.
+# Adding one to this set means giving it a durable source first. (Markers stay plain
 # ``dict[str, Any]`` to interleave with ``chat.turns.build_turns`` output and serialise
 # straight into the Alpine-rendered turns payload; the shape is ``id``/``role``/``status``/
 # ``message``.)

--- a/daiv/static_src/css/input.css
+++ b/daiv/static_src/css/input.css
@@ -905,6 +905,9 @@ main:has(.chat-shell) {
   .chat-run-status--aborted {
     @apply border-white/10 bg-white/[0.03] text-gray-400;
   }
+  .chat-run-status--notice {
+    @apply border-blue-400/25 bg-blue-500/[0.08] text-blue-200;
+  }
 
   .chat-text :where(p, ul, ol, pre, blockquote, h1, h2, h3, h4, h5, h6, hr, table, dl) {
     margin: 0 0 0.65rem 0;

--- a/tests/unit_tests/automation/agent/middlewares/test_git.py
+++ b/tests/unit_tests/automation/agent/middlewares/test_git.py
@@ -217,6 +217,32 @@ class TestGitMiddleware:
         lookup.assert_not_called()
         assert result["merge_request"] is state_mr
 
+    async def test_abefore_agent_drops_state_mr_whose_source_branch_is_not_the_current_ref(self):
+        """A checkpointed MR for a branch this run is not on is stale and must not carry forward.
+
+        Reachable whenever the pinned branch disappears: the chat ref fallback retargets the
+        default branch after a merged MR's source branch is deleted, and the checkpoint still
+        holds that merged MR. Keeping it would re-pin the session to the dead branch (via
+        ``persist_ref``, which reads the streamed MR) and make the publisher push HEAD to
+        ``merge_request.source_branch`` — recreating the deleted branch, silently attached to an
+        already-merged MR, with no new MR opened for the work.
+        """
+        middleware = GitMiddleware()
+        runtime = _make_runtime(scope=Scope.GLOBAL)
+        stale_state_mr = _mr(branch="chore/merged-and-deleted")
+
+        with (
+            patch("automation.agent.middlewares.git.get_repo_ref", return_value="main"),
+            patch(
+                "automation.agent.middlewares.git.GitMiddleware._alookup_open_mr", new=AsyncMock(return_value=None)
+            ) as lookup,
+        ):
+            result = await middleware.abefore_agent({"merge_request": stale_state_mr}, runtime)
+
+        # Falls through to the open-MR lookup for the branch actually checked out.
+        lookup.assert_awaited_once_with(runtime.context)
+        assert result["merge_request"] is None
+
     async def test_abefore_agent_runtime_context_overrides_state_in_mr_scope(self):
         middleware = GitMiddleware()
         runtime = _make_runtime(scope=Scope.MERGE_REQUEST)

--- a/tests/unit_tests/chat/api/test_streaming.py
+++ b/tests/unit_tests/chat/api/test_streaming.py
@@ -17,6 +17,7 @@ import pytest
 from ag_ui.core.events import EventType, StateSnapshotEvent, TextMessageContentEvent
 
 from chat.api.streaming import ChatRunStreamer, RuntimeContextLangGraphAGUIAgent
+from codebase.exceptions import RepositoryRefNotFoundError
 
 
 @pytest.fixture(autouse=True)
@@ -83,7 +84,7 @@ async def test_events_captures_merge_request_from_state_snapshot_and_persists_re
     persist_calls = []
     release_calls = []
 
-    async def _capture_persist(thread_id, original_ref, captured_mr):
+    async def _capture_persist(thread_id, original_ref, captured_mr, **_kwargs):
         persist_calls.append((thread_id, original_ref, captured_mr))
 
     async def _capture_release(thread_id, run_id):
@@ -126,7 +127,7 @@ async def test_events_captures_latest_merge_request_when_multiple_snapshots():
 
     persist_calls = []
 
-    async def _capture_persist(thread_id, original_ref, captured_mr):
+    async def _capture_persist(thread_id, original_ref, captured_mr, **_kwargs):
         persist_calls.append((thread_id, original_ref, captured_mr))
 
     with (
@@ -156,7 +157,7 @@ async def test_events_persists_none_when_no_state_snapshot_carries_merge_request
 
     persist_calls = []
 
-    async def _capture_persist(thread_id, original_ref, captured_mr):
+    async def _capture_persist(thread_id, original_ref, captured_mr, **_kwargs):
         persist_calls.append((thread_id, original_ref, captured_mr))
 
     with (
@@ -196,7 +197,7 @@ async def test_events_skips_persist_ref_when_run_errored():
     persist_calls: list = []
     release_calls: list = []
 
-    async def _capture_persist(*args):
+    async def _capture_persist(*args, **_kwargs):
         persist_calls.append(args)
 
     async def _capture_release(*args):
@@ -272,7 +273,7 @@ async def test_events_finalizes_failed_when_run_error_event_emitted():
 
     persist_calls: list = []
 
-    async def _capture_persist(*args):
+    async def _capture_persist(*args, **_kwargs):
         persist_calls.append(args)
 
     streamed_events: list = []
@@ -606,3 +607,187 @@ async def test_events_buffers_text_deltas_into_result_summary():
     assert captured["success"] is True
     assert captured["response_text"].startswith("Hello ")
     assert len(captured["response_text"]) == 2000  # truncated at the cap
+
+
+class TestMissingRefFallback:
+    """A session pinned to a branch that no longer exists must not wedge the thread.
+
+    ``persist_ref`` retargets ``Session.ref`` at the MR's source branch so follow-up turns
+    continue on it; when that MR is merged with source-branch deletion (GitLab's default),
+    the branch is gone and every later turn's clone fails. The run falls back to the
+    repository default branch instead of dying with an opaque "Run failed".
+    """
+
+    @staticmethod
+    def _ctx_factory(failures: int, default_branch: str = "dev"):
+        """``set_runtime_ctx`` stand-in raising ``RepositoryRefNotFoundError`` on entry for the
+        first ``failures`` calls, then yielding a ctx whose config reports ``default_branch``.
+        Records the ``ref=`` each call was made with.
+        """
+        refs: list = []
+
+        def _factory(*_args, **kwargs):
+            refs.append(kwargs.get("ref"))
+            attempt = len(refs)
+            ctx = MagicMock()
+
+            # ``AsyncExitStack`` resolves ``__aenter__`` on the type and calls it with the
+            # context manager as the first argument — hence ``*_args``.
+            async def _aenter(*_args):
+                if attempt <= failures:
+                    raise RepositoryRefNotFoundError("a/b", str(kwargs.get("ref")))
+                resolved = MagicMock()
+                resolved.config.default_branch = default_branch
+                return resolved
+
+            ctx.__aenter__ = AsyncMock(side_effect=_aenter)
+            ctx.__aexit__ = AsyncMock(return_value=None)
+            return ctx
+
+        return _factory, refs
+
+    @pytest.mark.django_db(transaction=True)
+    async def test_falls_back_to_default_branch_and_repoints_session(self):
+        ctx_factory, refs = self._ctx_factory(failures=1)
+        started: dict = {}
+        repointed: list = []
+
+        async def _capture_start(**kwargs):
+            started.update(kwargs)
+            return SimpleNamespace(pk="run-pk")
+
+        async def _capture_repoint(thread_id, ref):
+            repointed.append((thread_id, ref))
+
+        persisted: list = []
+
+        async def _capture_persist(thread_id, original_ref, mr, *, missing_ref=None):
+            persisted.append((thread_id, original_ref, mr, missing_ref))
+
+        with (
+            patch("chat.api.streaming.open_checkpointer", _mock_ctx),
+            patch("chat.api.streaming.set_runtime_ctx", ctx_factory),
+            patch("chat.api.streaming.start_chat_run", side_effect=_capture_start),
+            patch("chat.api.streaming.create_daiv_agent", new=AsyncMock()),
+            patch("chat.api.streaming.RuntimeContextLangGraphAGUIAgent", return_value=_mock_agent([])),
+            patch("chat.api.streaming.ChatSessionService.repoint_ref", side_effect=_capture_repoint),
+            patch("chat.api.streaming.ChatSessionService.persist_ref", side_effect=_capture_persist),
+            patch("chat.api.streaming.SessionLock.release", new=AsyncMock()),
+            patch("chat.api.streaming.SessionLock.heartbeat", new=AsyncMock()),
+        ):
+            events = [e async for e in _streamer().events()]
+
+        # First attempt uses the pinned ref; the retry passes ref=None so set_runtime_ctx
+        # resolves the default branch itself (no duplicated resolution in the streamer).
+        assert refs == ["main", None]
+        # No RUN_ERROR: the turn ran.
+        assert not [e for e in events if e.type == EventType.RUN_ERROR]
+        # The user is told the base moved, and the stored ref is healed so the composer pill
+        # and every later turn stop pointing at the deleted branch.
+        notices = [e for e in events if e.type == EventType.CUSTOM and e.name == "ref_fallback"]
+        assert [n.value for n in notices] == [{"ref": "dev", "previous_ref": "main", "persisted": True}]
+        assert repointed == [("t-stream", "dev")]
+        # The Run row records the branch that actually ran, not the dead one.
+        assert started["ref"] == "dev"
+        # End-of-run persistence compares against the branch that ran, and is told which ref was
+        # proven missing — otherwise a checkpointed MR for the dead branch would be written
+        # straight back, undoing the heal.
+        assert persisted == [("t-stream", "dev", None, "main")]
+
+    @pytest.mark.django_db(transaction=True)
+    async def test_fallback_reports_when_the_heal_could_not_be_persisted(self):
+        """A failed ``repoint_ref`` must not let the client claim a heal the DB doesn't have —
+        the pill would silently revert on the next page load."""
+        ctx_factory, _ = self._ctx_factory(failures=1)
+
+        with (
+            patch("chat.api.streaming.open_checkpointer", _mock_ctx),
+            patch("chat.api.streaming.set_runtime_ctx", ctx_factory),
+            patch("chat.api.streaming.create_daiv_agent", new=AsyncMock()),
+            patch("chat.api.streaming.RuntimeContextLangGraphAGUIAgent", return_value=_mock_agent([])),
+            patch("chat.api.streaming.ChatSessionService.repoint_ref", side_effect=RuntimeError("db down")),
+            patch("chat.api.streaming.ChatSessionService.persist_ref", new=AsyncMock()),
+            patch("chat.api.streaming.SessionLock.release", new=AsyncMock()),
+            patch("chat.api.streaming.SessionLock.heartbeat", new=AsyncMock()),
+        ):
+            events = [e async for e in _streamer().events()]
+
+        notices = [e for e in events if e.type == EventType.CUSTOM and e.name == "ref_fallback"]
+        assert [n.value["persisted"] for n in notices] == [False]
+        # The turn still runs on the fallback branch — only the healing was lost.
+        assert not [e for e in events if e.type == EventType.RUN_ERROR]
+
+    @pytest.mark.django_db(transaction=True)
+    async def test_first_turn_of_a_thread_does_not_fall_back(self):
+        """On a brand-new session the caller chose this ref moments ago and can choose another,
+        so surface the failure instead of silently running against a different branch."""
+        ctx_factory, refs = self._ctx_factory(failures=1)
+
+        with (
+            patch("chat.api.streaming.open_checkpointer", _mock_ctx),
+            patch("chat.api.streaming.set_runtime_ctx", ctx_factory),
+            patch("chat.api.streaming.create_daiv_agent", new=AsyncMock()),
+            patch("chat.api.streaming.RuntimeContextLangGraphAGUIAgent", return_value=_mock_agent([])),
+            patch("chat.api.streaming.ChatSessionService.repoint_ref", new=AsyncMock()) as repoint,
+            patch("chat.api.streaming.ChatSessionService.persist_ref", new=AsyncMock()),
+            patch("chat.api.streaming.SessionLock.release", new=AsyncMock()),
+            patch("chat.api.streaming.SessionLock.heartbeat", new=AsyncMock()),
+        ):
+            streamer = ChatRunStreamer(
+                repo_id="a/b",
+                ref="typoed-branch",
+                thread_id="t-stream",
+                run_id="r-1",
+                input_data=SimpleNamespace(thread_id="t-stream", run_id="r-1"),
+                session_created=True,
+            )
+            events = [e async for e in streamer.events()]
+
+        assert refs == ["typoed-branch"]  # no second attempt
+        repoint.assert_not_called()
+        assert not [e for e in events if e.type == EventType.CUSTOM and e.name == "ref_fallback"]
+        assert [e.code for e in events if e.type == EventType.RUN_ERROR] == ["run_failed"]
+
+    @pytest.mark.django_db(transaction=True)
+    async def test_repo_without_a_default_branch_surfaces_the_original_error(self):
+        """Nothing to fall back *to* (an empty repository): keep the original error rather than
+        inventing a ref name like ``"None"`` and persisting it."""
+        ctx_factory, refs = self._ctx_factory(failures=1, default_branch=None)
+
+        with (
+            patch("chat.api.streaming.open_checkpointer", _mock_ctx),
+            patch("chat.api.streaming.set_runtime_ctx", ctx_factory),
+            patch("chat.api.streaming.create_daiv_agent", new=AsyncMock()),
+            patch("chat.api.streaming.RuntimeContextLangGraphAGUIAgent", return_value=_mock_agent([])),
+            patch("chat.api.streaming.ChatSessionService.repoint_ref", new=AsyncMock()) as repoint,
+            patch("chat.api.streaming.ChatSessionService.persist_ref", new=AsyncMock()),
+            patch("chat.api.streaming.SessionLock.release", new=AsyncMock()),
+            patch("chat.api.streaming.SessionLock.heartbeat", new=AsyncMock()),
+        ):
+            events = [e async for e in _streamer().events()]
+
+        assert refs == ["main", None]
+        repoint.assert_not_called()
+        assert [e.code for e in events if e.type == EventType.RUN_ERROR] == ["run_failed"]
+
+    @pytest.mark.django_db(transaction=True)
+    async def test_default_branch_also_missing_surfaces_run_error(self):
+        """Exactly one fallback attempt: a repo whose default branch is gone too must
+        surface a failure instead of retrying forever.
+        """
+        ctx_factory, refs = self._ctx_factory(failures=2)
+
+        with (
+            patch("chat.api.streaming.open_checkpointer", _mock_ctx),
+            patch("chat.api.streaming.set_runtime_ctx", ctx_factory),
+            patch("chat.api.streaming.create_daiv_agent", new=AsyncMock()),
+            patch("chat.api.streaming.RuntimeContextLangGraphAGUIAgent", return_value=_mock_agent([])),
+            patch("chat.api.streaming.ChatSessionService.repoint_ref", new=AsyncMock()),
+            patch("chat.api.streaming.ChatSessionService.persist_ref", new=AsyncMock()),
+            patch("chat.api.streaming.SessionLock.release", new=AsyncMock()),
+            patch("chat.api.streaming.SessionLock.heartbeat", new=AsyncMock()),
+        ):
+            events = [e async for e in _streamer().events()]
+
+        assert refs == ["main", None]
+        assert [e.code for e in events if e.type == EventType.RUN_ERROR] == ["run_failed"]

--- a/tests/unit_tests/chat/api/test_threads.py
+++ b/tests/unit_tests/chat/api/test_threads.py
@@ -83,6 +83,32 @@ async def test_persist_ref_noop_when_no_mr_captured():
 
 
 @pytest.mark.django_db(transaction=True)
+async def test_persist_ref_refuses_to_pin_a_ref_already_proven_missing():
+    """After a ref fallback, an MR still pointing at the deleted branch is stale — pinning it
+    would undo the heal ``repoint_ref`` just wrote and re-wedge the thread."""
+    with patch("chat.api.threads.Session.objects.filter") as filter_mock:
+        await ChatSessionService.persist_ref(
+            "t-ref-4", "dev", SimpleNamespace(source_branch="chore/merged"), missing_ref="chore/merged"
+        )
+
+    filter_mock.assert_not_called()
+
+
+@pytest.mark.django_db(transaction=True)
+async def test_repoint_ref_overwrites_the_stored_ref():
+    user = await User.objects.acreate_user(username="u-ref-5", email="ref5@x.com", password="x")  # noqa: S106
+    await Session.objects.acreate(
+        thread_id="t-ref-5", origin=SessionOrigin.CHAT, user=user, repo_id="a/b", ref="chore/merged"
+    )
+
+    await ChatSessionService.repoint_ref("t-ref-5", "dev")
+
+    refreshed = await Session.objects.aget(thread_id="t-ref-5")
+    assert refreshed.ref == "dev"
+    await user.adelete()
+
+
+@pytest.mark.django_db(transaction=True)
 async def test_get_or_create_creates_chat_origin_session():
     user = await User.objects.acreate_user(username="u-create-1", email="create1@x.com", password="x")  # noqa: S106
     input_data = _fake_input(["hello"])

--- a/tests/unit_tests/codebase/clients/gitlab/test_client.py
+++ b/tests/unit_tests/codebase/clients/gitlab/test_client.py
@@ -15,6 +15,7 @@ from codebase.clients.gitlab.client import (
     GitLabClient,
     _is_source_branch_missing_error,
 )
+from codebase.exceptions import RepositoryRefNotFoundError
 
 _CLONE_URL = "https://gitlab.com/group/repo.git"
 
@@ -380,18 +381,55 @@ class TestGitLabClient:
 
         assert "No git credential resolved for group/repo" in caplog.text
 
-    def test_load_repo_does_not_retry_non_auth_clone_failures(self, gitlab_client, clone_setup):
+    @pytest.mark.parametrize(
+        ("stderr", "branch_exists", "expected_exception"),
+        [
+            pytest.param(
+                "fatal: Remote branch nope not found in upstream origin",
+                False,
+                RepositoryRefNotFoundError,
+                id="missing-branch-confirmed-by-api-is-translated",
+            ),
+            pytest.param(
+                "fatal: Remote branch nope not found in upstream origin",
+                True,
+                GitCommandError,
+                id="missing-branch-contradicted-by-api-stays-raw",
+            ),
+            pytest.param(
+                "fatal: Remote branch nope not found in upstream origin",
+                None,
+                GitCommandError,
+                id="missing-branch-unknown-to-api-stays-raw",
+            ),
+            pytest.param(
+                "fatal: unable to access 'https://gitlab.com/group/repo.git/': Could not resolve host",
+                False,
+                GitCommandError,
+                id="transport-failure-stays-raw",
+            ),
+        ],
+    )
+    def test_load_repo_does_not_retry_non_auth_clone_failures(
+        self, gitlab_client, clone_setup, stderr, branch_exists, expected_exception
+    ):
         """A missing branch (or any non-auth 128) won't be fixed by a fresh credential, so it must
-        not trigger the token-rotation retry."""
+        not trigger the token-rotation retry.
+
+        A branch the *API also* reports gone surfaces as ``RepositoryRefNotFoundError`` so callers
+        can act on it — a chat thread pinned to a merged MR's deleted source branch retargets the
+        default branch instead of failing every later turn. git's wording on its own is not
+        enough: an advertisement miss the API contradicts (or can't confirm) stays a raw error,
+        because the chat fallback would otherwise abandon a live branch.
+        """
         repository, clone_from, _ = clone_setup
-        clone_from.side_effect = GitCommandError(
-            "git clone", 128, "fatal: Remote branch nope not found in upstream origin"
-        )
+        clone_from.side_effect = GitCommandError("git clone", 128, stderr)
 
         with (
             patch("codebase.clients.gitlab.client.get_ephemeral_clone_token", return_value="glpat-eph"),
             patch("codebase.clients.gitlab.client.invalidate_clone_token") as invalidate,
-            pytest.raises(GitCommandError),
+            patch.object(type(gitlab_client), "branch_exists", return_value=branch_exists),
+            pytest.raises(expected_exception),
             gitlab_client.load_repo(repository, "main"),
         ):
             pass
@@ -860,6 +898,26 @@ class TestGitLabClient:
         for error in (GitlabGetError("404", response_code=404), GitlabAuthenticationError("401")):
             mock_project.branches.get.side_effect = error
             assert gitlab_client.is_branch_protected("group/repo", "missing") is False
+
+    def test_branch_exists_distinguishes_absent_from_unknown(self, gitlab_client):
+        """Three-valued on purpose: only a 404 means "gone". Anything else is ``None``, because a
+        caller acting on absence (``translate_missing_ref`` → the chat ref fallback) must never
+        mistake an API outage for a deleted branch."""
+        from gitlab.exceptions import GitlabAuthenticationError
+
+        mock_project = Mock()
+        gitlab_client.client.projects.get.return_value = mock_project
+
+        mock_project.branches.get.side_effect = None
+        mock_project.branches.get.return_value = Mock()
+        assert gitlab_client.branch_exists("group/repo", "dev") is True
+
+        mock_project.branches.get.side_effect = GitlabGetError("404", response_code=404)
+        assert gitlab_client.branch_exists("group/repo", "gone") is False
+
+        for error in (GitlabAuthenticationError("401"), GitlabGetError("500", response_code=500), OSError("reset")):
+            mock_project.branches.get.side_effect = error
+            assert gitlab_client.branch_exists("group/repo", "dunno") is None
 
     def test_get_merge_request_by_branches_returns_none_when_empty(self, gitlab_client):
         """Empty list → ``None`` (not an exception)."""

--- a/tests/unit_tests/codebase/clients/test_utils.py
+++ b/tests/unit_tests/codebase/clients/test_utils.py
@@ -1,4 +1,109 @@
-from codebase.clients.utils import _clean_ansi_codes
+from unittest.mock import Mock
+
+import pytest
+from git import GitCommandError
+
+from codebase.clients.utils import _clean_ansi_codes, translate_missing_ref
+from codebase.exceptions import RepositoryRefNotFoundError
+
+_MISSING_BRANCH_STDERR = "fatal: Remote branch feature-x not found in upstream origin"
+
+
+class TestTranslateMissingRef:
+    """A clone whose ref is *confirmed* gone must surface as a typed, actionable error.
+
+    The trigger case is a chat session pinned to a merged MR's auto-deleted source branch:
+    without the translation the caller only sees an opaque ``GitCommandError`` and cannot tell
+    "the branch vanished" (recoverable — retarget the default branch) from "git broke".
+
+    git's wording alone is not enough evidence: the same message appears when a branch is merely
+    absent from the advertisement this credential got (replication lag, restricted ref view,
+    stale proxy). Since the chat fallback rewrites the session's stored ref, a false positive is
+    destructive — so the platform API has to agree.
+    """
+
+    def _clone_error(self, stderr: str) -> GitCommandError:
+        return GitCommandError(["git", "clone", "--branch=feature-x"], 128, stderr)
+
+    def _client(self, exists: bool | None) -> Mock:
+        client = Mock()
+        client.branch_exists.return_value = exists
+        return client
+
+    def test_missing_remote_branch_confirmed_by_api_becomes_typed_error(self):
+        client = self._client(exists=False)
+        with (
+            pytest.raises(RepositoryRefNotFoundError) as exc_info,
+            translate_missing_ref(client, "group/project", "feature-x"),
+        ):
+            raise self._clone_error(_MISSING_BRANCH_STDERR)
+
+        assert exc_info.value.ref == "feature-x"
+        assert exc_info.value.repo_id == "group/project"
+        # The cause is preserved so the server-side log keeps git's own wording.
+        assert isinstance(exc_info.value.__cause__, GitCommandError)
+        client.branch_exists.assert_called_once_with("group/project", "feature-x")
+
+    def test_could_not_find_remote_branch_wording_also_matches(self):
+        """Older/dumb-HTTP git reports the miss as a warning before failing."""
+        with (
+            pytest.raises(RepositoryRefNotFoundError),
+            translate_missing_ref(self._client(exists=False), "group/project", "feature-x"),
+        ):
+            raise self._clone_error("warning: Could not find remote branch feature-x to clone.")
+
+    def test_branch_still_present_on_the_api_keeps_the_raw_error(self):
+        """git said missing but the platform says it exists → a transient advertisement miss.
+        Must NOT be translated: the chat fallback would abandon a live branch and rewrite the
+        session's ref with no way for the user to undo it."""
+        with (
+            pytest.raises(GitCommandError),
+            translate_missing_ref(self._client(exists=True), "group/project", "feature-x"),
+        ):
+            raise self._clone_error(_MISSING_BRANCH_STDERR)
+
+    def test_unknown_api_answer_keeps_the_raw_error(self):
+        """``None`` = the platform could not be reached. An API outage must never be read as a
+        deleted branch."""
+        with (
+            pytest.raises(GitCommandError),
+            translate_missing_ref(self._client(exists=None), "group/project", "feature-x"),
+        ):
+            raise self._clone_error(_MISSING_BRANCH_STDERR)
+
+    @pytest.mark.parametrize("ref", ["a1b2c3d", "0123456789abcdef0123456789abcdef01234567"])
+    def test_commit_sha_ref_keeps_the_raw_error(self, ref):
+        """``--branch`` resolves branches and tags but never a commit SHA, so the same message
+        there means "that isn't a branch" — not "it was deleted". Callers may legitimately pin a
+        SHA, and the API is never even consulted."""
+        client = self._client(exists=False)
+        with pytest.raises(GitCommandError), translate_missing_ref(client, "group/project", ref):
+            raise self._clone_error(f"fatal: Remote branch {ref} not found in upstream origin")
+
+        client.branch_exists.assert_not_called()
+
+    def test_auth_failure_passes_through_untranslated(self):
+        """Auth rejections have their own retry/self-heal path — never relabel them."""
+        client = self._client(exists=False)
+        with pytest.raises(GitCommandError), translate_missing_ref(client, "group/project", "feature-x"):
+            raise self._clone_error("fatal: Authentication failed for 'https://git.example.com/x.git/'")
+
+        # No wasted API call: the wording gate runs before the corroboration.
+        client.branch_exists.assert_not_called()
+
+    def test_unrelated_error_passes_through(self):
+        with (
+            pytest.raises(GitCommandError),
+            translate_missing_ref(self._client(exists=False), "group/project", "feature-x"),
+        ):
+            raise self._clone_error("fatal: unable to access 'https://git.example.com/x.git/': Could not resolve host")
+
+    def test_success_is_transparent(self):
+        client = self._client(exists=False)
+        with translate_missing_ref(client, "group/project", "feature-x"):
+            pass
+
+        client.branch_exists.assert_not_called()
 
 
 def test__clean_ansi_codes():

--- a/tests/unit_tests/core/test_site_configuration.py
+++ b/tests/unit_tests/core/test_site_configuration.py
@@ -39,14 +39,19 @@ class TestCaching:
         instance = SiteConfiguration.get_cached()
         assert instance.pk == 1
 
-    async def test_get_cached_works_in_async_context_cold_cache(self, db):
+    # ``transactional_db`` (not ``db``) on the two cold-cache tests below: the fetch they exercise
+    # runs ``get_instance()`` in a thread pool, so the singleton row it creates lands on a
+    # thread-local connection outside the plain-``db`` savepoint and commits for real — leaking a
+    # test-created singleton into every later test in the same worker that reads site config.
+    # The other async tests here patch ``get_instance``/``submit`` out, so they never write.
+    async def test_get_cached_works_in_async_context_cold_cache(self, transactional_db):
         """When called from an async context with cold cache, fetches via thread pool."""
         django_cache.delete(SITE_CONFIGURATION_CACHE_KEY)
         result = SiteConfiguration.get_cached()
         assert result is not None
         assert result.pk == 1
 
-    async def test_get_cached_populates_cache_in_async_context(self, db):
+    async def test_get_cached_populates_cache_in_async_context(self, transactional_db):
         """Cold cache async fetch should populate cache for subsequent calls."""
         django_cache.delete(SITE_CONFIGURATION_CACHE_KEY)
         SiteConfiguration.get_cached()

--- a/tests/unit_tests/jobs/test_tasks.py
+++ b/tests/unit_tests/jobs/test_tasks.py
@@ -128,7 +128,7 @@ async def test_run_job_task_forwards_overrides():
     assert "use_max" not in captured_kwargs
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(transaction=True)
 async def test_run_job_task_persists_resolved_model():
     """The resolved model/thinking are written back onto the Run + Session so the
     session detail view reflects what the run actually executed with, not the empty
@@ -177,7 +177,7 @@ async def test_run_job_task_persists_resolved_model():
     assert run.agent_thinking_level == "xhigh"
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(transaction=True)
 async def test_run_job_task_leaves_model_empty_when_setup_fails_before_resolution():
     """A run that dies before the model is resolved (e.g. the git clone inside
     ``set_runtime_ctx``) leaves ``agent_model`` empty — the UI falls back to the

--- a/tests/unit_tests/jobs/test_tasks_lock.py
+++ b/tests/unit_tests/jobs/test_tasks_lock.py
@@ -6,7 +6,12 @@ from jobs.tasks import _acquire_session_lock
 from sessions.locks import SessionLock
 from sessions.models import Session, SessionOrigin
 
-pytestmark = pytest.mark.django_db
+# ``transaction=True``: these are async DB tests. Async writes commit and escape the
+# plain-``django_db`` savepoint rollback (a known footgun in this project's in-memory
+# SQLite), so the created Session rows would leak into later tests that make global
+# ``Session``/``Run`` count assertions. The transactional flush after each test cleans
+# them up. Same reasoning as ``tests/unit_tests/sessions/test_chat_runs.py``.
+pytestmark = pytest.mark.django_db(transaction=True)
 
 
 async def _mk_session(**kwargs):

--- a/tests/unit_tests/schedules/test_dispatch_authz.py
+++ b/tests/unit_tests/schedules/test_dispatch_authz.py
@@ -39,7 +39,7 @@ def test_dispatch_denied_owner_advances_without_runs(due_schedule, caplog):
         dispatch_scheduled_jobs_cron_task.func()
 
     due_schedule.refresh_from_db()
-    assert Run.objects.count() == 0
+    assert Run.objects.filter(session__scheduled_job=due_schedule).count() == 0
     assert due_schedule.next_run_at > datetime.now(tz=UTC)  # advanced, not hot-looping
     assert due_schedule.is_enabled  # not disabled — access may come back
 

--- a/tests/unit_tests/schedules/test_tasks.py
+++ b/tests/unit_tests/schedules/test_tasks.py
@@ -234,7 +234,9 @@ def test_dispatch_respects_owner_is_active(member_user, owner_active, expected_r
         dispatch_scheduled_jobs_cron_task.func()
 
     schedule.refresh_from_db()
-    assert Run.objects.count() == expected_runs
+    # Scoped to this schedule, not a table-wide count: a global count also answers for rows
+    # any other test leaked into this worker's DB, which is not what this test is about.
+    assert Run.objects.filter(session__scheduled_job=schedule).count() == expected_runs
     if owner_active:
         assert schedule.next_run_at > past  # advanced to next cron tick
     else:
@@ -267,7 +269,7 @@ def test_dispatch_resumes_after_owner_reactivated(member_user):
 
         # Inactive owner: skipped, no run, next_run_at untouched.
         dispatch_scheduled_jobs_cron_task.func()
-        assert Run.objects.count() == 0
+        assert Run.objects.filter(session__scheduled_job=schedule).count() == 0
         schedule.refresh_from_db()
         assert schedule.next_run_at == past
 
@@ -276,7 +278,7 @@ def test_dispatch_resumes_after_owner_reactivated(member_user):
         member_user.save(update_fields=["is_active"])
         dispatch_scheduled_jobs_cron_task.func()
 
-    assert Run.objects.count() == 1
+    assert Run.objects.filter(session__scheduled_job=schedule).count() == 1
     schedule.refresh_from_db()
     assert schedule.next_run_at > datetime.now(tz=UTC)
 
@@ -321,7 +323,7 @@ def test_dispatch_skips_only_inactive_owner_in_mixed_run(member_user):
 
     # Selectivity: only the active owner's schedule dispatched; the inactive
     # owner's was skipped even though both were due in the same run.
-    assert Run.objects.count() == 1
+    assert Run.objects.filter(session__scheduled_job__in=[active_schedule, inactive_schedule]).count() == 1
     assert Run.objects.filter(session__scheduled_job=active_schedule).count() == 1
     assert Run.objects.filter(session__scheduled_job=inactive_schedule).count() == 0
     active_schedule.refresh_from_db()
@@ -358,7 +360,7 @@ def test_dispatch_skips_once_schedule_of_inactive_owner_without_retiring(member_
     # Skipped, not retired: a ONCE schedule owned by an inactive user must keep
     # is_enabled=True and its next_run_at intact so it fires exactly once when
     # the owner is reactivated — not be consumed by the ONCE auto-disable path.
-    assert Run.objects.count() == 0
+    assert Run.objects.filter(session__scheduled_job=schedule).count() == 0
     assert schedule.is_enabled is True
     assert schedule.next_run_at == past
     assert schedule.run_count == 0

--- a/tests/unit_tests/sessions/test_locks.py
+++ b/tests/unit_tests/sessions/test_locks.py
@@ -7,7 +7,12 @@ import pytest
 from sessions.locks import SessionLock
 from sessions.models import Session, SessionOrigin
 
-pytestmark = pytest.mark.django_db
+# ``transaction=True``: these are async DB tests. Async writes commit and escape the
+# plain-``django_db`` savepoint rollback (a known footgun in this project's in-memory
+# SQLite), so the created Session rows would leak into later tests that make global
+# ``Session``/``Run`` count assertions. The transactional flush after each test cleans
+# them up. Same reasoning as ``tests/unit_tests/sessions/test_chat_runs.py``.
+pytestmark = pytest.mark.django_db(transaction=True)
 
 
 async def _mk_session(**kwargs) -> Session:

--- a/tests/unit_tests/sessions/test_services.py
+++ b/tests/unit_tests/sessions/test_services.py
@@ -82,6 +82,7 @@ def _patch_run_job_task(side_effect=None):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.django_db(transaction=True)
 async def test_aget_or_create_session_creates_with_origin():
     tid = str(uuid.uuid4())
     session = await aget_or_create_session(thread_id=tid, origin=SessionOrigin.API_JOB, repo_id="g/r", ref="main")
@@ -89,6 +90,7 @@ async def test_aget_or_create_session_creates_with_origin():
     assert session.origin == SessionOrigin.API_JOB
 
 
+@pytest.mark.django_db(transaction=True)
 async def test_aget_or_create_session_existing_keeps_origin_and_touches():
     tid = str(uuid.uuid4())
     first = await aget_or_create_session(thread_id=tid, origin=SessionOrigin.ISSUE_WEBHOOK, repo_id="g/r")
@@ -100,6 +102,7 @@ async def test_aget_or_create_session_existing_keeps_origin_and_touches():
     assert again.last_active_at > before
 
 
+@pytest.mark.django_db(transaction=True)
 async def test_acreate_run_creates_session_and_run():
     tid = str(uuid.uuid4())
     run = await acreate_run(


### PR DESCRIPTION
Two independent fixes, one per commit — reviewable separately.

## 1. `fix(chat)`: a merged MR no longer wedges its chat thread (Sentry DAIV-AT)

**The bug.** A chat session is pinned to the source branch of the MR it opens (`ChatSessionService.persist_ref`). Merging that MR with source-branch deletion — GitLab's default — left every later turn cloning a branch that no longer exists. The clone died with a raw `GitCommandError`, surfacing to the user as an opaque *"Run failed. Check server logs for details."* The composer's branch pill is read-only on an existing thread, so there was no way to repoint it: the thread was **permanently unusable**.

Confirmed against the real repo: MR !2362 on `dipcode/clientportal/webapp` was created at 14:03:42Z, merged at 14:08:27Z with `force_remove_source_branch=true`, and the next turn failed at 14:11:26Z cloning the deleted branch. The clone-token propagation retry was *not* involved — it correctly failed fast.

**The fix.** `load_repo` (both platform clients) now raises a typed `RepositoryRefNotFoundError`, and an established thread retargets the repository default branch — where the merged work lives — heals the stored ref, and says so in the conversation.

**Why the classifier is deliberately conservative.** git emits "not found in upstream" whenever the ref is absent from *the advertisement this credential received*, which is also what replication lag, a restricted ref view, or a stale proxy look like — and this instance already carries `MERGE_REQUEST_BRANCH_VISIBILITY_RETRY_BACKOFF_SECONDS` for exactly that race. Since the fallback rewrites stored state, a false positive would abandon a live branch. So:

- the new three-valued `RepoClient.branch_exists()` must **also** report the branch absent; an unknown answer (API unreachable) keeps the raw git error;
- SHA-shaped refs never translate — `--branch` doesn't resolve a commit SHA, so "missing" there means "not a branch", and `submit_job` documents a SHA as a valid ref;
- a thread's **first** turn never falls back: that ref was just chosen and is the caller's to fix.

**Two follow-on hazards this exposed** (both caught in review, both would have made the fix worse than useless):

- `GitMiddleware.abefore_agent` re-emitted the checkpointed MR — the merged one, still pointing at the deleted branch — into a `STATE_SNAPSHOT`, so `persist_ref` wrote the dead ref straight back and **undid the heal on every turn**. Stale state MRs whose `source_branch` isn't the current ref are now dropped, the same rule `_effective_mr_iid` already applies to the prompt, plus a `missing_ref` guard at the write itself.
- The publisher pushes `HEAD` to `merge_request.source_branch`, so it would have **recreated the deleted branch** and attached the turn's work to an already-merged MR — invisible in review, no new MR opened. Fixed by the same drop.

**Reviewer note:** that `GitMiddleware` change is the one hunk with reach beyond chat — it also protects job and webhook flows from the branch-resurrection hazard. Worth a careful look.

## 2. `test`: async DB tests were leaking committed rows suite-wide

`test_dispatch_respects_owner_is_active[True-1]` failed intermittently under `make test` (~1 in 16 full-suite runs) while always passing in isolation. Its `assert Run.objects.count() == N` is table-wide, so it also answers for rows other tests left behind — and those rows were real.

**Root cause:** thirteen tests across five files are `async def` tests marked plain `@pytest.mark.django_db`. Async ORM writes run on a **thread-local connection**, not the one pytest-django wrapped in a rollback-only atomic block, so they commit for real; the rows outlive teardown and stay visible to every later test in that xdist worker until some later transactional test's flush truncates the tables. Whether that window contains a table-wide count assertion is a coin flip under xdist's dynamic distribution — the whole of the intermittency.

Measured with a temporary plugin hooking `pytest_runtest_teardown` and counting rows of every model per worker: **678 dirty-teardown observations, 12 distinct leak origins → 0 after the fix, across all models.** Leaks weren't limited to `Run`: `Session` rows and a `core.SiteConfiguration` **singleton** leaked too — the latter meaning any later test reading site config silently inherited test-specific configuration.

Same defect, second face: run one of these tests first and it fails outright with `OperationalError: database table is locked`.

Fixed at both layers — `transaction=True` / `transactional_db` on the leaking tests, and the schedules assertions scoped to the schedule under test so a future leak elsewhere can't break them. An inline comment in `sessions/test_chat_runs.py` had explained this footgun for years and didn't prevent 13 recurrences, so the rule is now in `AGENTS.md`.

**Bonus:** this is the latent isolation bug that blocked `--dist worksteal`. It now runs **8/8 clean and ~35% faster** (36-40s vs 53-57s). I left the Makefile on plain `-n auto` — switching it is your call and a one-word change.

## Verification

- `make test` green across 5 runs (3939 tests, +13 new); worksteal 8/8 green.
- Leak probe clean across every model.
- `make lint-fix` clean; `make lint-typing` at 432 diagnostics — identical to baseline, none on new lines.

## Honest caveats

- I never captured the original flake's failing assertion value (it fired once in ~16 runs), so "a leaked `Run` row made the count 2" is a mechanically-necessary inference, not an observed fact. The evidence above measures the leak directly instead of reproducing that one failure.
- Correspondingly, clean runs don't *prove* the flake is gone — but the assertion can no longer see foreign rows, and there are no foreign rows to see.
