### PR TITLE
test: stop async DB tests leaking committed rows across the suite

### DIFF
--- a/tests/unit_tests/core/test_site_configuration.py
+++ b/tests/unit_tests/core/test_site_configuration.py
@@ -39,14 +39,14 @@ class TestCaching:
         instance = SiteConfiguration.get_cached()
         assert instance.pk == 1
 
-    async def test_get_cached_works_in_async_context_cold_cache(self, db):
+    async def test_get_cached_works_in_async_context_cold_cache(self, transactional_db):
         """When called from an async context with cold cache, fetches via thread pool."""
         django_cache.delete(SITE_CONFIGURATION_CACHE_KEY)
         result = SiteConfiguration.get_cached()
         assert result is not None
         assert result.pk == 1
 
-    async def test_get_cached_populates_cache_in_async_context(self, db):
+    async def test_get_cached_populates_cache_in_async_context(self, transactional_db):
         """Cold cache async fetch should populate cache for subsequent calls."""
         django_cache.delete(SITE_CONFIGURATION_CACHE_KEY)
         SiteConfiguration.get_cached()

--- a/tests/unit_tests/jobs/test_tasks.py
+++ b/tests/unit_tests/jobs/test_tasks.py
@@ -128,7 +128,7 @@ async def test_run_job_task_forwards_overrides():
     assert "use_max" not in captured_kwargs
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(transaction=True)
 async def test_run_job_task_persists_resolved_model():
     """The resolved model/thinking are written back onto the Run + Session so the
     session detail view reflects what the run actually executed with, not the empty
@@ -177,7 +177,7 @@ async def test_run_job_task_persists_resolved_model():
     assert run.agent_thinking_level == "xhigh"
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(transaction=True)
 async def test_run_job_task_leaves_model_empty_when_setup_fails_before_resolution():
     """A run that dies before the model is resolved (e.g. the git clone inside
     ``set_runtime_ctx``) leaves ``agent_model`` empty — the UI falls back to the

--- a/tests/unit_tests/jobs/test_tasks_lock.py
+++ b/tests/unit_tests/jobs/test_tasks_lock.py
@@ -6,7 +6,7 @@ from jobs.tasks import _acquire_session_lock
 from sessions.locks import SessionLock
 from sessions.models import Session, SessionOrigin
 
-pytestmark = pytest.mark.django_db
+pytestmark = pytest.mark.django_db(transaction=True)
 
 
 async def _mk_session(**kwargs):

--- a/tests/unit_tests/schedules/test_dispatch_authz.py
+++ b/tests/unit_tests/schedules/test_dispatch_authz.py
@@ -39,7 +39,7 @@ def test_dispatch_denied_owner_advances_without_runs(due_schedule, caplog):
         dispatch_scheduled_jobs_cron_task.func()
 
     due_schedule.refresh_from_db()
-    assert Run.objects.count() == 0
+    assert Run.objects.filter(session__scheduled_job=due_schedule).count() == 0
     assert due_schedule.next_run_at > datetime.now(tz=UTC)  # advanced, not hot-looping
     assert due_schedule.is_enabled  # not disabled — access may come back
 

--- a/tests/unit_tests/schedules/test_tasks.py
+++ b/tests/unit_tests/schedules/test_tasks.py
@@ -234,7 +234,7 @@ def test_dispatch_respects_owner_is_active(member_user, owner_active, expected_r
         dispatch_scheduled_jobs_cron_task.func()
 
     schedule.refresh_from_db()
-    assert Run.objects.count() == expected_runs
+    assert Run.objects.filter(session__scheduled_job=schedule).count() == expected_runs
     if owner_active:
         assert schedule.next_run_at > past  # advanced to next cron tick
     else:
@@ -267,7 +267,7 @@ def test_dispatch_resumes_after_owner_reactivated(member_user):
 
         # Inactive owner: skipped, no run, next_run_at untouched.
         dispatch_scheduled_jobs_cron_task.func()
-        assert Run.objects.count() == 0
+        assert Run.objects.filter(session__scheduled_job=schedule).count() == 0
         schedule.refresh_from_db()
         assert schedule.next_run_at == past
 
@@ -276,7 +276,7 @@ def test_dispatch_resumes_after_owner_reactivated(member_user):
         member_user.save(update_fields=["is_active"])
         dispatch_scheduled_jobs_cron_task.func()
 
-    assert Run.objects.count() == 1
+    assert Run.objects.filter(session__scheduled_job=schedule).count() == 1
     schedule.refresh_from_db()
     assert schedule.next_run_at > datetime.now(tz=UTC)
 
@@ -321,7 +321,7 @@ def test_dispatch_skips_only_inactive_owner_in_mixed_run(member_user):
 
     # Selectivity: only the active owner's schedule dispatched; the inactive
     # owner's was skipped even though both were due in the same run.
-    assert Run.objects.count() == 1
+    assert Run.objects.filter(session__scheduled_job__in=[active_schedule, inactive_schedule]).count() == 1
     assert Run.objects.filter(session__scheduled_job=active_schedule).count() == 1
     assert Run.objects.filter(session__scheduled_job=inactive_schedule).count() == 0
     active_schedule.refresh_from_db()
@@ -358,7 +358,7 @@ def test_dispatch_skips_once_schedule_of_inactive_owner_without_retiring(member_
     # Skipped, not retired: a ONCE schedule owned by an inactive user must keep
     # is_enabled=True and its next_run_at intact so it fires exactly once when
     # the owner is reactivated — not be consumed by the ONCE auto-disable path.
-    assert Run.objects.count() == 0
+    assert Run.objects.filter(session__scheduled_job=schedule).count() == 0
     assert schedule.is_enabled is True
     assert schedule.next_run_at == past
     assert schedule.run_count == 0

--- a/tests/unit_tests/sessions/test_locks.py
+++ b/tests/unit_tests/sessions/test_locks.py
@@ -7,7 +7,7 @@ import pytest
 from sessions.locks import SessionLock
 from sessions.models import Session, SessionOrigin
 
-pytestmark = pytest.mark.django_db
+pytestmark = pytest.mark.django_db(transaction=True)
 
 
 async def _mk_session(**kwargs) -> Session:

--- a/tests/unit_tests/sessions/test_services.py
+++ b/tests/unit_tests/sessions/test_services.py
@@ -82,6 +82,7 @@ def _patch_run_job_task(side_effect=None):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.django_db(transaction=True)
 async def test_aget_or_create_session_creates_with_origin():
     tid = str(uuid.uuid4())
     session = await aget_or_create_session(thread_id=tid, origin=SessionOrigin.API_JOB, repo_id="g/r", ref="main")
@@ -89,6 +90,7 @@ async def test_aget_or_create_session_creates_with_origin():
     assert session.origin == SessionOrigin.API_JOB
 
 
+@pytest.mark.django_db(transaction=True)
 async def test_aget_or_create_session_existing_keeps_origin_and_touches():
     tid = str(uuid.uuid4())
     first = await aget_or_create_session(thread_id=tid, origin=SessionOrigin.ISSUE_WEBHOOK, repo_id="g/r")
@@ -100,6 +102,7 @@ async def test_aget_or_create_session_existing_keeps_origin_and_touches():
     assert again.last_active_at > before
 
 
+@pytest.mark.django_db(transaction=True)
 async def test_acreate_run_creates_session_and_run():
     tid = str(uuid.uuid4())
     run = await acreate_run(


### PR DESCRIPTION
`test_dispatch_respects_owner_is_active[True-1]` failed intermittently under `make test` (~1 in 16 full-suite runs) while always passing in isolation. Its `assert Run.objects.count() == expected_runs` is a table-wide count, so it also answers for rows other tests left behind — and those rows were real.

## Root cause

Thirteen tests across five files are `async def` tests marked plain `@pytest.mark.django_db`. Async ORM writes run on a thread-local connection — not the one pytest-django wrapped in a rollback-only atomic block — so they **commit for real**. The rows outlive teardown and stay visible to every later test in that xdist worker until some later transactional test's flush truncates the tables. Whether that window happens to contain a table-wide count assertion is a coin flip under xdist's dynamic distribution, which is the whole of the intermittency.

Same defect, second face: run one of these tests first and it fails outright with `OperationalError: database table is locked`, the async write colliding with a write lock the main thread's transaction already holds.

## How it was measured

A temporary plugin hooking `pytest_runtest_teardown` (post-yield, borrowing pytest-django's DB blocker) counted rows of every model per worker: **678 dirty-teardown observations, 12 distinct leak origins → 0 after the fix**, across all models.

Leaks weren't limited to `Run`: `Session` rows and a `core.SiteConfiguration` **singleton** leaked too — the latter meaning any later test reading site config silently inherited test-specific configuration.

## The fix

Both layers, entirely mechanical (+15/−12 across 7 test files):

- `transaction=True` / `transactional_db` on the leaking tests.
- The table-wide `Run.objects.count()` assertions in the schedules tests scoped to the schedule under test, so a future leak elsewhere can't break them. The mixed-owner test keeps its "nothing else fired" intent, bounded to the schedules it creates.

**No prose prevention added.** `transaction=True` is used bare at 349 sites across the suite, and the one file that did explain it inline had done so for years without preventing these 13 recurrences — so an inline essay or an `AGENTS.md` paragraph is not the mechanism that stops recurrence #14. A `conftest` guard that fails any async test requesting plain `django_db` would actually enforce it; that's a separate change, noted below.

## Verification

- Full suite on current `main`: **4010 passed**. `make lint` clean.
- The fix is load-bearing, not just suite-green: reverting `sessions/test_locks.py` to `main` makes `test_claim_free_slot` fail deterministically with `OperationalError: database table is locked`; restoring the fix makes it pass. Chosen over re-rolling the 1-in-16 flake because it's the same defect with a deterministic trigger.

## Follow-ups, deliberately not in this PR

- **`conftest` guard** to fail any async test using plain `django_db` — the enforceable version of the rule this PR declines to write down in prose.
- **`--dist worksteal`**: this is the latent isolation bug that blocked it. It now runs 8/8 clean and ~35% faster (36-40s vs 53-57s). The Makefile is still on plain `-n auto` — a one-word change, separate call.
