### PR TITLE
fix(codebase): Tolerate GitLab post-push branch-visibility lag on MR create

### DIFF
--- a/daiv/automation/agent/middlewares/git.py
+++ b/daiv/automation/agent/middlewares/git.py
@@ -415,6 +415,10 @@ class GitMiddleware(AgentMiddleware[GitState, RuntimeCtx]):
         outcome = await publisher.publish(merge_request=self._state_merge_request(state), skip_ci=self.skip_ci)
 
         if outcome.merge_request is None:
+            # published + no MR is the branch-visibility degrade (branch pushed, MR pending): record
+            # that work landed so the run isn't persisted as an indistinguishable no-op.
+            if outcome.published:
+                update["code_changes"] = True
             return update or None
 
         self._record_issue_mr(outcome.merge_request, runtime)

--- a/daiv/automation/agent/publishers.py
+++ b/daiv/automation/agent/publishers.py
@@ -15,6 +15,7 @@ from automation.agent.git_utils import open_git_manager
 from automation.agent.utils import build_langsmith_config
 from codebase.base import GitPlatform, MergeRequest, Scope
 from codebase.clients import RepoClient
+from codebase.exceptions import MergeRequestBranchNotVisibleError
 from codebase.utils import redact_diff_content
 from core.constants import BOT_AUTO_LABEL, BOT_LABEL, BOT_NAME
 from core.site_settings import site_settings
@@ -151,13 +152,27 @@ class GitChangePublisher(ChangePublisher):
         logger.info("Published changes to branch: '%s' [skip_ci: %s]", branch_name, skip_ci)
 
         if merge_request is None:
-            merge_request = await self._create_merge_request(
-                branch_name,
-                changes_metadata["pr_metadata"].title,
-                changes_metadata["pr_metadata"].description,
-                as_draft=as_draft,
-                fallback_from_mr=fallback_from_mr,
-            )
+            try:
+                merge_request = await self._create_merge_request(
+                    branch_name,
+                    changes_metadata["pr_metadata"].title,
+                    changes_metadata["pr_metadata"].description,
+                    as_draft=as_draft,
+                    fallback_from_mr=fallback_from_mr,
+                )
+            except MergeRequestBranchNotVisibleError:
+                # Branch is pushed but GitLab won't open the MR yet; failing here would orphan the work
+                # and discard the agent's reply, so report a partial publish (MR pending) and log loudly.
+                logger.error(
+                    "Pushed branch '%s' but GitLab did not make it visible for MR creation within the retry "
+                    "budget; reporting a partial publish (MR pending).",
+                    branch_name,
+                )
+                return PublishOutcome(
+                    merge_request=None,
+                    published=True,
+                    protected_branch_fallback_source=protected_branch_fallback_source,
+                )
             logger.info(
                 "Created merge request: %s [merge_request_id: %s, draft: %r]",
                 merge_request.web_url,

--- a/daiv/codebase/clients/base.py
+++ b/daiv/codebase/clients/base.py
@@ -344,7 +344,12 @@ class RepoClient(abc.ABC):
         assignee_id: str | int | None = None,
         as_draft: bool = False,
     ) -> MergeRequest:
-        pass
+        """Create the merge request for ``source_branch`` or update the existing one.
+
+        May raise :class:`~codebase.exceptions.MergeRequestBranchNotVisibleError` when the branch is
+        confirmed pushed but the platform will not open the MR within the retry budget (a transient
+        post-push visibility lag); callers degrade to "branch pushed, MR pending" rather than failing.
+        """
 
     @abc.abstractmethod
     def update_merge_request(

--- a/daiv/codebase/clients/gitlab/client.py
+++ b/daiv/codebase/clients/gitlab/client.py
@@ -35,6 +35,7 @@ from codebase.base import (
 )
 from codebase.clients import RepoClient
 from codebase.clients.gitlab.clone_tokens import get_ephemeral_clone_token, invalidate_clone_token
+from codebase.exceptions import MergeRequestBranchNotVisibleError
 from core.constants import BOT_NAME
 from core.utils import async_download_url, build_uri, is_git_auth_error_text
 from daiv import USER_AGENT
@@ -48,16 +49,10 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger("daiv.clients")
 
-# GitLab does not guarantee a just-pushed branch is immediately visible to the merge-request-create
-# validation: the ref lands in Gitaly synchronously with the push HTTP response, but the branch view
-# that `POST /merge_requests` checks is refreshed by the (asynchronous) post-receive processing. A
-# sandbox-authoritative run pushes from inside the sandbox and creates the MR from the app in the same
-# instant, landing squarely in that window, so the create can fail with
-# `400 {'source_branch': ['does not exist']}` for a branch that was *just* pushed successfully. Retry
-# the create until the branch becomes visible (a successful create is the signal), sleeping these many
-# seconds between attempts (~15s of backoff over four retries) before one final attempt whose error
-# surfaces to the caller.
-MERGE_REQUEST_BRANCH_VISIBILITY_RETRY_BACKOFF_SECONDS = (1.0, 2.0, 4.0, 8.0)
+# A just-pushed branch may not be visible to `POST /merge_requests` immediately (async post-receive lag,
+# observed ~37s on GitLab 19.x); the budget must cover that tail, and exhaustion while the branch is
+# confirmed pushed degrades to "branch pushed, MR pending" (see _create_merge_request_awaiting_branch).
+MERGE_REQUEST_BRANCH_VISIBILITY_RETRY_BACKOFF_SECONDS = (1.0, 2.0, 4.0, 8.0, 16.0, 30.0)
 
 # A freshly minted project access token (see :func:`get_ephemeral_clone_token`) is not always
 # immediately accepted for git-over-HTTPS: GitLab appears to propagate the token's project
@@ -746,9 +741,37 @@ class GitLabClient(RepoClient):
                     delay,
                 )
                 time.sleep(delay)
-        # Retries exhausted: the branch should be visible now, so this final attempt's result — or its
-        # error, if the branch genuinely never appeared — is the caller's to handle.
-        return project.mergerequests.create(payload)
+        # Retries exhausted: if the branch still isn't visible but is confirmed pushed, degrade to a
+        # recoverable error (see MergeRequestBranchNotVisibleError); anything else surfaces unchanged.
+        try:
+            return project.mergerequests.create(payload)
+        except GitlabCreateError as e:
+            if _is_source_branch_missing_error(e) and self._branch_exists(project, source_branch):
+                logger.error(
+                    "MR create for '%s' still reports the branch missing after the full retry budget, but the "
+                    "branch exists on the remote — GitLab's branch view is lagging the push. Degrading to "
+                    "'branch pushed, MR pending'.",
+                    source_branch,
+                )
+                raise MergeRequestBranchNotVisibleError(source_branch) from e
+            raise
+
+    @staticmethod
+    def _branch_exists(project: Any, source_branch: str) -> bool:
+        """True when ``source_branch`` is confirmed present on the remote (the push landed in Gitaly).
+
+        Distinguishes GitLab's post-push branch-visibility lag (branch exists; MR-create just can't see
+        it yet) from a branch that never made it. Any lookup failure — SDK error or unwrapped transport
+        error (TLS/DNS/reset) — is treated as "not confirmed", so the caller re-raises the original
+        create error instead of this incidental one; the probe failure is logged for diagnosis. Mirrors
+        :meth:`is_branch_protected`'s fail-safe on the same call.
+        """
+        try:
+            project.branches.get(source_branch)
+        except Exception:  # noqa: BLE001 — SDK + transport failures both mean "not confirmed"; see is_branch_protected
+            logger.warning("Could not confirm branch '%s' exists after MR-create retries", source_branch, exc_info=True)
+            return False
+        return True
 
     def get_merge_request_by_branches(
         self, repo_id: str, source_branch: str, target_branch: str

--- a/daiv/codebase/exceptions.py
+++ b/daiv/codebase/exceptions.py
@@ -1,3 +1,17 @@
+class MergeRequestBranchNotVisibleError(RuntimeError):
+    """Raised when a just-pushed branch exists on the remote but GitLab still won't open an MR for it.
+
+    Signals that the post-push branch-visibility race outlived the retry budget: the branch is
+    confirmed present on the remote (the push landed in Gitaly), so the failure is a transient
+    GitLab-side lag, not an agent-actionable error. Callers degrade to a partial "branch pushed, MR
+    pending" outcome instead of failing the whole job and orphaning the run's work.
+    """
+
+    def __init__(self, source_branch: str) -> None:
+        super().__init__(f"Branch '{source_branch}' was pushed but GitLab has not made it visible for MR creation yet.")
+        self.source_branch = source_branch
+
+
 class SingleRepoRequiredError(RuntimeError):
     """Raised when a ``RuntimeCtx`` is constructed or accessed without exactly one repo handle.
 

--- a/tests/unit_tests/automation/agent/middlewares/test_git.py
+++ b/tests/unit_tests/automation/agent/middlewares/test_git.py
@@ -109,6 +109,17 @@ class TestGitMiddleware:
             pub_cls.return_value.publish = AsyncMock(return_value=PublishOutcome(merge_request=None, published=False))
             assert await mw.aafter_agent({"session_id": "s", "merge_request": None}, runtime) is None
 
+    async def test_aafter_agent_records_code_changes_on_pending_mr_degrade(self):
+        """The branch-visibility degrade (published + no MR) must flip ``code_changes`` so a pushed
+        branch is not persisted as an indistinguishable no-op."""
+        mw = GitMiddleware(auto_commit_changes=True, sandbox_backend=_bound_backend())
+        runtime = MagicMock()
+        runtime.context.scope = Scope.GLOBAL
+        with patch("automation.agent.middlewares.git.GitChangePublisher") as pub_cls:
+            pub_cls.return_value.publish = AsyncMock(return_value=PublishOutcome(merge_request=None, published=True))
+            result = await mw.aafter_agent({"session_id": "s", "merge_request": None}, runtime)
+        assert result == {"code_changes": True}
+
     async def test_aafter_agent_confirms_existing_mr_without_fallback_key(self):
         """A clean tree already on its MR: publish returns the MR with ``published=False``, so
         aafter confirms it in state WITHOUT touching ``protected_branch_fallback_source`` (a

--- a/tests/unit_tests/automation/agent/test_publishers.py
+++ b/tests/unit_tests/automation/agent/test_publishers.py
@@ -9,6 +9,7 @@ from automation.agent.git_manager import RepoStatus
 from automation.agent.publishers import GitChangePublisher, PublishOutcome
 from codebase.base import GitPlatform, MergeRequest, User
 from codebase.clients.base import GitAuthEnv
+from codebase.exceptions import MergeRequestBranchNotVisibleError
 from core.constants import BOT_AUTO_LABEL, BOT_NAME
 
 
@@ -394,6 +395,61 @@ class TestPublishSuggestsContextFile:
             gm.push_head_to.assert_awaited_once_with("feature", integrate_on_reject=False)
             mock_suggest.assert_called_once_with(mr)
             assert result == PublishOutcome(merge_request=mr, published=True)
+
+    async def test_degrades_to_pending_when_branch_not_visible(self, publisher, monkeypatch, caplog):
+        """A pushed branch GitLab won't open an MR for degrades to a partial publish, not a failed job.
+
+        The work is already committed/pushed; surfacing the recoverable error as ``merge_request=None,
+        published=True`` lets the run complete (agent reply preserved) instead of orphaning the branch.
+        """
+        gm = _fake_git_manager()
+        _patch_open_git_manager(monkeypatch, gm)
+
+        with (
+            patch.object(
+                publisher,
+                "_diff_to_metadata",
+                return_value={
+                    "pr_metadata": Mock(branch="feature", title="Title", description="Desc"),
+                    "commit_message": Mock(commit_message="commit msg"),
+                },
+            ),
+            patch.object(publisher, "_create_merge_request", side_effect=MergeRequestBranchNotVisibleError("feature")),
+            patch.object(publisher, "_suggest_context_file") as mock_suggest,
+            caplog.at_level("ERROR", logger="daiv.tools"),
+        ):
+            result = await publisher.publish(merge_request=None)
+
+        gm.commit_all.assert_awaited_once()
+        gm.push_head_to.assert_awaited_once_with("feature", integrate_on_reject=False)
+        mock_suggest.assert_not_called()
+        assert result == PublishOutcome(merge_request=None, published=True)
+        assert "MR pending" in caplog.text
+
+    async def test_degrade_preserves_protected_branch_fallback_source(self, publisher, monkeypatch):
+        """The compound case: a protected source branch forced a fresh branch, which then hit the
+        visibility race. The degrade outcome must still carry the fallback source."""
+        existing_mr = _make_merge_request(source_branch="dev", merge_request_id=42)
+        publisher.client.is_branch_protected.return_value = True
+        gm = _fake_git_manager()
+        _patch_open_git_manager(monkeypatch, gm)
+
+        with (
+            patch.object(
+                publisher,
+                "_diff_to_metadata",
+                return_value={
+                    "pr_metadata": Mock(branch="feature-fix", title="Title", description="Desc"),
+                    "commit_message": Mock(commit_message="commit msg"),
+                },
+            ),
+            patch.object(
+                publisher, "_create_merge_request", side_effect=MergeRequestBranchNotVisibleError("feature-fix")
+            ),
+        ):
+            result = await publisher.publish(merge_request=existing_mr)
+
+        assert result == PublishOutcome(merge_request=None, published=True, protected_branch_fallback_source="dev")
 
     async def test_falls_back_to_new_mr_when_source_branch_protected(self, publisher, monkeypatch):
         existing_mr = _make_merge_request(source_branch="dev", merge_request_id=42)

--- a/tests/unit_tests/codebase/clients/gitlab/test_client.py
+++ b/tests/unit_tests/codebase/clients/gitlab/test_client.py
@@ -15,6 +15,7 @@ from codebase.clients.gitlab.client import (
     GitLabClient,
     _is_source_branch_missing_error,
 )
+from codebase.exceptions import MergeRequestBranchNotVisibleError
 
 _CLONE_URL = "https://gitlab.com/group/repo.git"
 
@@ -474,10 +475,11 @@ class TestGitLabClient:
         assert result.source_branch == "feat/x"
         assert mock_sleep.call_args_list == [call(delay) for delay in backoff]
 
-    def test_update_or_create_merge_request_raises_when_branch_never_appears(self, gitlab_client):
-        """If the branch stays invisible past the retry budget, the create error surfaces."""
+    def test_update_or_create_merge_request_raises_when_branch_genuinely_missing(self, gitlab_client):
+        """If the branch stays invisible past the retry budget AND is genuinely absent, the create error surfaces."""
         mock_project = Mock()
         mock_project.mergerequests.create.side_effect = self._branch_missing_error()
+        mock_project.branches.get.side_effect = GitlabGetError(response_code=404)
         gitlab_client.client.projects.get.return_value = mock_project
 
         with patch("codebase.clients.gitlab.client.time.sleep"), pytest.raises(GitlabCreateError):
@@ -488,6 +490,84 @@ class TestGitLabClient:
         # One attempt per backoff step, plus the final attempt after the retries are exhausted.
         expected_attempts = len(MERGE_REQUEST_BRANCH_VISIBILITY_RETRY_BACKOFF_SECONDS) + 1
         assert mock_project.mergerequests.create.call_count == expected_attempts
+
+    def test_update_or_create_merge_request_degrades_when_branch_pushed_but_mr_pending(self, gitlab_client, caplog):
+        """Branch exists on the remote but MR-create still can't see it past the budget -> degrade, don't fail.
+
+        This is GitLab's post-push branch-visibility lag outliving the retry budget: the push succeeded
+        (``branches.get`` resolves), so we raise the recoverable pending error rather than the raw 400 the
+        caller would treat as a fatal job failure.
+        """
+        mock_project = Mock()
+        mock_project.mergerequests.create.side_effect = self._branch_missing_error()
+        mock_project.branches.get.return_value = Mock()  # branch resolves -> it really is pushed
+        gitlab_client.client.projects.get.return_value = mock_project
+
+        with (
+            patch("codebase.clients.gitlab.client.time.sleep"),
+            caplog.at_level("ERROR", logger="daiv.clients"),
+            pytest.raises(MergeRequestBranchNotVisibleError) as exc,
+        ):
+            gitlab_client.update_or_create_merge_request(
+                repo_id="group/repo", source_branch="feat/x", target_branch="main", title="Title", description="Desc"
+            )
+
+        assert exc.value.source_branch == "feat/x"
+        mock_project.branches.get.assert_called_once_with("feat/x")
+        assert "feat/x" in caplog.text
+
+    def test_update_or_create_merge_request_reraises_unrelated_400_on_final_attempt(self, gitlab_client):
+        """A non-branch-visibility 400 surfacing only on the final attempt must NOT degrade to pending.
+
+        Guards the fix's worst failure mode: a real error misclassified as "MR pending". The branch is
+        never probed because the final error isn't the branch-missing signature.
+        """
+        backoff = MERGE_REQUEST_BRANCH_VISIBILITY_RETRY_BACKOFF_SECONDS
+        mock_project = Mock()
+        mock_project.mergerequests.create.side_effect = [
+            *(self._branch_missing_error() for _ in backoff),
+            GitlabCreateError(error_message={"title": ["can't be blank"]}, response_code=400),
+        ]
+        gitlab_client.client.projects.get.return_value = mock_project
+
+        with patch("codebase.clients.gitlab.client.time.sleep"), pytest.raises(GitlabCreateError) as exc:
+            gitlab_client.update_or_create_merge_request(
+                repo_id="group/repo", source_branch="feat/x", target_branch="main", title="Title", description="Desc"
+            )
+
+        assert not isinstance(exc.value, MergeRequestBranchNotVisibleError)
+        mock_project.branches.get.assert_not_called()
+
+    def test_update_or_create_merge_request_reraises_create_error_when_branch_probe_fails(self, gitlab_client):
+        """If the branch-existence probe itself fails (e.g. a transport error), the original create error
+        surfaces — not the incidental probe error, and not a false "MR pending"."""
+        mock_project = Mock()
+        mock_project.mergerequests.create.side_effect = self._branch_missing_error()
+        mock_project.branches.get.side_effect = ConnectionError("boom")
+        gitlab_client.client.projects.get.return_value = mock_project
+
+        with patch("codebase.clients.gitlab.client.time.sleep"), pytest.raises(GitlabCreateError) as exc:
+            gitlab_client.update_or_create_merge_request(
+                repo_id="group/repo", source_branch="feat/x", target_branch="main", title="Title", description="Desc"
+            )
+
+        assert not isinstance(exc.value, MergeRequestBranchNotVisibleError)
+
+    @pytest.mark.parametrize(
+        ("side_effect", "expected"),
+        [
+            pytest.param(None, True, id="branch-present"),
+            pytest.param(GitlabGetError(response_code=404), False, id="gitlab-error-not-confirmed"),
+            pytest.param(ConnectionError("boom"), False, id="transport-error-not-confirmed"),
+        ],
+    )
+    def test_branch_exists_is_fail_safe(self, side_effect, expected):
+        """Present -> True; any lookup failure (SDK or unwrapped transport) -> "not confirmed" (False)."""
+        mock_project = Mock()
+        if side_effect is not None:
+            mock_project.branches.get.side_effect = side_effect
+        assert GitLabClient._branch_exists(mock_project, "feat/x") is expected
+        mock_project.branches.get.assert_called_once_with("feat/x")
 
     def test_update_or_create_merge_request_does_not_retry_unrelated_400(self, gitlab_client):
         """A 400 that isn't the branch-visibility race must fail fast (no retry/sleep)."""


### PR DESCRIPTION
## What & why

Fixes **Sentry DAIV-AW** — `GitlabCreateError: 400 {'source_branch': ['does not exist']}` raised while opening an MR for a branch that was *just pushed successfully*.

GitLab refreshes the branch view that `POST /merge_requests` validates against via its **asynchronous** post-receive processing, not synchronously with the push. A sandbox-authoritative run pushes and opens the MR in the same instant, landing in that window. The retry budget was only ~16s, but the lag has been observed at **~37.5s** on `git.eurotux.com` (GitLab 19.x). On exhaustion the raw error escaped all the way to `run_job_task` and failed the whole job — so a **fully successful** agent run (code written, committed, pushed) was reported as a total failure: the branch was left with no MR (work orphaned, a re-trigger builds a `-N` duplicate) and the agent's reply was discarded.

## Changes

- **Cover the real tail** — extend the MR-create backoff `(1,2,4,8)` → `(1,2,4,8,16,30)` (~61s). It only sleeps when actually racing, and blocks a worker thread (not the event loop / lock heartbeat).
- **Non-fatal exhaustion** — on the final failure, if the branch is confirmed pushed (via a fail-safe `_branch_exists` probe that mirrors `is_branch_protected`'s SDK+transport fail-open), raise the recoverable `MergeRequestBranchNotVisibleError` instead of the raw 400. `GitChangePublisher.publish` catches it and returns a partial `PublishOutcome(merge_request=None, published=True)`, so the job completes and the agent's reply survives. A genuinely-missing branch (or any unrelated create error) still re-raises unchanged.
- **Truthful state** — `GitMiddleware.aafter_agent` flips `code_changes=True` on the degrade so a pushed-but-MR-pending run isn't persisted as an indistinguishable no-op.
- **Contract** — declare the new exception on the platform-agnostic `RepoClient.update_or_create_merge_request` docstring.

## Reviewer notes

- **Why not poll `branches.get` to retry faster?** `branches.get` reads Gitaly (the branch is there at +0s) while MR-create validation reads the Rails cached branch list (lagged by post-receive). They don't correlate, so a successful `create` is the only reliable signal — hence sleep-the-schedule, and `_branch_exists` is only a *degrade* signal at exhaustion, not a retry signal.
- **`_branch_exists` catches broadly (`except Exception`)** on purpose: python-gitlab surfaces transport errors (`ConnectionError`/`Timeout`) unwrapped, and swallowing them → "not confirmed" → the original create error surfaces rather than an incidental probe error. Matches the sibling `is_branch_protected`.

## Not in this PR (follow-ups)

- Surface the "MR pending" state in the user-facing reply (state is now truthful, but the message doesn't yet tell the user an MR is owed).
- Reuse the pushed branch on re-trigger to avoid the `-N` duplicate.

## Testing

`237 passed` across the GitLab client, publisher, and git-middleware suites; `make lint` clean; no new `ty` errors in changed files. New/updated tests cover: the degrade path, genuinely-missing re-raise, unrelated-400 on the final attempt, the parametrized `_branch_exists` fail-safe (present / SDK error / transport error), transport-probe-failure surfacing the create error, the middleware `code_changes` flip, and the protected-branch fallback-source pass-through.
