### PR TITLE
fix(agent): Guarantee unique branch names so publish can't crash

### DIFF
--- a/daiv/automation/agent/git_manager.py
+++ b/daiv/automation/agent/git_manager.py
@@ -7,6 +7,7 @@ import re
 import subprocess  # noqa: S404
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
+from uuid import uuid4
 
 from git import GitCommandError
 
@@ -83,8 +84,6 @@ class GitManager:
         sandbox_backend: The run's bound :class:`SandboxFileBackend` for sandbox mode.
         repo_path: Repo path inside the sandbox (defaults to ``REPO_PATH``).
     """
-
-    BRANCH_NAME_MAX_ATTEMPTS = 10
 
     def __init__(
         self,
@@ -430,32 +429,26 @@ class GitManager:
                 branches.append(ref[len("refs/heads/") :])
         return branches
 
-    def unique_branch_name(
-        self, original_branch_name: str, existing_branch_names: list[str], max_attempts: int = BRANCH_NAME_MAX_ATTEMPTS
-    ) -> str:
+    def unique_branch_name(self, original_branch_name: str, existing_branch_names: list[str]) -> str:
         """
-        Generate a unique branch name.
+        Generate a branch name that does not collide with an existing remote branch.
+
+        Returns ``original_branch_name`` untouched when it is free; otherwise appends a
+        random suffix. A random suffix (rather than an incrementing counter) means naming
+        can never exhaust and abort the publish, which would discard the agent's work.
 
         Args:
-            original_branch_name: The original branch name.
-            existing_branch_names: The existing branch names.
-            max_attempts: The maximum number of attempts to generate a unique branch name.
+            original_branch_name: The preferred branch name.
+            existing_branch_names: Remote branch names to avoid colliding with.
 
         Returns:
-            A unique branch name.
+            A branch name absent from ``existing_branch_names``.
         """
-        suffix_count = 1
+        existing = set(existing_branch_names)
         branch_name = original_branch_name
 
-        while branch_name in existing_branch_names and suffix_count < max_attempts:
-            branch_name = f"{original_branch_name}-{suffix_count}"
-            suffix_count += 1
-
-        if suffix_count == max_attempts:
-            raise ValueError(
-                f"Failed to generate a unique branch name for {original_branch_name}, "
-                f"max attempts reached {max_attempts}."
-            )
+        while branch_name in existing:
+            branch_name = f"{original_branch_name}-{uuid4().hex[:8]}"
 
         return branch_name
 

--- a/tests/unit_tests/automation/agent/test_git_manager.py
+++ b/tests/unit_tests/automation/agent/test_git_manager.py
@@ -126,10 +126,20 @@ def test_gen_unique_branch_name_returns_original_when_available() -> None:
     assert gm.unique_branch_name("feature", ["main"]) == "feature"
 
 
-def test_gen_unique_branch_name_raises_when_max_attempts_exceeded() -> None:
+def test_gen_unique_branch_name_appends_random_suffix_on_collision() -> None:
     gm, _ = _sandbox_manager()
-    with pytest.raises(ValueError, match="max attempts reached 3"):
-        gm.unique_branch_name("feature", ["feature", "feature-1", "feature-2"], max_attempts=3)
+    result = gm.unique_branch_name("feature", ["feature"])
+    assert result != "feature"
+    assert result.startswith("feature-")
+    assert result not in {"feature"}
+
+
+def test_gen_unique_branch_name_never_returns_an_existing_name() -> None:
+    gm, _ = _sandbox_manager()
+    existing = ["feature", *(f"feature-{i}" for i in range(1, 20))]
+    result = gm.unique_branch_name("feature", existing)
+    assert result not in existing
+    assert result.startswith("feature-")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

A chat run crashed at publish time with:

```
ValueError: Failed to generate a unique branch name for feat/echo-slash-command, max attempts reached 10.
```

`unique_branch_name` incremented a numeric suffix (`-1`, `-2`, …) up to 10 attempts and raised on exhaustion. Two problems compounded:

1. **Off-by-one** — the `raise` was keyed on the attempt counter, not on whether the final candidate collided. When base + `-1`…`-8` existed, `feat/echo-slash-command-9` was **free**, but the function raised anyway and discarded it.
2. **Crashing over a branch name** — the `ValueError` propagated out of `aafter_agent`, failing the whole run and throwing away the agent's work (the sandbox patch and its reply), which contradicts the partial-publish handling right beside the call site.

## Fix

Switch from an incrementing counter to a guaranteed-unique suffix: return the preferred name when it's free, otherwise append `uuid4().hex[:8]` and re-check against the remote branch set. Naming can no longer exhaust, so publishing can never abort for this reason. The random suffix only appears after a real collision — the common path is unchanged.

Also removes the now-dead `BRANCH_NAME_MAX_ATTEMPTS` constant and `max_attempts` parameter (the sole caller passed neither).

## Tests

Replaced the "raises when max attempts exceeded" test with two asserting the new contract: a random suffix is appended on collision, and the result is never one of the existing names even with 20 taken. `test_git_manager.py` + `test_publishers.py` (94 tests) pass; lint clean.