### PR TITLE
fix(codebase): self-heal chat & skip MR-comment runs on a gone branch

### DIFF
--- a/daiv/chat/api/streaming.py
+++ b/daiv/chat/api/streaming.py
@@ -241,7 +241,12 @@ class ChatRunStreamer:
                         self.thread_id,
                         effective_ref,
                     )
-                    await ChatSessionService.reset_ref(self.thread_id, effective_ref)
+                    try:
+                        await ChatSessionService.reset_ref(self.thread_id, effective_ref)
+                    except Exception:
+                        # The fallback clone already succeeded; a failed session re-pin must not paint
+                        # a viable run as RUN_ERROR. The ref_fallback event still moves the UI.
+                        logger.exception("chat: failed to reset session ref for thread_id=%s", self.thread_id)
                     yield CustomEvent(
                         type=EventType.CUSTOM,
                         name="ref_fallback",

--- a/daiv/chat/api/streaming.py
+++ b/daiv/chat/api/streaming.py
@@ -200,6 +200,7 @@ class ChatRunStreamer:
 
     async def events(self) -> AsyncIterator[BaseEvent]:
         last_mr: MergeRequest | None = None
+        effective_ref = self.ref
         clean_run = False
         # Set when the agent surfaces a failure. ``ag_ui_langgraph`` reports a LangGraph
         # stream error as a RUN_ERROR *event* and then returns normally (it does not raise),
@@ -229,15 +230,30 @@ class ChatRunStreamer:
                     ref=self.ref,
                     sandbox_env_id=self.sandbox_environment_id,
                     acting_user_id=self.user_id,
+                    fallback_ref_on_missing=True,
                 ) as runtime_ctx,
             ):
+                if runtime_ctx.repo.ref != self.ref:
+                    effective_ref = runtime_ctx.repo.ref
+                    logger.warning(
+                        "chat: ref %r no longer exists for thread_id=%s; fell back to default branch %r",
+                        self.ref,
+                        self.thread_id,
+                        effective_ref,
+                    )
+                    await ChatSessionService.reset_ref(self.thread_id, effective_ref)
+                    yield CustomEvent(
+                        type=EventType.CUSTOM,
+                        name="ref_fallback",
+                        value={"requested": self.ref, "using": effective_ref},
+                    )
                 # Record the turn as a RUNNING Run once we're committed to executing.
                 chat_run = await start_chat_run(
                     session_id=self.thread_id,
                     user_id=self.user_id,
                     prompt=self.prompt,
                     repo_id=self.repo_id,
-                    ref=self.ref,
+                    ref=effective_ref,
                     message_id=self.message_id,
                 )
                 agent_kwargs = get_daiv_agent_kwargs(
@@ -364,7 +380,7 @@ class ChatRunStreamer:
             succeeded = clean_run and run_error_message is None
             if succeeded:
                 try:
-                    await ChatSessionService.persist_ref(self.thread_id, self.ref, last_mr)
+                    await ChatSessionService.persist_ref(self.thread_id, effective_ref, last_mr)
                 except Exception:
                     logger.exception("chat: failed to persist session ref for thread_id=%s", self.thread_id)
             if chat_run is not None:

--- a/daiv/chat/api/threads.py
+++ b/daiv/chat/api/threads.py
@@ -124,3 +124,12 @@ class ChatSessionService:
         new_ref = mr.get("source_branch") if isinstance(mr, dict) else getattr(mr, "source_branch", None)
         if new_ref and new_ref != original_ref:
             await Session.objects.filter(thread_id=thread_id).aupdate(ref=new_ref)
+
+    @staticmethod
+    async def reset_ref(thread_id: str, new_ref: str) -> None:
+        """Re-pin ``Session.ref`` after a run fell back off a vanished branch.
+
+        Unlike ``persist_ref`` (success-only, driven by the agent's final MR), this fires the
+        moment the clone falls back, so the session self-heals even if the turn later fails.
+        """
+        await Session.objects.filter(thread_id=thread_id).aupdate(ref=new_ref)

--- a/daiv/chat/static/chat/js/chat-stream.js
+++ b/daiv/chat/static/chat/js/chat-stream.js
@@ -844,6 +844,12 @@
         } else {
           this._pushRunStatus("failed", evt.message || "Run failed.");
         }
+      } else if (type === AGUI.CUSTOM && evt.name === "ref_fallback") {
+        // The pinned branch was merged/deleted; the server fell back to the default branch
+        // and re-pinned the session. Move the composer ref pill so the UI matches reality.
+        const v = evt.value || {};
+        if (v.using) this._applyRepoState({ ref: v.using });
+        console.debug("chat: ref_fallback %o → %o", v.requested, v.using);
       } else if (type === AGUI.CUSTOM && evt.name === "resolved_env") {
         // Server resolved Auto → real env for this run. Swap the locked pill text in
         // place when the user is still on Auto client-side; an explicit mid-flight

--- a/daiv/codebase/base.py
+++ b/daiv/codebase/base.py
@@ -98,6 +98,9 @@ class MergeRequest(BaseModel):
     author: User
     draft: bool = False
     merged: bool = False
+    """Whether the MR/PR is merged. Only populated by ``get_merge_request`` — the fetch path the
+    merged-MR skip guard reads. Other construction sites keep the ``False`` default, so do not
+    treat it as a source of truth off those paths."""
 
 
 class MergeRequestDiff(BaseModel):

--- a/daiv/codebase/base.py
+++ b/daiv/codebase/base.py
@@ -97,6 +97,7 @@ class MergeRequest(BaseModel):
     sha: str | None = None
     author: User
     draft: bool = False
+    merged: bool = False
 
 
 class MergeRequestDiff(BaseModel):

--- a/daiv/codebase/clients/github/client.py
+++ b/daiv/codebase/clients/github/client.py
@@ -768,6 +768,7 @@ class GitHubClient(RepoClient):
             web_url=mr.html_url,
             sha=mr.head.sha,
             author=User(id=mr.user.id, username=mr.user.login, name=mr.user.name),
+            merged=mr.merged,
         )
 
     def get_merge_request_comment(self, repo_id: str, merge_request_id: int, comment_id: str) -> Discussion:

--- a/daiv/codebase/clients/github/client.py
+++ b/daiv/codebase/clients/github/client.py
@@ -7,7 +7,7 @@ from functools import cached_property
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from git import Repo
+from git import GitCommandError, Repo
 from github import Consts, Github, GithubIntegration, Installation, UnknownObjectException
 from github.GithubException import GithubException
 from github.IssueComment import IssueComment
@@ -35,7 +35,8 @@ from codebase.base import (
 )
 from codebase.clients import RepoClient
 from codebase.clients.base import Emoji, WebhookSetupResult
-from core.utils import async_download_url
+from codebase.exceptions import CloneRefNotFoundError
+from core.utils import async_download_url, is_git_ref_not_found_text
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -293,12 +294,17 @@ class GitHubClient(RepoClient):
             token = self._mint_installation_token(repository)
             clone_dir = Path(tmpdir) / "repo"
             clone_dir.mkdir(exist_ok=True)
-            repo = Repo.clone_from(
-                repository.clone_url,
-                clone_dir,
-                branch=sha,
-                env=GitAuthEnv.for_token(repository.clone_url, token).as_env(),
-            )
+            try:
+                repo = Repo.clone_from(
+                    repository.clone_url,
+                    clone_dir,
+                    branch=sha,
+                    env=GitAuthEnv.for_token(repository.clone_url, token).as_env(),
+                )
+            except GitCommandError as e:
+                if is_git_ref_not_found_text(f"{e.stderr or ''} {e}"):
+                    raise CloneRefNotFoundError(sha, repository.slug) from e
+                raise
             self._configure_commit_identity(repo)
             yield repo
 

--- a/daiv/codebase/clients/gitlab/client.py
+++ b/daiv/codebase/clients/gitlab/client.py
@@ -35,9 +35,9 @@ from codebase.base import (
 )
 from codebase.clients import RepoClient
 from codebase.clients.gitlab.clone_tokens import get_ephemeral_clone_token, invalidate_clone_token
-from codebase.exceptions import MergeRequestBranchNotVisibleError
+from codebase.exceptions import CloneRefNotFoundError, MergeRequestBranchNotVisibleError
 from core.constants import BOT_NAME
-from core.utils import async_download_url, build_uri, is_git_auth_error_text
+from core.utils import async_download_url, build_uri, is_git_auth_error_text, is_git_ref_not_found_text
 from daiv import USER_AGENT
 
 if TYPE_CHECKING:
@@ -396,7 +396,12 @@ class GitLabClient(RepoClient):
             logger.debug("Cloning repository %s to %s", repository.clone_url, tmpdir)
 
             clone_dir = Path(tmpdir) / "repo"
-            repo = self._clone(repository, sha, clone_dir)
+            try:
+                repo = self._clone(repository, sha, clone_dir)
+            except GitCommandError as e:
+                if is_git_ref_not_found_text(f"{e.stderr or ''} {e}"):
+                    raise CloneRefNotFoundError(sha, repository.slug) from e
+                raise
             self._configure_commit_identity(repo)
             yield repo
 

--- a/daiv/codebase/clients/gitlab/client.py
+++ b/daiv/codebase/clients/gitlab/client.py
@@ -998,6 +998,7 @@ class GitLabClient(RepoClient):
             web_url=mr.web_url,
             sha=mr.sha,
             author=User(id=mr.author.get("id"), username=mr.author.get("username"), name=mr.author.get("name")),
+            merged=mr.state == "merged",
         )
 
     def get_merge_request_comment(self, repo_id: str, merge_request_id: int, comment_id: str) -> Discussion:

--- a/daiv/codebase/clients/gitlab/client.py
+++ b/daiv/codebase/clients/gitlab/client.py
@@ -987,19 +987,7 @@ class GitLabClient(RepoClient):
         """
         project = self.client.projects.get(repo_id, lazy=True)
         mr = project.mergerequests.get(merge_request_id)
-        return MergeRequest(
-            repo_id=repo_id,
-            merge_request_id=cast("int", mr.get_id()),
-            source_branch=mr.source_branch,
-            target_branch=mr.target_branch,
-            title=mr.title,
-            description=mr.description,
-            labels=mr.labels,
-            web_url=mr.web_url,
-            sha=mr.sha,
-            author=User(id=mr.author.get("id"), username=mr.author.get("username"), name=mr.author.get("name")),
-            merged=mr.state == "merged",
-        )
+        return self._serialize_merge_request(repo_id, mr, merged=mr.state == "merged")
 
     def get_merge_request_comment(self, repo_id: str, merge_request_id: int, comment_id: str) -> Discussion:
         """
@@ -1176,7 +1164,9 @@ class GitLabClient(RepoClient):
             and (note_types is None or note["type"] in note_types)
         ]
 
-    def _serialize_merge_request(self, repo_id: str, merge_request: ProjectMergeRequest) -> MergeRequest:
+    def _serialize_merge_request(
+        self, repo_id: str, merge_request: ProjectMergeRequest, *, merged: bool = False
+    ) -> MergeRequest:
         return MergeRequest(
             repo_id=repo_id,
             merge_request_id=cast("int", merge_request.get_id()),
@@ -1193,4 +1183,5 @@ class GitLabClient(RepoClient):
                 name=merge_request.author.get("name"),
             ),
             draft=merge_request.work_in_progress,
+            merged=merged,
         )

--- a/daiv/codebase/context.py
+++ b/daiv/codebase/context.py
@@ -1,5 +1,5 @@
 import logging
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, cast
@@ -8,7 +8,7 @@ from git import Repo  # noqa: TC002
 
 from codebase.base import GitPlatform, Issue, MergeRequest, Repository, Scope  # noqa: TC001
 from codebase.clients import RepoClient
-from codebase.exceptions import SingleRepoRequiredError
+from codebase.exceptions import CloneRefNotFoundError, SingleRepoRequiredError
 from codebase.repo_config import RepositoryConfig  # noqa: TC001
 from core.sandbox.client import DAIVSandboxClient, reset_run_sandbox_client, set_run_sandbox_client
 from core.sandbox.command_policy import SandboxCommandPolicy  # noqa: TC001
@@ -61,6 +61,9 @@ class RepoHandle:
     repository: Repository
     gitrepo: Repo
     config: RepositoryConfig
+    ref: str
+    """The branch/ref actually checked out — may differ from the requested ref when a
+    vanished branch triggered a fallback to the default branch."""
 
 
 @dataclass(frozen=True)
@@ -118,6 +121,32 @@ class RuntimeCtx:
 runtime_ctx: ContextVar[RuntimeCtx | None] = ContextVar[RuntimeCtx | None]("runtime_ctx", default=None)
 
 
+@contextmanager
+def _load_repo_with_optional_fallback(repo_client, repository, ref, default_branch, fallback):
+    """Clone ``repository`` at ``ref``; on a vanished ref, optionally retry on ``default_branch``.
+
+    Yields ``(repo, effective_ref)``. The try/except wraps only the clone acquisition — a
+    ``CloneRefNotFoundError`` from the yielded body is not the concern here (nothing downstream
+    raises it). When ``fallback`` is False, or the missing ref already *is* the default branch,
+    the error propagates.
+    """
+    try:
+        with repo_client.load_repo(repository, sha=ref) as repo:
+            yield repo, ref
+            return
+    except CloneRefNotFoundError:
+        if not fallback or ref == default_branch:
+            raise
+    logger.warning(
+        "Clone of %s failed because ref %r no longer exists on the remote; falling back to the default branch %r.",
+        repository.slug,
+        ref,
+        default_branch,
+    )
+    with repo_client.load_repo(repository, sha=default_branch) as repo:
+        yield repo, default_branch
+
+
 @asynccontextmanager
 async def set_runtime_ctx(
     repo_id: str,
@@ -129,6 +158,7 @@ async def set_runtime_ctx(
     offline: bool = False,
     sandbox_env_id: str | None = None,
     acting_user_id: int | None = None,
+    fallback_ref_on_missing: bool = False,
     **kwargs: Any,
 ) -> AsyncIterator[RuntimeCtx]:
     """Set the runtime context and load repository files to a temporary directory.
@@ -146,6 +176,9 @@ async def set_runtime_ctx(
             :func:`sandbox_envs.services.resolve_env_for_run` using ``repo_id``; falls back
             to the GLOBAL default env if nothing matches.
         acting_user_id: DAIV user id that triggered the run; selects their personal MCP servers.
+        fallback_ref_on_missing: When True, a clone that fails because ``ref`` no longer exists on
+            the remote (a merged-and-deleted branch) retries on the repository default branch
+            instead of raising. ``ctx.repo.ref`` then reflects the branch actually used.
         **kwargs: Additional keyword arguments to pass to the repository client.
 
     Yields:
@@ -188,7 +221,9 @@ async def set_runtime_ctx(
         client_token = set_run_sandbox_client(sandbox_client)
 
     try:
-        with repo_client.load_repo(repository, sha=ref) as repo:
+        with _load_repo_with_optional_fallback(
+            repo_client, repository, ref, cast("str", config.default_branch), fallback_ref_on_missing
+        ) as (repo, effective_ref):
             # Always reach + authenticate the repo's git platform for git-over-HTTPS in the sandbox — DAIV
             # pushes from inside the sandbox, so even a network-off env is opened for the platform host when
             # a token can be minted. Runtime-only (never stored on the env); a no-op only when the sandbox is
@@ -202,6 +237,7 @@ async def set_runtime_ctx(
                 repository=repository,
                 gitrepo=repo,
                 config=config,
+                ref=effective_ref,
             )
             ctx = RuntimeCtx(
                 bot_username=repo_client.current_user.username,

--- a/daiv/codebase/context.py
+++ b/daiv/codebase/context.py
@@ -1,4 +1,5 @@
 import logging
+import sys
 from contextlib import asynccontextmanager, contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass
@@ -15,7 +16,7 @@ from core.sandbox.command_policy import SandboxCommandPolicy  # noqa: TC001
 from core.sandbox.schemas import EgressConfigRequest  # noqa: TC001
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator
+    from collections.abc import AsyncIterator, Iterator
 
 
 logger = logging.getLogger("daiv.codebase")
@@ -122,29 +123,37 @@ runtime_ctx: ContextVar[RuntimeCtx | None] = ContextVar[RuntimeCtx | None]("runt
 
 
 @contextmanager
-def _load_repo_with_optional_fallback(repo_client, repository, ref, default_branch, fallback):
+def _load_repo_with_optional_fallback(
+    repo_client: RepoClient, repository: Repository, ref: str, default_branch: str, fallback: bool
+) -> Iterator[tuple[Repo, str]]:
     """Clone ``repository`` at ``ref``; on a vanished ref, optionally retry on ``default_branch``.
 
-    Yields ``(repo, effective_ref)``. The try/except wraps only the clone acquisition — a
-    ``CloneRefNotFoundError`` from the yielded body is not the concern here (nothing downstream
-    raises it). When ``fallback`` is False, or the missing ref already *is* the default branch,
-    the error propagates.
+    Yields ``(repo, effective_ref)``. The clone is acquired inside the ``try/except`` but the
+    ``yield`` sits OUTSIDE it, so only a clone-acquisition failure can reach the except — an
+    exception raised by the yielded body is thrown back at the ``yield`` (via ``gen.throw()``)
+    and unwinds the ``finally`` teardown, never the fallback branch. When ``fallback`` is False,
+    or the missing ref already *is* the default branch, the ``CloneRefNotFoundError`` propagates.
     """
     try:
-        with repo_client.load_repo(repository, sha=ref) as repo:
-            yield repo, ref
-            return
+        cm = repo_client.load_repo(repository, sha=ref)
+        repo = cm.__enter__()
+        effective_ref = ref
     except CloneRefNotFoundError:
         if not fallback or ref == default_branch:
             raise
-    logger.warning(
-        "Clone of %s failed because ref %r no longer exists on the remote; falling back to the default branch %r.",
-        repository.slug,
-        ref,
-        default_branch,
-    )
-    with repo_client.load_repo(repository, sha=default_branch) as repo:
-        yield repo, default_branch
+        logger.warning(
+            "Clone of %s failed because ref %r no longer exists on the remote; falling back to the default branch %r.",
+            repository.slug,
+            ref,
+            default_branch,
+        )
+        cm = repo_client.load_repo(repository, sha=default_branch)
+        repo = cm.__enter__()
+        effective_ref = default_branch
+    try:
+        yield repo, effective_ref
+    finally:
+        cm.__exit__(*sys.exc_info())
 
 
 @asynccontextmanager

--- a/daiv/codebase/exceptions.py
+++ b/daiv/codebase/exceptions.py
@@ -24,3 +24,17 @@ class SingleRepoRequiredError(RuntimeError):
         detail = "got 0 (no repository supplied)" if actual == 0 else f"got {actual} (multi-repo not yet supported)"
         super().__init__(f"RuntimeCtx requires exactly one repository handle, {detail}.")
         self.actual = actual
+
+
+class CloneRefNotFoundError(RuntimeError):
+    """Raised when a clone fails because the requested branch/ref no longer exists on the remote.
+
+    The common trigger is a chat session (or an MR-comment run) pinned to a merge-request branch
+    that was merged and had its source branch deleted. Callers fall back to the default branch or
+    skip gracefully instead of letting an opaque ``GitCommandError`` reach Sentry.
+    """
+
+    def __init__(self, ref: str, repo_slug: str) -> None:
+        super().__init__(f"Ref '{ref}' does not exist on the remote for repository '{repo_slug}'.")
+        self.ref = ref
+        self.repo_slug = repo_slug

--- a/daiv/codebase/tasks.py
+++ b/daiv/codebase/tasks.py
@@ -14,14 +14,28 @@ from codebase.base import GitPlatform, Scope
 from codebase.clients import RepoClient
 from codebase.conf import settings as codebase_settings
 from codebase.context import set_runtime_ctx
+from codebase.exceptions import CloneRefNotFoundError
 from codebase.managers.issue_addressor import IssueAddressorManager
 from codebase.managers.review_addressor import CommentsAddressorManager
 from core.utils import locked_task
 
 if TYPE_CHECKING:
     from automation.agent.results import AgentResult
+    from codebase.base import MergeRequest
 
 logger = logging.getLogger("daiv.tasks")
+
+
+def _mr_comment_skip_result(response: str, merge_request: MergeRequest) -> AgentResult:
+    from automation.agent.results import AgentResult
+
+    return AgentResult(
+        response=response,
+        code_changes=False,
+        merge_request_id=merge_request.merge_request_id,
+        merge_request_web_url=merge_request.web_url,
+        usage=None,
+    )
 
 
 if codebase_settings.CLIENT == GitPlatform.GITLAB:
@@ -383,16 +397,42 @@ async def address_mr_comments_task(
     """
     client = RepoClient.create_instance()
     merge_request = client.get_merge_request(repo_id, merge_request_id)
-    async with set_runtime_ctx(
-        repo_id,
-        scope=Scope.MERGE_REQUEST,
-        ref=merge_request.source_branch,
-        merge_request=merge_request,
-        sandbox_env_id=sandbox_environment_id,
-    ) as runtime_ctx:
-        return await CommentsAddressorManager.address_comments(
-            merge_request=merge_request,
-            mention_comment_id=mention_comment_id,
-            runtime_ctx=runtime_ctx,
-            thread_id=thread_id,
+
+    if merge_request.merged:
+        response = (
+            f"This merge request has already been merged, so I can't act on comments left against "
+            f"its branch (`{merge_request.source_branch}`). Please open a new issue or merge request "
+            f"for any follow-up changes."
         )
+        logger.warning("Skipping MR-comment run for %s!%s: already merged.", repo_id, merge_request_id)
+        client.create_merge_request_comment(repo_id, merge_request_id, body=response)
+        return _mr_comment_skip_result(response, merge_request)
+
+    try:
+        async with set_runtime_ctx(
+            repo_id,
+            scope=Scope.MERGE_REQUEST,
+            ref=merge_request.source_branch,
+            merge_request=merge_request,
+            sandbox_env_id=sandbox_environment_id,
+        ) as runtime_ctx:
+            return await CommentsAddressorManager.address_comments(
+                merge_request=merge_request,
+                mention_comment_id=mention_comment_id,
+                runtime_ctx=runtime_ctx,
+                thread_id=thread_id,
+            )
+    except CloneRefNotFoundError:
+        response = (
+            f"The source branch `{merge_request.source_branch}` for this merge request no longer "
+            f"exists, so I can't check it out to address this comment. If it was merged and deleted, "
+            f"please open a new issue or merge request for any follow-up changes."
+        )
+        logger.warning(
+            "Skipping MR-comment run for %s!%s: source branch %r no longer exists.",
+            repo_id,
+            merge_request_id,
+            merge_request.source_branch,
+        )
+        client.create_merge_request_comment(repo_id, merge_request_id, body=response)
+        return _mr_comment_skip_result(response, merge_request)

--- a/daiv/core/utils.py
+++ b/daiv/core/utils.py
@@ -47,6 +47,17 @@ def is_git_auth_error_text(text: str) -> bool:
     )
 
 
+def is_git_ref_not_found_text(text: str) -> bool:
+    """True when git clone output indicates the requested branch/ref does not exist on the remote.
+
+    Distinct from an auth or network failure: retrying is pointless — a deleted branch will not
+    reappear — so callers fall back or skip instead of surfacing an opaque GitCommandError. Git's
+    wording for ``git clone --branch <x>`` against a missing ref is ``Remote branch <x> not found
+    in upstream origin``.
+    """
+    return "not found in upstream" in text.lower()
+
+
 def build_absolute_url(path: str) -> str:
     """Build an absolute https:// URL from a relative path using the current Site domain."""
     site = Site.objects.get_current()

--- a/tests/unit_tests/chat/api/test_streaming.py
+++ b/tests/unit_tests/chat/api/test_streaming.py
@@ -766,3 +766,37 @@ async def test_events_falls_back_and_self_heals_ref_when_branch_gone():
     assert fallback_events[0].value == {"requested": "main", "using": "dev"}
     # The Run row must record the effective (fallen-back) ref, not the requested one.
     assert start_chat_run.call_args.kwargs["ref"] == "dev"
+
+
+@pytest.mark.django_db(transaction=True)
+async def test_events_ref_fallback_survives_reset_ref_failure():
+    """The fallback clone already succeeded, so a failed session re-pin must not abort the run:
+    the ref_fallback event still fires and no RUN_ERROR is emitted."""
+
+    def _fallback_ctx(*_args, **_kwargs):
+        ctx = MagicMock()
+        entered = MagicMock()
+        entered.repo.ref = "dev"  # differs from requested "main" → fallback happened
+        ctx.__aenter__ = AsyncMock(return_value=entered)
+        ctx.__aexit__ = AsyncMock(return_value=None)
+        return ctx
+
+    emitted = []
+
+    with (
+        patch("chat.api.streaming.open_checkpointer", _mock_ctx),
+        patch("chat.api.streaming.set_runtime_ctx", _fallback_ctx),
+        patch("chat.api.streaming.create_daiv_agent", new=AsyncMock()),
+        patch("chat.api.streaming.RuntimeContextLangGraphAGUIAgent", return_value=_mock_agent([])),
+        patch("chat.api.streaming.ChatSessionService.persist_ref", new=AsyncMock()),
+        patch("chat.api.streaming.ChatSessionService.reset_ref", side_effect=RuntimeError("db down")),
+        patch("chat.api.streaming.SessionLock.release", new=AsyncMock()),
+        patch("chat.api.streaming.SessionLock.heartbeat", new=AsyncMock()),
+    ):
+        streamer = _streamer()  # ref="main"
+        async for ev in streamer.events():
+            emitted.append(ev)
+
+    fallback_events = [e for e in emitted if e.type == EventType.CUSTOM and getattr(e, "name", None) == "ref_fallback"]
+    assert len(fallback_events) == 1
+    assert [e for e in emitted if e.type == EventType.RUN_ERROR] == []

--- a/tests/unit_tests/chat/api/test_streaming.py
+++ b/tests/unit_tests/chat/api/test_streaming.py
@@ -43,10 +43,13 @@ def _patch_run_lifecycle():
 
 def _mock_ctx(*_args, **_kwargs):
     """Async context manager yielding a MagicMock — stands in for ``open_checkpointer``
-    / ``set_runtime_ctx`` so we don't touch Redis or clone a repo.
+    / ``set_runtime_ctx`` so we don't touch Redis or clone a repo. ``repo.ref`` matches
+    ``_streamer``'s ref so the ref-fallback branch stays dormant here.
     """
     ctx = MagicMock()
-    ctx.__aenter__ = AsyncMock(return_value=MagicMock())
+    entered = MagicMock()
+    entered.repo.ref = "main"
+    ctx.__aenter__ = AsyncMock(return_value=entered)
     ctx.__aexit__ = AsyncMock(return_value=None)
     return ctx
 
@@ -718,3 +721,43 @@ class TestReasoningProvenance:
         assert out, "expected a text chunk to produce events"
         # Upstream sets raw_event to the whole LangGraph event, not just its metadata.
         assert all(ev.raw_event.get("event") == "on_chat_model_stream" for ev in out)
+
+
+@pytest.mark.django_db(transaction=True)
+async def test_events_falls_back_and_self_heals_ref_when_branch_gone():
+    """When set_runtime_ctx checked out a different ref than requested (fallback), the streamer
+    self-heals Session.ref and emits a ref_fallback event before agent output."""
+
+    def _fallback_ctx(*_args, **_kwargs):
+        ctx = MagicMock()
+        entered = MagicMock()
+        entered.repo.ref = "dev"  # differs from requested "main" → fallback happened
+        ctx.__aenter__ = AsyncMock(return_value=entered)
+        ctx.__aexit__ = AsyncMock(return_value=None)
+        return ctx
+
+    reset_calls = []
+
+    async def _capture_reset(thread_id, new_ref):
+        reset_calls.append((thread_id, new_ref))
+
+    emitted = []
+
+    with (
+        patch("chat.api.streaming.open_checkpointer", _mock_ctx),
+        patch("chat.api.streaming.set_runtime_ctx", _fallback_ctx),
+        patch("chat.api.streaming.create_daiv_agent", new=AsyncMock()),
+        patch("chat.api.streaming.RuntimeContextLangGraphAGUIAgent", return_value=_mock_agent([])),
+        patch("chat.api.streaming.ChatSessionService.persist_ref", new=AsyncMock()),
+        patch("chat.api.streaming.ChatSessionService.reset_ref", side_effect=_capture_reset),
+        patch("chat.api.streaming.SessionLock.release", new=AsyncMock()),
+        patch("chat.api.streaming.SessionLock.heartbeat", new=AsyncMock()),
+    ):
+        streamer = _streamer()  # ref="main"
+        async for ev in streamer.events():
+            emitted.append(ev)
+
+    assert reset_calls == [("t-stream", "dev")]
+    fallback_events = [e for e in emitted if e.type == EventType.CUSTOM and getattr(e, "name", None) == "ref_fallback"]
+    assert len(fallback_events) == 1
+    assert fallback_events[0].value == {"requested": "main", "using": "dev"}

--- a/tests/unit_tests/chat/api/test_streaming.py
+++ b/tests/unit_tests/chat/api/test_streaming.py
@@ -743,11 +743,14 @@ async def test_events_falls_back_and_self_heals_ref_when_branch_gone():
 
     emitted = []
 
+    start_chat_run = AsyncMock(return_value=SimpleNamespace(pk="run-pk"))
+
     with (
         patch("chat.api.streaming.open_checkpointer", _mock_ctx),
         patch("chat.api.streaming.set_runtime_ctx", _fallback_ctx),
         patch("chat.api.streaming.create_daiv_agent", new=AsyncMock()),
         patch("chat.api.streaming.RuntimeContextLangGraphAGUIAgent", return_value=_mock_agent([])),
+        patch("chat.api.streaming.start_chat_run", new=start_chat_run),
         patch("chat.api.streaming.ChatSessionService.persist_ref", new=AsyncMock()),
         patch("chat.api.streaming.ChatSessionService.reset_ref", side_effect=_capture_reset),
         patch("chat.api.streaming.SessionLock.release", new=AsyncMock()),
@@ -761,3 +764,5 @@ async def test_events_falls_back_and_self_heals_ref_when_branch_gone():
     fallback_events = [e for e in emitted if e.type == EventType.CUSTOM and getattr(e, "name", None) == "ref_fallback"]
     assert len(fallback_events) == 1
     assert fallback_events[0].value == {"requested": "main", "using": "dev"}
+    # The Run row must record the effective (fallen-back) ref, not the requested one.
+    assert start_chat_run.call_args.kwargs["ref"] == "dev"

--- a/tests/unit_tests/chat/api/test_views.py
+++ b/tests/unit_tests/chat/api/test_views.py
@@ -49,8 +49,12 @@ def _mock_stream(*_args, **_kwargs):
     open_checkpointer() and set_runtime_ctx() during tests so we exercise the ownership
     path without hitting Redis or cloning a repo.
     """
+    inner = MagicMock()
+    # Mirror the requested ref so streaming.py's fallback-ref guard doesn't fire.
+    if "ref" in _kwargs:
+        inner.repo.ref = _kwargs["ref"]
     ctx = MagicMock()
-    ctx.__aenter__ = AsyncMock(return_value=MagicMock())
+    ctx.__aenter__ = AsyncMock(return_value=inner)
     ctx.__aexit__ = AsyncMock(return_value=None)
     return ctx
 

--- a/tests/unit_tests/codebase/clients/github/test_client.py
+++ b/tests/unit_tests/codebase/clients/github/test_client.py
@@ -461,6 +461,33 @@ class TestGitHubClient:
         assert result.merge_request_id == 7
         assert "Multiple open PRs" in caplog.text
 
+    def test_get_merge_request_maps_merged_state(self, github_client):
+        """get_merge_request reflects the PR's ``merged`` flag — the value the merged-MR skip guard
+        in address_mr_comments_task reads."""
+
+        def _pr(merged):
+            mock_pr = Mock()
+            mock_pr.head = Mock(ref="feat-x", sha="abc123")
+            mock_pr.base = Mock(ref="main")
+            mock_pr.title = "feat: add x"
+            mock_pr.body = "details"
+            mock_pr.labels = []
+            mock_pr.html_url = "https://github.com/o/r/pull/7"
+            user = Mock(id=1, login="alice")
+            user.name = "Alice"
+            mock_pr.user = user
+            mock_pr.merged = merged
+            return mock_pr
+
+        mock_repo = Mock()
+        github_client.client.get_repo.return_value = mock_repo
+
+        mock_repo.get_pull.return_value = _pr(True)
+        assert github_client.get_merge_request("owner/repo", 7).merged is True
+
+        mock_repo.get_pull.return_value = _pr(False)
+        assert github_client.get_merge_request("owner/repo", 7).merged is False
+
     def test_is_branch_protected_returns_true_when_branch_protected(self, github_client):
         mock_repo = Mock()
         mock_repo.get_branch.return_value = Mock(protected=True)

--- a/tests/unit_tests/codebase/clients/github/test_client.py
+++ b/tests/unit_tests/codebase/clients/github/test_client.py
@@ -2,6 +2,7 @@ import logging
 from unittest.mock import Mock, patch
 
 import pytest
+from git import GitCommandError
 from github import Consts, UnknownObjectException
 from github.GithubException import GithubException
 from github.IssueComment import IssueComment
@@ -10,6 +11,7 @@ from github.PullRequestComment import PullRequestComment
 from codebase.base import GitPlatform, MergeRequestCommit, Repository, User
 from codebase.clients.base import Emoji, GitAuthEnv
 from codebase.clients.github.client import GitHubClient
+from codebase.exceptions import CloneRefNotFoundError
 
 
 class TestGitHubClient:
@@ -522,3 +524,26 @@ class TestGitHubClient:
             input={"permissions": {"contents": "write"}, "repository_ids": [42]},
         )
         github_client._integration.get_access_token.assert_not_called()
+
+    def test_github_load_repo_raises_clone_ref_not_found_when_branch_gone(self, github_client):
+        repository = Repository(
+            pk=1,
+            slug="owner/repo",
+            name="repo",
+            clone_url="https://github.com/owner/repo.git",
+            html_url="https://github.com/owner/repo",
+            default_branch="main",
+            git_platform=GitPlatform.GITHUB,
+        )
+        clone_error = GitCommandError("git clone", 128, "fatal: Remote branch gone-branch not found in upstream origin")
+
+        with (
+            patch.object(type(github_client), "_mint_installation_token", return_value="ghs-token"),
+            patch("codebase.clients.github.client.Repo.clone_from", side_effect=clone_error),
+            pytest.raises(CloneRefNotFoundError) as exc_info,
+            github_client.load_repo(repository, "gone-branch"),
+        ):
+            pass
+
+        assert exc_info.value.ref == "gone-branch"
+        assert exc_info.value.repo_slug == "owner/repo"

--- a/tests/unit_tests/codebase/clients/github/test_client.py
+++ b/tests/unit_tests/codebase/clients/github/test_client.py
@@ -461,7 +461,8 @@ class TestGitHubClient:
         assert result.merge_request_id == 7
         assert "Multiple open PRs" in caplog.text
 
-    def test_get_merge_request_maps_merged_state(self, github_client):
+    @pytest.mark.parametrize("merged", [True, False])
+    def test_get_merge_request_maps_merged_state(self, github_client, merged):
         """get_merge_request reflects the PR's ``merged`` flag — the value the merged-MR skip guard
         in address_mr_comments_task reads."""
 
@@ -482,11 +483,8 @@ class TestGitHubClient:
         mock_repo = Mock()
         github_client.client.get_repo.return_value = mock_repo
 
-        mock_repo.get_pull.return_value = _pr(True)
-        assert github_client.get_merge_request("owner/repo", 7).merged is True
-
-        mock_repo.get_pull.return_value = _pr(False)
-        assert github_client.get_merge_request("owner/repo", 7).merged is False
+        mock_repo.get_pull.return_value = _pr(merged)
+        assert github_client.get_merge_request("owner/repo", 7).merged is merged
 
     def test_is_branch_protected_returns_true_when_branch_protected(self, github_client):
         mock_repo = Mock()

--- a/tests/unit_tests/codebase/clients/gitlab/test_client.py
+++ b/tests/unit_tests/codebase/clients/gitlab/test_client.py
@@ -424,7 +424,8 @@ class TestGitLabClient:
         assert exc_info.value.repo_slug == "group/repo"
         assert clone_from.call_count == 1
 
-    def test_get_merge_request_maps_merged_state(self, gitlab_client):
+    @pytest.mark.parametrize("merged", [True, False])
+    def test_get_merge_request_maps_merged_state(self, gitlab_client, merged):
         """get_merge_request maps GitLab ``state == "merged"`` onto ``MergeRequest.merged`` — the
         value the merged-MR skip guard in address_mr_comments_task reads."""
 
@@ -445,11 +446,8 @@ class TestGitLabClient:
         mock_project = Mock()
         gitlab_client.client.projects.get.return_value = mock_project
 
-        mock_project.mergerequests.get.return_value = _mr("merged")
-        assert gitlab_client.get_merge_request("group/repo", 7).merged is True
-
-        mock_project.mergerequests.get.return_value = _mr("opened")
-        assert gitlab_client.get_merge_request("group/repo", 7).merged is False
+        mock_project.mergerequests.get.return_value = _mr("merged" if merged else "opened")
+        assert gitlab_client.get_merge_request("group/repo", 7).merged is merged
 
     def test_create_merge_request_inline_discussion_sends_position_payload(self, gitlab_client):
         """create_merge_request_inline_discussion must pass body + position dict to discussions.create."""

--- a/tests/unit_tests/codebase/clients/gitlab/test_client.py
+++ b/tests/unit_tests/codebase/clients/gitlab/test_client.py
@@ -383,7 +383,9 @@ class TestGitLabClient:
 
     def test_load_repo_does_not_retry_non_auth_clone_failures(self, gitlab_client, clone_setup):
         """A missing branch (or any non-auth 128) won't be fixed by a fresh credential, so it must
-        not trigger the token-rotation retry."""
+        not trigger the token-rotation retry; ref-not-found errors surface as CloneRefNotFoundError."""
+        from codebase.exceptions import CloneRefNotFoundError
+
         repository, clone_from, _ = clone_setup
         clone_from.side_effect = GitCommandError(
             "git clone", 128, "fatal: Remote branch nope not found in upstream origin"
@@ -392,12 +394,34 @@ class TestGitLabClient:
         with (
             patch("codebase.clients.gitlab.client.get_ephemeral_clone_token", return_value="glpat-eph"),
             patch("codebase.clients.gitlab.client.invalidate_clone_token") as invalidate,
-            pytest.raises(GitCommandError),
+            pytest.raises(CloneRefNotFoundError),
             gitlab_client.load_repo(repository, "main"),
         ):
             pass
 
         invalidate.assert_not_called()
+        assert clone_from.call_count == 1
+
+    def test_load_repo_raises_clone_ref_not_found_when_branch_gone(self, gitlab_client, clone_setup):
+        """A merged-and-deleted branch surfaces as CloneRefNotFoundError, not a raw GitCommandError,
+        and is not retried (it is not an auth failure)."""
+        from codebase.exceptions import CloneRefNotFoundError
+
+        repository, clone_from, _ = clone_setup
+        clone_from.side_effect = GitCommandError(
+            "git clone", 128, "fatal: Remote branch gone-branch not found in upstream origin"
+        )
+
+        with (
+            patch("codebase.clients.gitlab.client.get_ephemeral_clone_token", return_value="glpat-eph"),
+            patch("codebase.clients.gitlab.client.time.sleep"),
+            pytest.raises(CloneRefNotFoundError) as exc_info,
+            gitlab_client.load_repo(repository, "gone-branch"),
+        ):
+            pass
+
+        assert exc_info.value.ref == "gone-branch"
+        assert exc_info.value.repo_slug == "group/repo"
         assert clone_from.call_count == 1
 
     def test_create_merge_request_inline_discussion_sends_position_payload(self, gitlab_client):

--- a/tests/unit_tests/codebase/clients/gitlab/test_client.py
+++ b/tests/unit_tests/codebase/clients/gitlab/test_client.py
@@ -424,6 +424,33 @@ class TestGitLabClient:
         assert exc_info.value.repo_slug == "group/repo"
         assert clone_from.call_count == 1
 
+    def test_get_merge_request_maps_merged_state(self, gitlab_client):
+        """get_merge_request maps GitLab ``state == "merged"`` onto ``MergeRequest.merged`` — the
+        value the merged-MR skip guard in address_mr_comments_task reads."""
+
+        def _mr(state):
+            mock_mr = Mock()
+            mock_mr.get_id.return_value = 7
+            mock_mr.source_branch = "feat-x"
+            mock_mr.target_branch = "main"
+            mock_mr.title = "feat: add x"
+            mock_mr.description = "details"
+            mock_mr.labels = []
+            mock_mr.web_url = "https://gitlab.com/group/repo/-/merge_requests/7"
+            mock_mr.sha = "abc123"
+            mock_mr.author = {"id": 1, "username": "alice", "name": "Alice"}
+            mock_mr.state = state
+            return mock_mr
+
+        mock_project = Mock()
+        gitlab_client.client.projects.get.return_value = mock_project
+
+        mock_project.mergerequests.get.return_value = _mr("merged")
+        assert gitlab_client.get_merge_request("group/repo", 7).merged is True
+
+        mock_project.mergerequests.get.return_value = _mr("opened")
+        assert gitlab_client.get_merge_request("group/repo", 7).merged is False
+
     def test_create_merge_request_inline_discussion_sends_position_payload(self, gitlab_client):
         """create_merge_request_inline_discussion must pass body + position dict to discussions.create."""
         mock_project = Mock()

--- a/tests/unit_tests/codebase/clients/gitlab/test_client.py
+++ b/tests/unit_tests/codebase/clients/gitlab/test_client.py
@@ -441,6 +441,7 @@ class TestGitLabClient:
             mock_mr.sha = "abc123"
             mock_mr.author = {"id": 1, "username": "alice", "name": "Alice"}
             mock_mr.state = state
+            mock_mr.work_in_progress = False
             return mock_mr
 
         mock_project = Mock()

--- a/tests/unit_tests/codebase/test_context.py
+++ b/tests/unit_tests/codebase/test_context.py
@@ -6,6 +6,7 @@ from sandbox_envs.models import SandboxEnvironment, Scope
 
 from codebase.base import Scope as RepoScope
 from codebase.context import set_runtime_ctx
+from codebase.exceptions import CloneRefNotFoundError
 from core.sandbox.client import _run_sandbox_client
 
 
@@ -295,3 +296,66 @@ async def test_set_runtime_ctx_resolves_platform_egress_after_clone():
             assert calls == ["clone", "credential"], f"credential must resolve after clone, got {calls}"
             assert ctx.sandbox.egress is not None
             assert ctx.sandbox.egress.policy.rules[0].host == "github.com"
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_set_runtime_ctx_falls_back_to_default_when_ref_missing():
+    """With fallback enabled, a gone ref retries the clone on the default branch and records it."""
+    await SandboxEnvironment.objects.filter(scope=Scope.GLOBAL).adelete()
+
+    fake_repo = type("Repo", (), {})()
+    good_cm = MagicMock()
+    good_cm.__enter__ = MagicMock(return_value=fake_repo)
+    good_cm.__exit__ = MagicMock(return_value=False)
+    gone_cm = MagicMock()
+    gone_cm.__enter__ = MagicMock(side_effect=CloneRefNotFoundError("gone", "r/p"))
+    gone_cm.__exit__ = MagicMock(return_value=False)
+
+    with patch("codebase.context.RepoClient.create_instance") as mock_client_factory:
+        client = mock_client_factory.return_value
+        client.get_repository.return_value = type("R", (), {"name": "x", "slug": "r/p"})()
+        client.git_platform = "gitlab"
+        client.current_user.username = "bot"
+        client.get_git_egress_credential.return_value = None
+        client.load_repo.side_effect = [gone_cm, good_cm]
+
+        with patch("codebase.context.RepositoryConfig.get_config") as gc:
+            from codebase.repo_config import RepositoryConfig
+
+            gc.return_value = RepositoryConfig.model_validate({"default_branch": "main"})
+            async with set_runtime_ctx(
+                repo_id="r/p", scope=RepoScope.GLOBAL, ref="gone", fallback_ref_on_missing=True
+            ) as ctx:
+                assert ctx.repo.ref == "main"
+
+    assert client.load_repo.call_count == 2
+    assert client.load_repo.call_args_list[0].kwargs["sha"] == "gone"
+    assert client.load_repo.call_args_list[1].kwargs["sha"] == "main"
+
+
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_set_runtime_ctx_reraises_missing_ref_without_fallback():
+    """Default behavior (fallback disabled) propagates CloneRefNotFoundError unchanged."""
+    await SandboxEnvironment.objects.filter(scope=Scope.GLOBAL).adelete()
+
+    gone_cm = MagicMock()
+    gone_cm.__enter__ = MagicMock(side_effect=CloneRefNotFoundError("gone", "r/p"))
+    gone_cm.__exit__ = MagicMock(return_value=False)
+
+    with patch("codebase.context.RepoClient.create_instance") as mock_client_factory:
+        client = mock_client_factory.return_value
+        client.get_repository.return_value = type("R", (), {"name": "x", "slug": "r/p"})()
+        client.git_platform = "gitlab"
+        client.current_user.username = "bot"
+        client.get_git_egress_credential.return_value = None
+        client.load_repo.side_effect = [gone_cm]
+
+        with patch("codebase.context.RepositoryConfig.get_config") as gc:
+            from codebase.repo_config import RepositoryConfig
+
+            gc.return_value = RepositoryConfig.model_validate({"default_branch": "main"})
+            with pytest.raises(CloneRefNotFoundError):
+                async with set_runtime_ctx(repo_id="r/p", scope=RepoScope.GLOBAL, ref="gone") as _:
+                    pass

--- a/tests/unit_tests/codebase/test_context.py
+++ b/tests/unit_tests/codebase/test_context.py
@@ -361,6 +361,38 @@ async def test_set_runtime_ctx_reraises_missing_ref_without_fallback():
                     pass
 
 
+@pytest.mark.django_db(transaction=True)
+@pytest.mark.asyncio
+async def test_set_runtime_ctx_reraises_when_missing_ref_is_the_default_branch():
+    """Fallback enabled but the gone ref already IS the default branch: there is nothing to fall
+    back to, so the error propagates and the clone is attempted only once."""
+    await SandboxEnvironment.objects.filter(scope=Scope.GLOBAL).adelete()
+
+    gone_cm = MagicMock()
+    gone_cm.__enter__ = MagicMock(side_effect=CloneRefNotFoundError("main", "r/p"))
+    gone_cm.__exit__ = MagicMock(return_value=False)
+
+    with patch("codebase.context.RepoClient.create_instance") as mock_client_factory:
+        client = mock_client_factory.return_value
+        client.get_repository.return_value = type("R", (), {"name": "x", "slug": "r/p"})()
+        client.git_platform = "gitlab"
+        client.current_user.username = "bot"
+        client.get_git_egress_credential.return_value = None
+        client.load_repo.side_effect = [gone_cm]
+
+        with patch("codebase.context.RepositoryConfig.get_config") as gc:
+            from codebase.repo_config import RepositoryConfig
+
+            gc.return_value = RepositoryConfig.model_validate({"default_branch": "main"})
+            with pytest.raises(CloneRefNotFoundError):
+                async with set_runtime_ctx(
+                    repo_id="r/p", scope=RepoScope.GLOBAL, ref="main", fallback_ref_on_missing=True
+                ) as _:
+                    pass
+
+    assert client.load_repo.call_count == 1
+
+
 def test_load_repo_fallback_body_raise_does_not_trigger_fallback():
     """A CloneRefNotFoundError raised by the *yielded body* must propagate, not trigger a fallback.
 

--- a/tests/unit_tests/codebase/test_context.py
+++ b/tests/unit_tests/codebase/test_context.py
@@ -359,3 +359,32 @@ async def test_set_runtime_ctx_reraises_missing_ref_without_fallback():
             with pytest.raises(CloneRefNotFoundError):
                 async with set_runtime_ctx(repo_id="r/p", scope=RepoScope.GLOBAL, ref="gone") as _:
                     pass
+
+
+def test_load_repo_fallback_body_raise_does_not_trigger_fallback():
+    """A CloneRefNotFoundError raised by the *yielded body* must propagate, not trigger a fallback.
+
+    @contextmanager throws a body-raised exception back at the ``yield`` via gen.throw(). The yield
+    sits outside the ``except CloneRefNotFoundError`` guarding clone acquisition, so the body error
+    must NOT be swallowed into a spurious second clone (which would also raise
+    "generator didn't stop"). Only clone acquisition may reach the fallback.
+    """
+    from codebase.context import _load_repo_with_optional_fallback
+
+    fake_repo = type("Repo", (), {})()
+    good_cm = MagicMock()
+    good_cm.__enter__ = MagicMock(return_value=fake_repo)
+    good_cm.__exit__ = MagicMock(return_value=False)
+
+    repo_client = MagicMock()
+    repository = type("R", (), {"slug": "r/p"})()
+    repo_client.load_repo.return_value = good_cm
+
+    helper = _load_repo_with_optional_fallback(repo_client, repository, "gone", "main", fallback=True)
+    with pytest.raises(CloneRefNotFoundError), helper as (repo, ref):
+        assert repo is fake_repo
+        assert ref == "gone"
+        raise CloneRefNotFoundError("gone", "r/p")
+
+    assert repo_client.load_repo.call_count == 1
+    good_cm.__exit__.assert_called_once()

--- a/tests/unit_tests/codebase/test_runtime_ctx.py
+++ b/tests/unit_tests/codebase/test_runtime_ctx.py
@@ -15,7 +15,12 @@ from codebase.exceptions import SingleRepoRequiredError
 
 def _make_handle() -> RepoHandle:
     return RepoHandle(
-        repo_id="acme/api", git_platform=Mock(), repository=Mock(slug="acme/api"), gitrepo=Mock(), config=Mock()
+        repo_id="acme/api",
+        git_platform=Mock(),
+        repository=Mock(slug="acme/api"),
+        gitrepo=Mock(),
+        config=Mock(),
+        ref="main",
     )
 
 

--- a/tests/unit_tests/codebase/test_tasks.py
+++ b/tests/unit_tests/codebase/test_tasks.py
@@ -1,12 +1,66 @@
 from datetime import UTC, datetime, timedelta
-from unittest.mock import patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from github.GithubException import GithubException
 from gitlab.exceptions import GitlabError
 
 import codebase.tasks as codebase_tasks
-from codebase.base import MergeRequestCommit, MergeRequestDiffStats
+from codebase.base import MergeRequest, MergeRequestCommit, MergeRequestDiffStats, User
+from codebase.exceptions import CloneRefNotFoundError
+
+
+def _mr(*, merged: bool) -> MergeRequest:
+    return MergeRequest(
+        repo_id="group/repo",
+        merge_request_id=7,
+        source_branch="chore/x",
+        target_branch="dev",
+        title="t",
+        description="d",
+        web_url="https://git/group/repo/-/merge_requests/7",
+        author=User(id=1, username="u", name="U"),
+        merged=merged,
+    )
+
+
+async def test_address_mr_comments_skips_when_merged():
+    from codebase.tasks import address_mr_comments_task
+
+    client = MagicMock()
+    client.get_merge_request.return_value = _mr(merged=True)
+
+    with (
+        patch("codebase.tasks.RepoClient.create_instance", return_value=client),
+        patch("codebase.tasks.set_runtime_ctx") as set_ctx,
+    ):
+        result = await address_mr_comments_task.func(repo_id="group/repo", merge_request_id=7, mention_comment_id="d1")
+
+    set_ctx.assert_not_called()
+    client.create_merge_request_comment.assert_called_once()
+    assert "already been merged" in result["response"]
+    assert result["code_changes"] is False
+
+
+async def test_address_mr_comments_skips_when_branch_gone():
+    from codebase.tasks import address_mr_comments_task
+
+    client = MagicMock()
+    client.get_merge_request.return_value = _mr(merged=False)
+
+    ctx = MagicMock()
+    ctx.__aenter__ = AsyncMock(side_effect=CloneRefNotFoundError("chore/x", "group/repo"))
+    ctx.__aexit__ = AsyncMock(return_value=None)
+
+    with (
+        patch("codebase.tasks.RepoClient.create_instance", return_value=client),
+        patch("codebase.tasks.set_runtime_ctx", return_value=ctx),
+    ):
+        result = await address_mr_comments_task.func(repo_id="group/repo", merge_request_id=7, mention_comment_id="d1")
+
+    client.create_merge_request_comment.assert_called_once()
+    assert "no longer exists" in result["response"]
+    assert result["code_changes"] is False
 
 
 async def test_setup_webhooks_cron_task_calls_command():

--- a/tests/unit_tests/codebase/test_tasks.py
+++ b/tests/unit_tests/codebase/test_tasks.py
@@ -50,7 +50,6 @@ async def test_address_mr_comments_skips_when_branch_gone():
 
     ctx = MagicMock()
     ctx.__aenter__ = AsyncMock(side_effect=CloneRefNotFoundError("chore/x", "group/repo"))
-    ctx.__aexit__ = AsyncMock(return_value=None)
 
     with (
         patch("codebase.tasks.RepoClient.create_instance", return_value=client),

--- a/tests/unit_tests/core/test_utils.py
+++ b/tests/unit_tests/core/test_utils.py
@@ -12,6 +12,7 @@ from core.utils import (
     build_uri,
     extract_valid_image_mimetype,
     is_git_auth_error_text,
+    is_git_ref_not_found_text,
     is_valid_url,
     locked_task,
     prefixed_email_subject,
@@ -83,6 +84,20 @@ class IsGitAuthErrorTextTest:
     )
     def test_non_auth_text_returns_false(self, text):
         assert is_git_auth_error_text(text) is False
+
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        ("fatal: Remote branch chore/x not found in upstream origin", True),
+        ("Remote branch feature-1 not found in upstream origin\n", True),
+        ("fatal: could not read Username for 'https://...'", False),  # auth, not a missing ref
+        ("fatal: unable to access '...': Could not resolve host", False),  # network
+        ("", False),
+    ],
+)
+def test_is_git_ref_not_found_text(text, expected):
+    assert is_git_ref_not_found_text(text) is expected
 
 
 class IsValidUrlTest:


### PR DESCRIPTION
## What & why

Fixes **DAIV-AT**. When a chat session (or an MR-comment run) is pinned to a merge-request branch that gets merged and its source branch deleted, the next turn re-clones the now-gone branch. `git clone --branch <gone>` fails with `fatal: Remote branch <x> not found in upstream origin` — a non-auth `GitCommandError` the existing clone self-heal correctly does *not* retry. Today it escapes into the generic handler in `chat/api/streaming.py`, producing a Sentry ERROR + an opaque "Chat run failed". The identical failure is reachable on the webhook path in `address_mr_comments_task`.

This branch makes the failure self-healing (chat) or gracefully skipped (MR-comment), and never a Sentry ERROR.

## How

- **Shared primitives** — `is_git_ref_not_found_text()` (`core/utils.py`) classifies the terminal "remote branch not found" wording; `CloneRefNotFoundError(ref, repo_slug)` (`codebase/exceptions.py`) is the typed, catchable error. Retrying is pointless (a deleted branch won't reappear), so this is kept distinct from auth/network failures.
- **Both clients** — GitLab and GitHub `load_repo` reclassify a gone-branch `GitCommandError` into `CloneRefNotFoundError`; all other errors (auth retry/re-mint, network) are unchanged. The `try/except` wraps only the clone acquisition.
- **`set_runtime_ctx`** — new opt-in `fallback_ref_on_missing` (default `False`, so all existing callers are unchanged). When `True`, a `CloneRefNotFoundError` for a non-default ref retries the clone on the repository default branch; `RepoHandle.ref` records the branch actually checked out. The fallback helper yields *outside* the `except` guard, so only a clone-acquisition failure triggers fallback (a regression test pins this).
- **Chat** — the streamer opts into the fallback, self-heals `Session.ref` immediately (`ChatSessionService.reset_ref`), threads the effective ref into the Run row and `persist_ref`, and emits a `ref_fallback` AG-UI event. The JS client moves the composer ref pill to the branch actually used.
- **MR-comment** — `MergeRequest.merged` (populated by both clients) lets `address_mr_comments_task` skip *before* cloning when the MR is already merged; a gone source branch is caught via `CloneRefNotFoundError`. Both skip paths post a short explanatory note on the MR and log at WARNING (not ERROR).

## Testing

- `make test` — **3986 passed** on the final tree; `make lint` clean; `ty` at its known baseline (no new error class).
- New unit tests: classifier cases, GitLab/GitHub clone reclassification, `set_runtime_ctx` fallback + no-fallback propagation + body-raise regression guard, chat self-heal (`reset_ref`, `ref_fallback` event, effective-ref threaded into `start_chat_run`), and MR-comment skip-when-merged / skip-when-branch-gone.
- **Manual step for a human:** the chat ref-pill UI move (`ref_fallback` handler in `chat-stream.js`) has no JS test harness — verify live by merging+deleting an MR branch and sending a follow-up in the same session.

## Notes

- A closed-but-unmerged MR whose branch still exists is intentionally *not* skipped (the clone succeeds); only merged-or-gone-branch are skipped.
- A visible in-transcript fallback banner (beyond the pill move + `console.debug`) was intentionally deferred — it would need a new chat render turn type.
