### PR TITLE
fix: publish onto a branch's real MR and diff against its real base

### DIFF
--- a/daiv/automation/agent/git_manager.py
+++ b/daiv/automation/agent/git_manager.py
@@ -272,7 +272,7 @@ class GitManager:
         return self._nonempty_lines(changed_res.output) + self._nonempty_lines(untracked_res.output)
 
     async def status_snapshot(self, *, base_branch: str, mr_source_branch: str | None) -> RepoStatus:
-        """Collect everything the publisher needs in exactly two sandbox round-trips (<=2 total).
+        """Collect everything the publisher needs in exactly two sandbox round-trips.
 
         Batch A: working-tree status, merge-base of ``origin/<base_branch>`` and ``HEAD``, untracked
         file list, remote branch list, and — when ``mr_source_branch`` is given —
@@ -301,19 +301,19 @@ class GitManager:
         self._require_ok(batch_a[0], status_res)
         self._require_ok(batch_a[2], untracked_res)
 
-        # merge-base is deliberately NOT gated through _require_ok: exit 1 ("no common ancestor")
-        # is an expected outcome for unrelated histories, not a git failure. Fall back to the base
-        # branch tip so the diff still resolves.
+        # merge-base is not gated like the others: exit 1 ("no common ancestor") is expected for
+        # unrelated histories, so fall back to the base tip; any other non-zero exit is a real failure.
         if mergebase_res.exit_code == 0 and mergebase_res.output.strip():
             base_ref = mergebase_res.output.strip().splitlines()[0]
-        else:
+        elif mergebase_res.exit_code == 1:
             logger.warning(
-                "status_snapshot: `git merge-base origin/%s HEAD` found no common ancestor (exit %s); "
-                "falling back to the branch tip. Output: %s",
+                "status_snapshot: no common ancestor between origin/%s and HEAD; "
+                "falling back to the branch tip for the diff base.",
                 base_branch,
-                mergebase_res.exit_code,
-                mergebase_res.output.strip(),
             )
+            base_ref = f"origin/{base_branch}"
+        else:
+            self._require_ok(batch_a[1], mergebase_res)  # bad/missing ref (exit 128) raises; exit-0-no-SHA → tip
             base_ref = f"origin/{base_branch}"
 
         # ls-remote is the publish flow's FIRST network op, so in local mode a rejected/absent

--- a/daiv/automation/agent/git_manager.py
+++ b/daiv/automation/agent/git_manager.py
@@ -303,6 +303,7 @@ class GitManager:
 
         # merge-base is not gated like the others: exit 1 ("no common ancestor") is expected for
         # unrelated histories, so fall back to the base tip; any other non-zero exit is a real failure.
+        base_ref = f"origin/{base_branch}"
         if mergebase_res.exit_code == 0 and mergebase_res.output.strip():
             base_ref = mergebase_res.output.strip().splitlines()[0]
         elif mergebase_res.exit_code == 1:
@@ -311,10 +312,8 @@ class GitManager:
                 "falling back to the branch tip for the diff base.",
                 base_branch,
             )
-            base_ref = f"origin/{base_branch}"
         else:
-            self._require_ok(batch_a[1], mergebase_res)  # bad/missing ref (exit 128) raises; exit-0-no-SHA → tip
-            base_ref = f"origin/{base_branch}"
+            self._require_ok(batch_a[1], mergebase_res)  # exit 128 (bad ref) raises; exit-0-no-SHA keeps the tip
 
         # ls-remote is the publish flow's FIRST network op, so in local mode a rejected/absent
         # credential lands here before the push. Classify it as the same actionable transport error a

--- a/daiv/automation/agent/git_manager.py
+++ b/daiv/automation/agent/git_manager.py
@@ -272,17 +272,20 @@ class GitManager:
         return self._nonempty_lines(changed_res.output) + self._nonempty_lines(untracked_res.output)
 
     async def status_snapshot(self, *, base_branch: str, mr_source_branch: str | None) -> RepoStatus:
-        """Collect everything the publisher needs in at most two sandbox round-trips.
+        """Collect everything the publisher needs in exactly two sandbox round-trips (<=2 total).
 
-        Batch A (one round-trip): working-tree status, diff vs ``origin/<base_branch>``, untracked
+        Batch A: working-tree status, merge-base of ``origin/<base_branch>`` and ``HEAD``, untracked
         file list, remote branch list, and — when ``mr_source_branch`` is given —
-        ``origin/<mr_source_branch>..HEAD``. Batch B (only when untracked files exist): one
-        ``diff --no-index`` per untracked file, in a single round-trip. Replaces the previous
-        is_dirty/get_diff/has_unpushed/remote_branches sequence (~5+U round-trips) with <=2.
+        ``origin/<mr_source_branch>..HEAD``. Batch B (always): the working-tree diff against the
+        resolved merge-base SHA (or the branch tip when there is no common ancestor), plus one
+        ``diff --no-index`` per untracked file. Replaces the previous is_dirty/get_diff/has_unpushed/
+        remote_branches sequence (~5+U round-trips) with exactly 2. Diffing the merge-base (rather
+        than the branch tip) yields the branch's own delta only; tip diffing sweeps unrelated commits
+        in when the branch is stacked off a moving target.
         """
         batch_a: list[tuple[str, ...]] = [
             ("status", "--porcelain"),
-            ("diff", f"origin/{base_branch}"),
+            ("merge-base", f"origin/{base_branch}", "HEAD"),
             ("ls-files", "--others", "--exclude-standard"),
             ("ls-remote", "--heads", "origin"),
         ]
@@ -292,26 +295,42 @@ class GitManager:
             log_idx = len(batch_a) - 1
 
         res = await self._git_batch(batch_a)
-        status_res, diff_res, untracked_res, lsremote_res = res[0], res[1], res[2], res[3]
+        status_res, mergebase_res, untracked_res, lsremote_res = res[0], res[1], res[2], res[3]
 
-        # Exit-code discipline (same as the per-method versions): a real ref never exits non-zero for
-        # "differences found", and an empty branch list from a failing ls-remote would risk a colliding
-        # branch name, so raise rather than silently parse.
+        # status/ls-files use the same exit-code discipline as before.
         self._require_ok(batch_a[0], status_res)
-        self._require_ok(batch_a[1], diff_res)
         self._require_ok(batch_a[2], untracked_res)
+
+        # merge-base is deliberately NOT gated through _require_ok: exit 1 ("no common ancestor")
+        # is an expected outcome for unrelated histories, not a git failure. Fall back to the base
+        # branch tip so the diff still resolves.
+        if mergebase_res.exit_code == 0 and mergebase_res.output.strip():
+            base_ref = mergebase_res.output.strip().splitlines()[0]
+        else:
+            logger.warning(
+                "status_snapshot: `git merge-base origin/%s HEAD` found no common ancestor (exit %s); "
+                "falling back to the branch tip. Output: %s",
+                base_branch,
+                mergebase_res.exit_code,
+                mergebase_res.output.strip(),
+            )
+            base_ref = f"origin/{base_branch}"
+
         # ls-remote is the publish flow's FIRST network op, so in local mode a rejected/absent
         # credential lands here before the push. Classify it as the same actionable transport error a
-        # push would raise (auth → GitPushPermissionError, unreachable → GitPushNetworkError) instead
-        # of a raw GitCommandError that bypasses the classifier; non-transport failures fall through
-        # to _require_ok unchanged.
+        # push would raise instead of a raw GitCommandError; non-transport failures fall through.
         if lsremote_res.exit_code != 0:
             _raise_for_transport_failure(list(batch_a[3]), lsremote_res)
         self._require_ok(batch_a[3], lsremote_res)
 
+        # Batch B: the working-tree diff against the resolved base, plus one diff --no-index per
+        # untracked file. The main diff depends on the merge-base from batch A, so batch B always runs.
         untracked = self._nonempty_lines(untracked_res.output)
-        batch_b = await self._git_batch([("diff", "--no-index", "/dev/null", f) for f in untracked])
-        diff = self._append_untracked(diff_res.output, untracked, batch_b)
+        diff_specs: list[tuple[str, ...]] = [("diff", base_ref)]
+        diff_specs += [("diff", "--no-index", "/dev/null", f) for f in untracked]
+        batch_b = await self._git_batch(diff_specs)
+        self._require_ok(diff_specs[0], batch_b[0])
+        diff = self._append_untracked(batch_b[0].output, untracked, batch_b[1:])
 
         if log_idx >= 0:
             log_res = res[log_idx]

--- a/daiv/automation/agent/middlewares/git.py
+++ b/daiv/automation/agent/middlewares/git.py
@@ -268,9 +268,7 @@ class GitMiddleware(AgentMiddleware[GitState, RuntimeCtx]):
             return None
         try:
             client = RepoClient.create_instance(git_platform=context.git_platform)
-            return await sync_to_async(client.get_merge_request_by_branches)(
-                context.repository.slug, current_branch, context.config.default_branch
-            )
+            return await sync_to_async(client.get_merge_request_by_branches)(context.repository.slug, current_branch)
         except _MR_LOOKUP_PLATFORM_ERRORS:
             logger.exception(
                 "Failed to look up open merge request for %s on %s", context.repository.slug, current_branch

--- a/daiv/automation/agent/publishers.py
+++ b/daiv/automation/agent/publishers.py
@@ -300,10 +300,16 @@ class GitChangePublisher(ChangePublisher):
                 else self.ctx.issue.assignee.username
             )
 
+        target_branch = (
+            fallback_from_mr.target_branch
+            if fallback_from_mr is not None
+            else cast("str", self.ctx.config.default_branch)
+        )
+
         return await sync_to_async(self.client.update_or_create_merge_request)(
             repo_id=self.ctx.repository.slug,
             source_branch=branch_name,
-            target_branch=cast("str", self.ctx.config.default_branch),
+            target_branch=target_branch,
             labels=[BOT_LABEL],
             title=title,
             assignee_id=assignee_id,

--- a/daiv/automation/agent/publishers.py
+++ b/daiv/automation/agent/publishers.py
@@ -83,8 +83,8 @@ class GitChangePublisher(ChangePublisher):
         default_branch = cast("str", self.ctx.config.default_branch)
         # The diff base is the MR's real target — for a branch stacked off a release branch that is
         # the release branch, not the default. status_snapshot then diffs against the merge-base of
-        # this branch and HEAD. Falls back to the default branch when there is no MR (fresh work).
-        base_branch = merge_request.target_branch if merge_request is not None else default_branch
+        # this branch and HEAD. Falls back to the default branch when there is no MR (or a blank target).
+        base_branch = (merge_request.target_branch if merge_request is not None else default_branch) or default_branch
 
         # Local-mode git (sandbox-disabled runs) pushes from the DAIV-container clone, whose
         # .git/config deliberately holds no credential — overlay the per-run credential on its git

--- a/daiv/automation/agent/publishers.py
+++ b/daiv/automation/agent/publishers.py
@@ -84,7 +84,9 @@ class GitChangePublisher(ChangePublisher):
         # The diff base is the MR's real target — for a branch stacked off a release branch that is
         # the release branch, not the default. status_snapshot then diffs against the merge-base of
         # this branch and HEAD. Falls back to the default branch when there is no MR (or a blank target).
-        base_branch = (merge_request.target_branch if merge_request is not None else default_branch) or default_branch
+        base_branch = (
+            merge_request.target_branch if merge_request is not None and merge_request.target_branch else default_branch
+        )
 
         # Local-mode git (sandbox-disabled runs) pushes from the DAIV-container clone, whose
         # .git/config deliberately holds no credential — overlay the per-run credential on its git

--- a/daiv/automation/agent/publishers.py
+++ b/daiv/automation/agent/publishers.py
@@ -81,6 +81,10 @@ class GitChangePublisher(ChangePublisher):
         """
         protected_branch_fallback_source: str | None = None
         default_branch = cast("str", self.ctx.config.default_branch)
+        # The diff base is the MR's real target — for a branch stacked off a release branch that is
+        # the release branch, not the default. status_snapshot then diffs against the merge-base of
+        # this branch and HEAD. Falls back to the default branch when there is no MR (fresh work).
+        base_branch = merge_request.target_branch if merge_request is not None else default_branch
 
         # Local-mode git (sandbox-disabled runs) pushes from the DAIV-container clone, whose
         # .git/config deliberately holds no credential — overlay the per-run credential on its git
@@ -100,7 +104,7 @@ class GitChangePublisher(ChangePublisher):
             sandbox_backend=self.sandbox_backend, gitrepo=self.ctx.gitrepo, auth_env=auth_env
         ) as git_manager:
             snapshot = await git_manager.status_snapshot(
-                base_branch=default_branch,
+                base_branch=base_branch,
                 mr_source_branch=merge_request.source_branch if merge_request is not None else None,
             )
 

--- a/daiv/chat/repo_state.py
+++ b/daiv/chat/repo_state.py
@@ -73,7 +73,7 @@ async def aget_existing_mr_payload(repo_id: str, ref: str) -> dict[str, Any] | N
         if ref == config.default_branch:
             return None
         client = RepoClient.create_instance()
-        mr = await sync_to_async(client.get_merge_request_by_branches)(repo_id, ref, config.default_branch)
+        mr = await sync_to_async(client.get_merge_request_by_branches)(repo_id, ref)
     except _PLATFORM_ERRORS:
         logger.exception("Failed to look up existing merge request for %s on %s", repo_id, ref)
         return None

--- a/daiv/codebase/clients/base.py
+++ b/daiv/codebase/clients/base.py
@@ -423,14 +423,15 @@ class RepoClient(abc.ABC):
     def get_merge_request_by_branches(self, repo_id: str, source_branch: str) -> MergeRequest | None:
         """
         Return the open merge request whose source branch is ``source_branch`` (regardless of its
-        target branch), or ``None``.
+        target branch), or ``None``. When several open MRs share the source branch, the oldest is
+        returned so the choice is deterministic.
 
         Args:
             repo_id: The repository ID.
             source_branch: The source branch.
 
         Returns:
-            The first open MR with this source branch, or ``None`` if none exist.
+            The oldest open MR with this source branch, or ``None`` if none exist.
         """
         pass
 

--- a/daiv/codebase/clients/base.py
+++ b/daiv/codebase/clients/base.py
@@ -420,19 +420,17 @@ class RepoClient(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def get_merge_request_by_branches(
-        self, repo_id: str, source_branch: str, target_branch: str
-    ) -> MergeRequest | None:
+    def get_merge_request_by_branches(self, repo_id: str, source_branch: str) -> MergeRequest | None:
         """
-        Return the first open merge request for this source/target branch pair, or ``None``.
+        Return the open merge request whose source branch is ``source_branch`` (regardless of its
+        target branch), or ``None``.
 
         Args:
             repo_id: The repository ID.
             source_branch: The source branch.
-            target_branch: The target branch.
 
         Returns:
-            The first open MR matching the branch pair, or ``None`` if none exist.
+            The first open MR with this source branch, or ``None`` if none exist.
         """
         pass
 

--- a/daiv/codebase/clients/github/client.py
+++ b/daiv/codebase/clients/github/client.py
@@ -529,23 +529,23 @@ class GitHubClient(RepoClient):
             draft=pr.draft,
         )
 
-    def get_merge_request_by_branches(
-        self, repo_id: str, source_branch: str, target_branch: str
-    ) -> MergeRequest | None:
+    def get_merge_request_by_branches(self, repo_id: str, source_branch: str) -> MergeRequest | None:
         """
-        Return the open pull request for this source/target branch pair, or ``None``.
+        Return the open pull request whose head branch is ``source_branch`` (any base), or ``None``.
 
         Args:
             repo_id: The repository ID.
-            source_branch: The source branch.
-            target_branch: The target branch.
+            source_branch: The head branch.
 
         Returns:
-            The pull request if one open PR matches, otherwise ``None``.
+            The first open PR with this head branch, otherwise ``None``.
         """
         repo = self.client.get_repo(repo_id, lazy=True)
-        prs = repo.get_pulls(state="open", base=target_branch, head=source_branch)
-        pr = next(iter(prs), None)
+        owner = repo_id.split("/", 1)[0]
+        prs = repo.get_pulls(state="open", head=f"{owner}:{source_branch}")
+        # GitHub's `head` filter expects ``owner:ref`` and is only advisory; confirm the ref
+        # client-side so a mis-parsed filter can never return an unrelated open PR.
+        pr = next((p for p in prs if p.head.ref == source_branch), None)
         if pr is None:
             return None
         return MergeRequest(

--- a/daiv/codebase/clients/github/client.py
+++ b/daiv/codebase/clients/github/client.py
@@ -547,18 +547,16 @@ class GitHubClient(RepoClient):
         owner = repo_id.split("/", 1)[0]
         prs = repo.get_pulls(state="open", head=f"{owner}:{source_branch}", sort="created", direction="asc")
         # GitHub's `head` filter (owner:ref) is only advisory; re-check head.ref client-side so a
-        # loosely-matched filter can't return a PR on a different branch name.
-        matches = [p for p in prs if p.head.ref == source_branch]
-        if len(matches) > 1:
-            logger.warning(
-                "Multiple open PRs for head %s in %s; using the oldest (#%s).",
-                source_branch,
-                repo_id,
-                matches[0].number,
-            )
-        pr = matches[0] if matches else None
+        # loosely-matched filter can't return a PR on a different branch name. Pull lazily (like
+        # GitLab): take the first match, then peek one more only to detect duplicates.
+        matches = (p for p in prs if p.head.ref == source_branch)
+        pr = next(matches, None)
         if pr is None:
             return None
+        if next(matches, None) is not None:
+            logger.warning(
+                "Multiple open PRs for head %s in %s; using the oldest (#%s).", source_branch, repo_id, pr.number
+            )
         return MergeRequest(
             repo_id=repo_id,
             merge_request_id=pr.number,

--- a/daiv/codebase/clients/github/client.py
+++ b/daiv/codebase/clients/github/client.py
@@ -533,19 +533,30 @@ class GitHubClient(RepoClient):
         """
         Return the open pull request whose head branch is ``source_branch`` (any base), or ``None``.
 
+        A head branch can feed several open PRs (to different bases); ``sort``/``direction`` pin the
+        pick to the oldest so the choice is deterministic rather than API-default ordering.
+
         Args:
             repo_id: The repository ID.
             source_branch: The head branch.
 
         Returns:
-            The first open PR with this head branch, otherwise ``None``.
+            The oldest open PR with this head branch, otherwise ``None``.
         """
         repo = self.client.get_repo(repo_id, lazy=True)
         owner = repo_id.split("/", 1)[0]
-        prs = repo.get_pulls(state="open", head=f"{owner}:{source_branch}")
-        # GitHub's `head` filter expects ``owner:ref`` and is only advisory; confirm the ref
-        # client-side so a mis-parsed filter can never return an unrelated open PR.
-        pr = next((p for p in prs if p.head.ref == source_branch), None)
+        prs = repo.get_pulls(state="open", head=f"{owner}:{source_branch}", sort="created", direction="asc")
+        # GitHub's `head` filter (owner:ref) is only advisory; re-check head.ref client-side so a
+        # loosely-matched filter can't return a PR on a different branch name.
+        matches = [p for p in prs if p.head.ref == source_branch]
+        if len(matches) > 1:
+            logger.warning(
+                "Multiple open PRs for head %s in %s; using the oldest (#%s).",
+                source_branch,
+                repo_id,
+                matches[0].number,
+            )
+        pr = matches[0] if matches else None
         if pr is None:
             return None
         return MergeRequest(

--- a/daiv/codebase/clients/gitlab/client.py
+++ b/daiv/codebase/clients/gitlab/client.py
@@ -754,18 +754,30 @@ class GitLabClient(RepoClient):
         """
         Return the open merge request whose source branch is ``source_branch`` (any target), or ``None``.
 
+        A source branch can feed several open MRs (to different targets); ``order_by``/``sort`` pin the
+        pick to the oldest so the choice is deterministic rather than API-default ordering.
+
         Args:
             repo_id: The repository ID.
             source_branch: The source branch.
 
         Returns:
-            The first open MR with this source branch, otherwise ``None``.
+            The oldest open MR with this source branch, otherwise ``None``.
         """
         project = self.client.projects.get(repo_id, lazy=True)
-        merge_requests = project.mergerequests.list(source_branch=source_branch, state="opened", iterator=True)
+        merge_requests = project.mergerequests.list(
+            source_branch=source_branch, state="opened", order_by="created_at", sort="asc", iterator=True
+        )
         merge_request = next(merge_requests, None)
         if merge_request is None:
             return None
+        if next(merge_requests, None) is not None:
+            logger.warning(
+                "Multiple open MRs for source branch %s in %s; using the oldest (!%s).",
+                source_branch,
+                repo_id,
+                merge_request.iid,
+            )
         return self._serialize_merge_request(repo_id, merge_request)
 
     def update_merge_request(

--- a/daiv/codebase/clients/gitlab/client.py
+++ b/daiv/codebase/clients/gitlab/client.py
@@ -750,24 +750,19 @@ class GitLabClient(RepoClient):
         # error, if the branch genuinely never appeared — is the caller's to handle.
         return project.mergerequests.create(payload)
 
-    def get_merge_request_by_branches(
-        self, repo_id: str, source_branch: str, target_branch: str
-    ) -> MergeRequest | None:
+    def get_merge_request_by_branches(self, repo_id: str, source_branch: str) -> MergeRequest | None:
         """
-        Return the open merge request for this source/target branch pair, or ``None``.
+        Return the open merge request whose source branch is ``source_branch`` (any target), or ``None``.
 
         Args:
             repo_id: The repository ID.
             source_branch: The source branch.
-            target_branch: The target branch.
 
         Returns:
-            The merge request if one open MR matches, otherwise ``None``.
+            The first open MR with this source branch, otherwise ``None``.
         """
         project = self.client.projects.get(repo_id, lazy=True)
-        merge_requests = project.mergerequests.list(
-            source_branch=source_branch, target_branch=target_branch, state="opened", iterator=True
-        )
+        merge_requests = project.mergerequests.list(source_branch=source_branch, state="opened", iterator=True)
         merge_request = next(merge_requests, None)
         if merge_request is None:
             return None

--- a/daiv/codebase/clients/swe.py
+++ b/daiv/codebase/clients/swe.py
@@ -335,14 +335,10 @@ class SWERepoClient(RepoClient):
         """Not supported for SWE client."""
         raise NotImplementedError("SWERepoClient does not support merge requests")
 
-    def get_merge_request_by_branches(
-        self, repo_id: str, source_branch: str, target_branch: str
-    ) -> MergeRequest | None:
+    def get_merge_request_by_branches(self, repo_id: str, source_branch: str) -> MergeRequest | None:
         """SWE runs have no merge-request concept: there is never an open MR, so report
-        none rather than raising — platform-agnostic callers (e.g. GitMiddleware's
-        pre-run MR lookup) then fall through gracefully. Defense in depth: that lookup
-        already short-circuits on the detached HEAD typical of SWE runs, so this only
-        fires for hypothetical branch-based ones."""
+        none rather than raising — platform-agnostic callers (e.g. GitMiddleware's pre-run
+        MR lookup) then fall through gracefully."""
         return None
 
     def get_merge_request_comment(self, repo_id: str, merge_request_id: int, comment_id: str) -> Discussion:

--- a/tests/unit_tests/automation/agent/middlewares/test_git.py
+++ b/tests/unit_tests/automation/agent/middlewares/test_git.py
@@ -357,7 +357,23 @@ class TestGitMiddleware:
             mr = await GitMiddleware._alookup_open_mr(runtime.context)  # noqa: SLF001
 
         assert mr is existing_mr
-        client.get_merge_request_by_branches.assert_called_once_with("a/b", "feature-x", "main")
+        client.get_merge_request_by_branches.assert_called_once_with("a/b", "feature-x")
+
+    async def test_alookup_open_mr_returns_nondefault_target_mr(self):
+        """The lookup no longer filters on target, so an MR targeting a release branch is found."""
+        runtime = _make_runtime()
+        existing_mr = MagicMock(source_branch="feature-x", target_branch="release/x")
+        client = MagicMock()
+        client.get_merge_request_by_branches = MagicMock(return_value=existing_mr)
+
+        with (
+            patch("automation.agent.middlewares.git.get_repo_ref", return_value="feature-x"),
+            patch("automation.agent.middlewares.git.RepoClient.create_instance", return_value=client),
+        ):
+            mr = await GitMiddleware._alookup_open_mr(runtime.context)  # noqa: SLF001
+
+        assert mr.target_branch == "release/x"
+        client.get_merge_request_by_branches.assert_called_once_with("a/b", "feature-x")
 
     async def test_alookup_open_mr_skips_detached_head(self):
         """Commit-pinned runs (SWE-bench evals check out a raw SHA) have no branch, so

--- a/tests/unit_tests/automation/agent/test_git_manager.py
+++ b/tests/unit_tests/automation/agent/test_git_manager.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock
 
@@ -581,17 +582,63 @@ async def test_status_snapshot_diffs_against_merge_base_in_batch_b() -> None:
     assert "diff mb123" in batch_b.commands[0]
 
 
-async def test_status_snapshot_falls_back_to_tip_when_no_merge_base() -> None:
-    """A merge-base exit 1 (unrelated histories) falls back to diffing origin/<base> tip."""
+async def test_status_snapshot_falls_back_to_tip_when_no_merge_base(caplog) -> None:
+    """A merge-base exit 1 (unrelated histories) falls back to diffing origin/<base> tip, with a warning."""
     client = MagicMock()
     client.run_commands = AsyncMock(
         side_effect=[_resp(("", 0), ("", 1), ("", 0), ("abc\trefs/heads/main\n", 0)), _resp(("", 0))]
+    )
+    gm = GitManager.for_sandbox(_backend_for(client))
+    with caplog.at_level(logging.WARNING, logger="daiv.tools"):
+        snap = await gm.status_snapshot(base_branch="main", mr_source_branch=None)
+    assert snap.diff == ""
+    batch_b = client.run_commands.await_args_list[1].args[1]
+    assert "diff origin/main" in batch_b.commands[0]
+    assert "no common ancestor" in caplog.text
+
+
+async def test_status_snapshot_falls_back_to_tip_on_empty_merge_base_output() -> None:
+    """merge-base exit 0 but no SHA (anomalous) falls back to the tip rather than an empty ref."""
+    client = MagicMock()
+    client.run_commands = AsyncMock(
+        side_effect=[_resp(("", 0), ("", 0), ("", 0), ("abc\trefs/heads/main\n", 0)), _resp(("", 0))]
     )
     gm = GitManager.for_sandbox(_backend_for(client))
     snap = await gm.status_snapshot(base_branch="main", mr_source_branch=None)
     assert snap.diff == ""
     batch_b = client.run_commands.await_args_list[1].args[1]
     assert "diff origin/main" in batch_b.commands[0]
+
+
+async def test_status_snapshot_raises_on_merge_base_hard_failure() -> None:
+    """A merge-base failure that is NOT "no common ancestor" (exit 128, bad/missing ref) must surface
+    rather than be mislabeled as unrelated histories and swept into the tip fallback."""
+    client = MagicMock()
+    client.run_commands = AsyncMock(
+        return_value=_resp(("", 0), ("fatal: Not a valid object name", 128), ("", 0), ("abc\trefs/heads/main\n", 0))
+    )
+    gm = GitManager.for_sandbox(_backend_for(client))
+    with pytest.raises(GitCommandError) as exc_info:
+        await gm.status_snapshot(base_branch="main", mr_source_branch=None)
+    assert "merge-base origin/main HEAD" in str(exc_info.value)
+    # Raises during batch A, before the batch-B diff round-trip.
+    assert client.run_commands.await_count == 1
+
+
+async def test_status_snapshot_raises_when_batch_b_main_diff_fails() -> None:
+    """The main working-tree diff moved to batch B; a non-zero exit there must still raise."""
+    client = MagicMock()
+    client.run_commands = AsyncMock(
+        side_effect=[
+            _resp(("", 0), ("mb123\n", 0), ("", 0), ("abc\trefs/heads/main\n", 0)),
+            _resp(("fatal: bad object", 128)),
+        ]
+    )
+    gm = GitManager.for_sandbox(_backend_for(client))
+    with pytest.raises(GitCommandError) as exc_info:
+        await gm.status_snapshot(base_branch="main", mr_source_branch=None)
+    assert "diff mb123" in str(exc_info.value)
+    assert client.run_commands.await_count == 2
 
 
 async def test_status_snapshot_folds_untracked_into_batch_b() -> None:

--- a/tests/unit_tests/automation/agent/test_git_manager.py
+++ b/tests/unit_tests/automation/agent/test_git_manager.py
@@ -12,7 +12,6 @@ from automation.agent.git_manager import (
     GitPushNetworkError,
     GitPushPermissionError,
     GitPushStaleError,
-    RepoStatus,
     _GitResult,
     _is_push_stale_error_text,
     _shell_quote,
@@ -561,34 +560,52 @@ def _backend_for(client) -> SandboxFileBackend:
     return backend
 
 
-async def test_status_snapshot_one_round_trip_when_clean() -> None:
-    client = MagicMock()
-    client.run_commands = AsyncMock(
-        return_value=_resp(("", 0), ("", 0), ("", 0), ("abc\trefs/heads/main\n", 0), ("", 0))
-    )
-    gm = GitManager.for_sandbox(_backend_for(client))
-    snap = await gm.status_snapshot(base_branch="main", mr_source_branch="feat/x")
-    assert isinstance(snap, RepoStatus)
-    assert (snap.dirty, snap.diff, snap.remote_branches, snap.has_unpushed) == (False, "", ["main"], False)
-    assert client.run_commands.await_count == 1
-    sent = client.run_commands.await_args.args[1]
-    assert sent.fail_fast is False
-    assert len(sent.commands) == 5
-
-
-async def test_status_snapshot_second_round_trip_only_for_untracked() -> None:
+async def test_status_snapshot_diffs_against_merge_base_in_batch_b() -> None:
     client = MagicMock()
     client.run_commands = AsyncMock(
         side_effect=[
-            _resp(("?? new.py\n", 0), ("", 0), ("new.py\n", 0), ("abc\trefs/heads/main\n", 0)),
-            _resp(("+++ b/new.py\n+hello\n", 1)),
+            # batch A: status, merge-base -> SHA, ls-files, ls-remote, log
+            _resp(("", 0), ("mb123\n", 0), ("", 0), ("abc\trefs/heads/main\n", 0), ("", 0)),
+            # batch B: the working-tree diff against the merge-base SHA
+            _resp(("", 0)),
+        ]
+    )
+    gm = GitManager.for_sandbox(_backend_for(client))
+    snap = await gm.status_snapshot(base_branch="main", mr_source_branch="feat/x")
+    assert (snap.dirty, snap.diff, snap.remote_branches, snap.has_unpushed) == (False, "", ["main"], False)
+    assert client.run_commands.await_count == 2
+    batch_a = client.run_commands.await_args_list[0].args[1]
+    assert len(batch_a.commands) == 5
+    assert any("merge-base origin/main HEAD" in c for c in batch_a.commands)
+    batch_b = client.run_commands.await_args_list[1].args[1]
+    assert "diff mb123" in batch_b.commands[0]
+
+
+async def test_status_snapshot_falls_back_to_tip_when_no_merge_base() -> None:
+    """A merge-base exit 1 (unrelated histories) falls back to diffing origin/<base> tip."""
+    client = MagicMock()
+    client.run_commands = AsyncMock(
+        side_effect=[_resp(("", 0), ("", 1), ("", 0), ("abc\trefs/heads/main\n", 0)), _resp(("", 0))]
+    )
+    gm = GitManager.for_sandbox(_backend_for(client))
+    snap = await gm.status_snapshot(base_branch="main", mr_source_branch=None)
+    assert snap.diff == ""
+    batch_b = client.run_commands.await_args_list[1].args[1]
+    assert "diff origin/main" in batch_b.commands[0]
+
+
+async def test_status_snapshot_folds_untracked_into_batch_b() -> None:
+    client = MagicMock()
+    client.run_commands = AsyncMock(
+        side_effect=[
+            _resp(("?? new.py\n", 0), ("mb123\n", 0), ("new.py\n", 0), ("abc\trefs/heads/main\n", 0)),
+            _resp(("", 0), ("+++ b/new.py\n+hello\n", 1)),  # diff <mb>, then diff --no-index for new.py
         ]
     )
     gm = GitManager.for_sandbox(_backend_for(client))
     snap = await gm.status_snapshot(base_branch="main", mr_source_branch=None)
     assert snap.dirty is True
     assert "new.py" in snap.diff
-    assert snap.has_unpushed is False
     assert client.run_commands.await_count == 2
 
 
@@ -651,13 +668,12 @@ def test_append_untracked_with_empty_base_has_no_leading_blank_line() -> None:
 
 
 @pytest.mark.parametrize(
-    "failing_index,command_fragment",
-    [(0, "status --porcelain"), (1, "diff origin/main"), (2, "ls-files --others"), (3, "ls-remote --heads")],
+    "failing_index,command_fragment", [(0, "status --porcelain"), (2, "ls-files --others"), (3, "ls-remote --heads")]
 )
 async def test_status_snapshot_raises_on_batch_a_command_failure(failing_index: int, command_fragment: str) -> None:
-    # A non-zero exit from any batch-A query must raise rather than parse to a misleading empty value
-    # (e.g. a failing ls-remote parsing to [] would risk a colliding branch name).
-    outputs = [("", 0), ("", 0), ("", 0), ("abc\trefs/heads/main\n", 0)]
+    # A non-zero exit from any *gated* batch-A query must raise rather than parse to a misleading
+    # empty value. (merge-base at index 1 is intentionally tolerant and excluded here.)
+    outputs = [("", 0), ("mb123\n", 0), ("", 0), ("abc\trefs/heads/main\n", 0)]
     outputs[failing_index] = ("boom", 128)
     client = MagicMock()
     client.run_commands = AsyncMock(return_value=_resp(*outputs))
@@ -665,15 +681,19 @@ async def test_status_snapshot_raises_on_batch_a_command_failure(failing_index: 
     with pytest.raises(GitCommandError) as exc_info:
         await gm.status_snapshot(base_branch="main", mr_source_branch=None)
     assert command_fragment in str(exc_info.value)
-    # The failing check short-circuits before the untracked second round-trip.
+    # The failing check short-circuits before the batch-B diff round-trip.
     assert client.run_commands.await_count == 1
 
 
 async def test_status_snapshot_has_unpushed_true_when_log_has_output() -> None:
     # mr_source_branch present and `git log origin/<src>..HEAD` returns commits -> has_unpushed True.
+    # Batch A: status, merge-base, ls-files, ls-remote, log. Batch B: diff <merge-base>.
     client = MagicMock()
     client.run_commands = AsyncMock(
-        return_value=_resp(("", 0), ("", 0), ("", 0), ("abc\trefs/heads/main\n", 0), ("abc123 commit\n", 0))
+        side_effect=[
+            _resp(("", 0), ("mb123\n", 0), ("", 0), ("abc\trefs/heads/main\n", 0), ("abc123 commit\n", 0)),
+            _resp(("", 0)),
+        ]
     )
     gm = GitManager.for_sandbox(_backend_for(client))
     snap = await gm.status_snapshot(base_branch="main", mr_source_branch="feat/x")
@@ -685,7 +705,10 @@ async def test_status_snapshot_treats_log_failure_as_unpushed() -> None:
     # unpushed" rather than raising, mirroring has_unpushed().
     client = MagicMock()
     client.run_commands = AsyncMock(
-        return_value=_resp(("", 0), ("", 0), ("", 0), ("abc\trefs/heads/main\n", 0), ("fatal: bad revision", 128))
+        side_effect=[
+            _resp(("", 0), ("mb123\n", 0), ("", 0), ("abc\trefs/heads/main\n", 0), ("fatal: bad revision", 128)),
+            _resp(("", 0)),
+        ]
     )
     gm = GitManager.for_sandbox(_backend_for(client))
     snap = await gm.status_snapshot(base_branch="main", mr_source_branch="feat/x")

--- a/tests/unit_tests/automation/agent/test_publishers.py
+++ b/tests/unit_tests/automation/agent/test_publishers.py
@@ -543,6 +543,32 @@ class TestPublishDecision:
         meta.assert_not_called()
         gm.push_head_to.assert_not_called()
 
+    async def test_diffs_against_existing_mr_target_branch(self, monkeypatch):
+        """An in-review MR targeting a non-default branch is diffed against that branch, not main."""
+        publisher = _make_publisher()
+        mr = _make_merge_request(source_branch="feat/x", target_branch="release/x", merge_request_id=42)
+        gm = _fake_git_manager(dirty=False, diff="diff", remote_branches=["feat/x"], has_unpushed=False)
+        _patch_open_git_manager(monkeypatch, gm)
+
+        with patch.object(publisher, "_diff_to_metadata") as meta:
+            outcome = await publisher.publish(merge_request=mr)
+
+        assert gm.status_snapshot.await_args.kwargs["base_branch"] == "release/x"
+        assert gm.status_snapshot.await_args.kwargs["mr_source_branch"] == "feat/x"
+        # Clean tree already on its MR → no duplicate MR, no metadata call.
+        assert outcome == PublishOutcome(merge_request=mr, published=False)
+        meta.assert_not_called()
+
+    async def test_diffs_against_default_branch_when_no_mr(self, monkeypatch):
+        publisher = _make_publisher()
+        gm = _fake_git_manager(dirty=False, diff="", has_unpushed=False)
+        _patch_open_git_manager(monkeypatch, gm)
+
+        with patch.object(publisher, "_diff_to_metadata"):
+            await publisher.publish(merge_request=None)
+
+        assert gm.status_snapshot.await_args.kwargs["base_branch"] == "main"
+
 
 def test_create_merge_request_and_suggest_are_async():
     assert inspect.iscoroutinefunction(GitChangePublisher._create_merge_request)

--- a/tests/unit_tests/automation/agent/test_publishers.py
+++ b/tests/unit_tests/automation/agent/test_publishers.py
@@ -412,7 +412,7 @@ class TestPublishSuggestsContextFile:
             assert result == PublishOutcome(merge_request=mr, published=True)
 
     async def test_falls_back_to_new_mr_when_source_branch_protected(self, publisher, monkeypatch):
-        existing_mr = _make_merge_request(source_branch="dev", merge_request_id=42)
+        existing_mr = _make_merge_request(source_branch="dev", target_branch="release/x", merge_request_id=42)
         new_mr = _make_merge_request(source_branch="feature-fix", merge_request_id=43)
         publisher.client.is_branch_protected.return_value = True
         gm = _fake_git_manager()
@@ -442,6 +442,9 @@ class TestPublishSuggestsContextFile:
             # The new MR is created with a back-link to the original protected MR.
             mock_create_mr.assert_called_once()
             assert mock_create_mr.call_args.kwargs["fallback_from_mr"] is existing_mr
+            # The original MR's non-default target flows through to the fallback (paired with the unit
+            # test that _create_merge_request derives target_branch from it).
+            assert mock_create_mr.call_args.kwargs["fallback_from_mr"].target_branch == "release/x"
             # No fallback comment is posted from the publisher itself.
             publisher.client.create_merge_request_comment.assert_not_called()
             # Fallback source is exposed on the outcome so the manager can bundle a footer onto the
@@ -574,6 +577,32 @@ class TestPublishDecision:
         # Clean tree already on its MR → no duplicate MR, no metadata call.
         assert outcome == PublishOutcome(merge_request=mr, published=False)
         meta.assert_not_called()
+
+    async def test_diffs_against_existing_mr_target_branch_on_dirty_tree(self, monkeypatch):
+        """A dirty tree on a non-default-target MR still diffs against that target and proceeds to
+        commit/push — guards against a regression recomputing the base below the clean short-circuit."""
+        publisher = _make_publisher()
+        mr = _make_merge_request(source_branch="feat/x", target_branch="release/x", merge_request_id=42)
+        gm = _fake_git_manager()  # dirty=True, has_unpushed=True → publish proceeds
+        _patch_open_git_manager(monkeypatch, gm)
+
+        with (
+            patch.object(
+                publisher,
+                "_diff_to_metadata",
+                return_value={
+                    "pr_metadata": Mock(branch="feat/x", title="Title", description="Desc"),
+                    "commit_message": Mock(commit_message="commit msg"),
+                },
+            ) as meta,
+            patch.object(publisher, "_suggest_context_file"),
+        ):
+            outcome = await publisher.publish(merge_request=mr)
+
+        assert gm.status_snapshot.await_args.kwargs["base_branch"] == "release/x"
+        meta.assert_called_once()  # proceeded past the clean short-circuit
+        gm.push_head_to.assert_awaited_once_with("feat/x", integrate_on_reject=True)
+        assert outcome == PublishOutcome(merge_request=mr, published=True)
 
     async def test_diffs_against_default_branch_when_no_mr(self, monkeypatch):
         publisher = _make_publisher()

--- a/tests/unit_tests/automation/agent/test_publishers.py
+++ b/tests/unit_tests/automation/agent/test_publishers.py
@@ -216,6 +216,22 @@ class TestCreateMergeRequestDescription:
         assert "#10" in description
         assert "!10" not in description
 
+    async def test_fallback_mr_inherits_original_target(self):
+        """A protected-branch fallback MR targets the original MR's target, not the default."""
+        publisher = self._make_publisher_with_no_issue()
+        original = _make_merge_request(source_branch="dev", target_branch="release/x", merge_request_id=42)
+
+        await publisher._create_merge_request("feature-fix", "Title", "Body", fallback_from_mr=original)
+
+        assert publisher.client.update_or_create_merge_request.call_args.kwargs["target_branch"] == "release/x"
+
+    async def test_new_mr_targets_default_without_fallback(self):
+        publisher = self._make_publisher_with_no_issue()
+
+        await publisher._create_merge_request("feature", "Title", "Body")
+
+        assert publisher.client.update_or_create_merge_request.call_args.kwargs["target_branch"] == "main"
+
 
 class TestBuildIssueCreationUrl:
     def test_gitlab_url_format(self):

--- a/tests/unit_tests/chat/test_repo_state.py
+++ b/tests/unit_tests/chat/test_repo_state.py
@@ -64,7 +64,7 @@ async def test_returns_payload_on_happy_path():
     assert result == mr_to_payload(_make_mr())
     assert result["id"] == 42
     assert result["draft"] is True
-    repo_client.get_merge_request_by_branches.assert_called_once_with("a/b", "feature-x", "main")
+    repo_client.get_merge_request_by_branches.assert_called_once_with("a/b", "feature-x")
 
 
 async def test_returns_none_when_lookup_returns_none():

--- a/tests/unit_tests/codebase/clients/github/test_client.py
+++ b/tests/unit_tests/codebase/clients/github/test_client.py
@@ -1,3 +1,4 @@
+import logging
 from unittest.mock import Mock, patch
 
 import pytest
@@ -422,7 +423,7 @@ class TestGitHubClient:
         assert result.draft is True
         assert result.web_url == "https://github.com/o/r/pull/7"
         assert result.labels == ["enhancement"]
-        mock_repo.get_pulls.assert_called_once_with(state="open", head="owner:feat-x")
+        mock_repo.get_pulls.assert_called_once_with(state="open", head="owner:feat-x", sort="created", direction="asc")
 
     def test_get_merge_request_by_branches_skips_mismatched_head(self, github_client):
         """GitHub's `head` filter is advisory; a PR whose head.ref != source is ignored."""
@@ -435,6 +436,28 @@ class TestGitHubClient:
         result = github_client.get_merge_request_by_branches("owner/repo", "feat-x")
 
         assert result is None
+
+    def test_get_merge_request_by_branches_warns_and_picks_oldest_on_multiple(self, github_client, caplog):
+        """Several open PRs share the head branch: pick the oldest (sort=asc) and warn."""
+        mock_repo = Mock()
+        older = Mock(number=7)
+        older.head = Mock(ref="feat-x", sha="a")
+        older.base = Mock(ref="main")
+        older.title, older.body, older.labels = "older", "", []
+        older.html_url, older.draft = "https://github.com/o/r/pull/7", False
+        older.user = Mock(id=1, login="alice")
+        older.user.name = "Alice"
+        newer = Mock(number=8)
+        newer.head = Mock(ref="feat-x", sha="b")
+        mock_repo.get_pulls.return_value = iter([older, newer])
+        github_client.client.get_repo.return_value = mock_repo
+
+        with caplog.at_level(logging.WARNING, logger="daiv.clients"):
+            result = github_client.get_merge_request_by_branches("owner/repo", "feat-x")
+
+        assert result is not None
+        assert result.merge_request_id == 7
+        assert "Multiple open PRs" in caplog.text
 
     def test_is_branch_protected_returns_true_when_branch_protected(self, github_client):
         mock_repo = Mock()

--- a/tests/unit_tests/codebase/clients/github/test_client.py
+++ b/tests/unit_tests/codebase/clients/github/test_client.py
@@ -394,12 +394,12 @@ class TestGitHubClient:
         assert result == ["a", "b"]
 
     def test_get_merge_request_by_branches_returns_first_open_match(self, github_client):
-        """When an open PR exists for the source/target pair, return a serialized MergeRequest."""
+        """The lookup keys on the head branch only; the MR's real (non-default) base is returned."""
         mock_repo = Mock()
         mock_pr = Mock()
         mock_pr.number = 7
         mock_pr.head = Mock(ref="feat-x", sha="abc123")
-        mock_pr.base = Mock(ref="main")
+        mock_pr.base = Mock(ref="release/x")
         mock_pr.title = "feat: add x"
         mock_pr.body = "details"
         label = Mock()
@@ -413,16 +413,28 @@ class TestGitHubClient:
         mock_repo.get_pulls.return_value = iter([mock_pr])
         github_client.client.get_repo.return_value = mock_repo
 
-        result = github_client.get_merge_request_by_branches("owner/repo", "feat-x", "main")
+        result = github_client.get_merge_request_by_branches("owner/repo", "feat-x")
 
         assert result is not None
         assert result.merge_request_id == 7
         assert result.source_branch == "feat-x"
-        assert result.target_branch == "main"
+        assert result.target_branch == "release/x"
         assert result.draft is True
         assert result.web_url == "https://github.com/o/r/pull/7"
         assert result.labels == ["enhancement"]
-        mock_repo.get_pulls.assert_called_once_with(state="open", base="main", head="feat-x")
+        mock_repo.get_pulls.assert_called_once_with(state="open", head="owner:feat-x")
+
+    def test_get_merge_request_by_branches_skips_mismatched_head(self, github_client):
+        """GitHub's `head` filter is advisory; a PR whose head.ref != source is ignored."""
+        mock_repo = Mock()
+        wrong = Mock()
+        wrong.head = Mock(ref="other", sha="x")
+        mock_repo.get_pulls.return_value = iter([wrong])
+        github_client.client.get_repo.return_value = mock_repo
+
+        result = github_client.get_merge_request_by_branches("owner/repo", "feat-x")
+
+        assert result is None
 
     def test_is_branch_protected_returns_true_when_branch_protected(self, github_client):
         mock_repo = Mock()
@@ -449,12 +461,12 @@ class TestGitHubClient:
             assert github_client.is_branch_protected("owner/repo", "missing") is False
 
     def test_get_merge_request_by_branches_returns_none_when_empty(self, github_client):
-        """No open PR matching the branch pair → ``None``."""
+        """No open PR for the head branch → ``None``."""
         mock_repo = Mock()
         mock_repo.get_pulls.return_value = iter([])
         github_client.client.get_repo.return_value = mock_repo
 
-        result = github_client.get_merge_request_by_branches("owner/repo", "feat-x", "main")
+        result = github_client.get_merge_request_by_branches("owner/repo", "feat-x")
 
         assert result is None
 

--- a/tests/unit_tests/codebase/clients/gitlab/test_client.py
+++ b/tests/unit_tests/codebase/clients/gitlab/test_client.py
@@ -819,19 +819,18 @@ class TestGitLabClient:
         assert kwargs["per_page"] == 100
 
     def test_get_merge_request_by_branches_returns_first_open_match(self, gitlab_client):
-        """When an open MR exists for the source/target pair, return the serialized MR."""
+        """When an open MR exists for the source branch, return the serialized MR."""
         mock_project = Mock()
         mock_mr = Mock()
         mock_project.mergerequests.list.return_value = iter([mock_mr])
         gitlab_client.client.projects.get.return_value = mock_project
         sentinel = Mock(name="serialized")
         with patch.object(gitlab_client, "_serialize_merge_request", return_value=sentinel) as serialize:
-            result = gitlab_client.get_merge_request_by_branches("group/repo", "feat-x", "main")
+            result = gitlab_client.get_merge_request_by_branches("group/repo", "feat-x")
 
         assert result is sentinel
-        mock_project.mergerequests.list.assert_called_once_with(
-            source_branch="feat-x", target_branch="main", state="opened", iterator=True
-        )
+        mock_project.mergerequests.list.assert_called_once_with(source_branch="feat-x", state="opened", iterator=True)
+        assert "target_branch" not in mock_project.mergerequests.list.call_args.kwargs
         serialize.assert_called_once_with("group/repo", mock_mr)
 
     def test_is_branch_protected_returns_true_when_branch_protected(self, gitlab_client):
@@ -867,7 +866,7 @@ class TestGitLabClient:
         mock_project.mergerequests.list.return_value = iter([])
         gitlab_client.client.projects.get.return_value = mock_project
 
-        result = gitlab_client.get_merge_request_by_branches("group/repo", "feat-x", "main")
+        result = gitlab_client.get_merge_request_by_branches("group/repo", "feat-x")
 
         assert result is None
 

--- a/tests/unit_tests/codebase/clients/gitlab/test_client.py
+++ b/tests/unit_tests/codebase/clients/gitlab/test_client.py
@@ -829,9 +829,28 @@ class TestGitLabClient:
             result = gitlab_client.get_merge_request_by_branches("group/repo", "feat-x")
 
         assert result is sentinel
-        mock_project.mergerequests.list.assert_called_once_with(source_branch="feat-x", state="opened", iterator=True)
+        mock_project.mergerequests.list.assert_called_once_with(
+            source_branch="feat-x", state="opened", order_by="created_at", sort="asc", iterator=True
+        )
         assert "target_branch" not in mock_project.mergerequests.list.call_args.kwargs
         serialize.assert_called_once_with("group/repo", mock_mr)
+
+    def test_get_merge_request_by_branches_warns_and_picks_oldest_on_multiple(self, gitlab_client, caplog):
+        """Several open MRs share the source branch: return the oldest (sort=asc) and warn."""
+        mock_project = Mock()
+        oldest = Mock(iid=1)
+        mock_project.mergerequests.list.return_value = iter([oldest, Mock(iid=2)])
+        gitlab_client.client.projects.get.return_value = mock_project
+        sentinel = Mock(name="serialized")
+        with (
+            patch.object(gitlab_client, "_serialize_merge_request", return_value=sentinel) as serialize,
+            caplog.at_level(logging.WARNING, logger="daiv.clients"),
+        ):
+            result = gitlab_client.get_merge_request_by_branches("group/repo", "feat-x")
+
+        assert result is sentinel
+        serialize.assert_called_once_with("group/repo", oldest)
+        assert "Multiple open MRs" in caplog.text
 
     def test_is_branch_protected_returns_true_when_branch_protected(self, gitlab_client):
         mock_project = Mock()

--- a/tests/unit_tests/codebase/clients/test_swe.py
+++ b/tests/unit_tests/codebase/clients/test_swe.py
@@ -60,9 +60,8 @@ class TestSWERepoClient:
             client.get_repository("psf/requests")
 
     def test_get_merge_request_by_branches_returns_none(self, swe_client):
-        """SWE runs have no merge-request concept: report "no open MR" instead of raising,
-        so platform-agnostic callers (GitMiddleware's MR lookup) fall through gracefully."""
-        assert swe_client.get_merge_request_by_branches("psf/requests", "feature-x", "main") is None
+        """SWE runs have no merge-request concept: report "no open MR" instead of raising."""
+        assert swe_client.get_merge_request_by_branches("psf/requests", "feature-x") is None
 
     def test_list_repositories_not_supported(self, swe_client):
         """Test that listing repositories raises NotImplementedError."""


### PR DESCRIPTION
## Summary

Two coupled defects shared one false assumption: **a branch's merge request always targets the default branch.** A chat-scope run on a branch whose open MR targets a *non-default* branch (a release branch, or a stacked feature branch) was mishandled twice — DAIV opened a **duplicate MR against the default branch**, and generated commit/PR metadata from a diff describing **unrelated history**.

This branch resolves the MR by its **source branch only**, then derives the publish diff base from that MR's **real target**, diffing against the merge-base of source and target.

## Changes

- **`fix(codebase)`** — `get_merge_request_by_branches` now keys on the source branch only (drops the target-branch filter) across the base ABC and the GitLab, GitHub, and SWE clients, plus both callers. GitHub additionally uses the correct `owner:ref` head filter with a client-side `head.ref` guard so the advisory server-side filter can't return an unrelated PR.
- **`fix(agent)`** — `status_snapshot` diffs against the **merge-base** of `origin/<base>` and `HEAD` (tip fallback when there is no common ancestor), instead of the base-branch tip that swept unrelated commits into the metadata diff. The working-tree diff moves to batch B; the snapshot still costs at most two sandbox round-trips (now always exactly two).
- **`fix(agent)`** — `publish()` derives `base_branch` from `merge_request.target_branch` (default branch when there is no MR), so the diff feeding `diff_to_metadata` contains only the branch's own changes.
- **`fix(agent)`** — the protected-branch fallback MR inherits `fallback_from_mr.target_branch` instead of hardcoding the default, so a `release/x`-targeting MR whose source branch is protected is replaced by one that also targets `release/x`.

## Testing

- `make test` — 3970 passed, 0 failed.
- `make lint-typing` — at the pre-existing ty baseline; no new diagnostics on the changed files (`publishers.py` and `git_manager.py` have zero).

MR-scope, issue-scope, detached-HEAD (SWE), and default-branch runs are behaviorally unchanged.
