### PR TITLE
perf(imports): defer agent-stack imports out of django.setup()

### DIFF
--- a/daiv/automation/agent/__init__.py
+++ b/daiv/automation/agent/__init__.py
@@ -1,3 +1,16 @@
-from .base import BaseAgent, ThinkingLevel
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .base import BaseAgent, ThinkingLevel
 
 __all__ = ["BaseAgent", "ThinkingLevel"]
+
+
+# Deferred so importing light submodules (e.g. automation.agent.display) does not
+# pull the langchain/langgraph stack (~160MB) into every Django process at setup.
+def __getattr__(name: str):
+    if name in __all__:
+        from automation.agent import base
+
+        return getattr(base, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/daiv/automation/agent/graph.py
+++ b/daiv/automation/agent/graph.py
@@ -49,6 +49,7 @@ from automation.agent.middlewares.slash_commands import SlashCommandMiddleware
 from automation.agent.middlewares.step_budget import StepBudgetMiddleware
 from automation.agent.middlewares.web_fetch import WebFetchMiddleware
 from automation.agent.middlewares.web_search import WebSearchMiddleware
+from automation.agent.profile import register as _register_harness_profile
 from automation.agent.prompts import DAIV_SYSTEM_PROMPT, REPO_RELATIVE_SYSTEM_REMINDER, WRITE_TODOS_SYSTEM_PROMPT
 from automation.agent.subagents import (
     create_explore_subagent,
@@ -73,6 +74,8 @@ if TYPE_CHECKING:
 
 
 logger = logging.getLogger("daiv.agent")
+
+_register_harness_profile()
 
 
 # Tools always bound to the model; everything else is deferred behind tool_search.

--- a/daiv/automation/apps.py
+++ b/daiv/automation/apps.py
@@ -6,8 +6,3 @@ class AutomationConfig(AppConfig):
     name = "automation"
     label = "automation"
     verbose_name = _("Automation")
-
-    def ready(self):
-        from automation.agent.profile import register as register_harness_profile
-
-        register_harness_profile()

--- a/daiv/automation/titling/tasks.py
+++ b/daiv/automation/titling/tasks.py
@@ -5,10 +5,8 @@ import re
 from typing import Literal, cast
 
 from django_tasks import task
-from langchain_core.messages import HumanMessage, SystemMessage
 from pydantic import BaseModel, Field
 
-from automation.agent.base import BaseAgent
 from automation.titling.services import MAX_TITLE_LENGTH
 from core.site_settings import site_settings
 
@@ -39,6 +37,7 @@ class GeneratedTitle(BaseModel):
 
 def _build_structured_llm():
     """Build the structured LLM chain with fallback. Raises ``RuntimeError`` if no model is configured."""
+    from automation.agent.base import BaseAgent
 
     def _structured(model_name: str):
         # No ``max_tokens`` cap: reasoning models (GPT-5, Claude thinking) count reasoning
@@ -61,6 +60,8 @@ def _invoke_titler(structured_llm, *, prompt: str, repo_id: str = "", ref: str =
 
     ``repo_id`` and ``ref`` are optional context: omitted for batches that span multiple repos.
     """
+    from langchain_core.messages import HumanMessage, SystemMessage
+
     ref = ref.strip()
     user_text = ""
     if repo_id:

--- a/daiv/codebase/repo_config.py
+++ b/daiv/codebase/repo_config.py
@@ -10,8 +10,8 @@ import yaml
 from pydantic import AliasChoices, BaseModel, Field, ValidationError
 from yaml.parser import ParserError
 
-from automation.agent.base import ThinkingLevel  # noqa: TC001
 from automation.agent.constants import ModelName  # noqa: TC001
+from core.models import ThinkingLevelChoices as ThinkingLevel  # noqa: TC001
 from core.site_settings import site_settings
 
 if TYPE_CHECKING:

--- a/daiv/codebase/tasks.py
+++ b/daiv/codebase/tasks.py
@@ -15,8 +15,6 @@ from codebase.clients import RepoClient
 from codebase.conf import settings as codebase_settings
 from codebase.context import set_runtime_ctx
 from codebase.exceptions import CloneRefNotFoundError
-from codebase.managers.issue_addressor import IssueAddressorManager
-from codebase.managers.review_addressor import CommentsAddressorManager
 from core.utils import locked_task
 
 if TYPE_CHECKING:
@@ -235,6 +233,8 @@ async def address_issue_task(
             :func:`sandbox_envs.services.resolve_env_for_run` (USER tier skipped) and ultimately
             falls back to the GLOBAL ``is_default=True`` env — so a non-None env may still apply.
     """
+    from codebase.managers.issue_addressor import IssueAddressorManager
+
     client = RepoClient.create_instance()
     issue = client.get_issue(repo_id, issue_iid)
     async with set_runtime_ctx(
@@ -395,6 +395,8 @@ async def address_mr_comments_task(
             :func:`sandbox_envs.services.resolve_env_for_run` (USER tier skipped) and ultimately
             falls back to the GLOBAL ``is_default=True`` env — so a non-None env may still apply.
     """
+    from codebase.managers.review_addressor import CommentsAddressorManager
+
     client = RepoClient.create_instance()
     merge_request = client.get_merge_request(repo_id, merge_request_id)
 

--- a/daiv/codebase/utils.py
+++ b/daiv/codebase/utils.py
@@ -3,7 +3,6 @@ import logging
 import re
 from typing import TYPE_CHECKING
 
-from langchain_core.messages import AIMessage, AnyMessage, HumanMessage
 from unidiff import PatchSet
 from unidiff.constants import LINE_TYPE_CONTEXT
 from unidiff.errors import UnidiffParseError
@@ -14,6 +13,7 @@ from core.utils import generate_uuid
 
 if TYPE_CHECKING:
     from git import Repo
+    from langchain_core.messages import AnyMessage
 
     from codebase.base import Discussion, Note, Scope, User
 
@@ -99,6 +99,8 @@ def notes_to_messages(notes: list[Note], bot_user_id) -> list[AnyMessage]:
     Returns:
         List of messages
     """
+    from langchain_core.messages import AIMessage, HumanMessage
+
     messages: list[AnyMessage] = []
     for note in notes:
         if note.author.id == bot_user_id:

--- a/daiv/jobs/tasks.py
+++ b/daiv/jobs/tasks.py
@@ -1,19 +1,14 @@
 import asyncio
 import logging
 import time
+from typing import TYPE_CHECKING
 
 from django_tasks import task
-from langchain_core.messages import HumanMessage
 from sessions.locks import SessionLock
 from sessions.models import Run, Session
 
-from automation.agent.graph import create_daiv_agent
-from automation.agent.results import AgentResult, build_agent_result
-from automation.agent.usage_tracking import build_usage_summary, track_usage_metadata
-from automation.agent.utils import build_langsmith_config, extract_text_content, get_daiv_agent_kwargs
-from codebase.base import Scope
-from codebase.context import set_runtime_ctx
-from core.checkpointer import open_checkpointer
+if TYPE_CHECKING:
+    from automation.agent.results import AgentResult
 
 logger = logging.getLogger("daiv.jobs")
 
@@ -111,6 +106,17 @@ async def run_job_task(
     Webhook callers (issue/review addressors) bypass this task and call
     ``create_daiv_agent`` directly; ``use_max`` is therefore not accepted here.
     """
+    # Heavy imports live here so enqueue-side importers of this module stay light.
+    from langchain_core.messages import HumanMessage
+
+    from automation.agent.graph import create_daiv_agent
+    from automation.agent.results import build_agent_result
+    from automation.agent.usage_tracking import build_usage_summary, track_usage_metadata
+    from automation.agent.utils import build_langsmith_config, extract_text_content, get_daiv_agent_kwargs
+    from codebase.base import Scope
+    from codebase.context import set_runtime_ctx
+    from core.checkpointer import open_checkpointer
+
     if not thread_id:
         raise ValueError("run_job_task requires a non-empty thread_id; mint one before enqueueing")
 

--- a/daiv/memory/tasks.py
+++ b/daiv/memory/tasks.py
@@ -12,16 +12,11 @@ from django.utils import timezone
 from asgiref.sync import sync_to_async
 from crontask import cron
 from django_tasks import task
-from langchain_core.messages import HumanMessage, SystemMessage
 
-from automation.agent.base import BaseAgent
 from codebase.repo_config import RepositoryConfig
-from core.checkpointer import aresolve_thread_messages, open_checkpointer
 from core.site_settings import site_settings
 from memory.models import MemoryObservation, ObservationStatus, RepositoryMemory
-from memory.prompts import consolidation_human, consolidation_system, extraction_human, extraction_system
 from memory.schemas import ConsolidatedMemory, ExtractedObservations
-from memory.transcript import serialize_transcript
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -45,6 +40,7 @@ def _build_structured_llm(schema: type, model_names: Sequence[str]):
     No ``max_tokens`` cap: reasoning models count reasoning tokens toward the budget,
     so a tight cap starves the structured-output JSON.
     """
+    from automation.agent.base import BaseAgent
 
     def _structured(model_name: str):
         return BaseAgent.get_model(model=model_name).with_structured_output(schema).with_retry(stop_after_attempt=2)
@@ -77,6 +73,10 @@ async def consolidate_memory_task(repo_id: str) -> None:
     Throttling is the caller's job (see ``consolidate_memory_cron_task``); this is not
     deduplicated, so a redundant trigger simply finds 0 pending observations and no-ops.
     """
+    from langchain_core.messages import HumanMessage, SystemMessage
+
+    from memory.prompts import consolidation_human, consolidation_system
+
     if not site_settings.memory_enabled:
         logger.info("consolidate_memory_task: memory disabled site-wide, skipping repo %s", repo_id)
         return
@@ -185,7 +185,12 @@ async def extract_observations_task(run_id: str) -> None:
     lost. Losing a single run's learnings is an accepted trade-off; agent runs
     are unaffected because this runs out-of-band.
     """
+    from langchain_core.messages import HumanMessage, SystemMessage
     from sessions.models import Run
+
+    from core.checkpointer import aresolve_thread_messages, open_checkpointer
+    from memory.prompts import extraction_human, extraction_system
+    from memory.transcript import serialize_transcript
 
     if not site_settings.memory_enabled:
         logger.info("extract_observations_task: memory disabled site-wide, skipping run %s", run_id)

--- a/daiv/schedules/models.py
+++ b/daiv/schedules/models.py
@@ -13,7 +13,7 @@ from django.utils.translation import gettext_lazy as _
 from croniter import croniter
 from django_extensions.db.models import TimeStampedModel
 from notifications.choices import NotifyOn
-from sessions.services import validate_repo_list
+from sessions.validators import validate_repo_list
 
 from automation.agent.display import MODEL_NAME_MAX_LEN, display_model_name, display_thinking_level
 from core.models import ThinkingLevelChoices

--- a/daiv/sessions/forms.py
+++ b/daiv/sessions/forms.py
@@ -17,7 +17,7 @@ from sandbox_envs.models import SandboxEnvironment
 from automation.agent.validators import AgentOverrideError, ensure_agent_model_available, validate_agent_override
 from codebase.authorization import REPO_ACCESS_DENIED_MESSAGE, RepositoryAccessDenied, assert_can_run
 from core.models import ThinkingLevelChoices
-from sessions.services import validate_repo_list
+from sessions.validators import validate_repo_list
 
 
 class RepoListField(forms.JSONField):

--- a/daiv/sessions/services.py
+++ b/daiv/sessions/services.py
@@ -16,6 +16,7 @@ from automation.titling.tasks import generate_batch_title_task
 from codebase.authorization import aassert_can_run
 from sessions.models import Run, RunStatus, Session, SessionOrigin
 from sessions.signals import LINK_FAILED_PREFIX, emit_run_finished_if_terminal
+from sessions.validators import MAX_REPOS_PER_BATCH
 
 if TYPE_CHECKING:
     from datetime import datetime
@@ -26,8 +27,6 @@ if TYPE_CHECKING:
     from schedules.models import ScheduledJob
 
 logger = logging.getLogger("daiv.sessions")
-
-MAX_REPOS_PER_BATCH = 20
 
 
 @dataclass(frozen=True)
@@ -49,37 +48,6 @@ class BatchSubmitResult:
     batch_id: uuid.UUID
     runs: list[Run] = field(default_factory=list)
     failed: list[BatchSubmitFailure] = field(default_factory=list)
-
-
-def validate_repo_list(raw) -> list[dict]:
-    """Validate and normalize a list of ``{repo_id, ref}`` entries.
-
-    Raises ``ValueError`` on any violation. Returns a fresh list of normalized dicts
-    (guaranteed string keys/values, no duplicates, 1-20 entries).
-    """
-    if not isinstance(raw, list) or not raw:
-        raise ValueError("At least one repository is required.")
-    if len(raw) > MAX_REPOS_PER_BATCH:
-        raise ValueError(f"At most {MAX_REPOS_PER_BATCH} repositories allowed per submission.")
-
-    seen: set[tuple[str, str]] = set()
-    out: list[dict] = []
-    for entry in raw:
-        if not isinstance(entry, dict) or set(entry.keys()) != {"repo_id", "ref"}:
-            raise ValueError("Each entry must be an object with keys 'repo_id' and 'ref'.")
-        repo_id = entry["repo_id"]
-        ref = entry["ref"] or ""
-        if not isinstance(repo_id, str) or not repo_id.strip():
-            raise ValueError("repo_id must be a non-empty string.")
-        if not isinstance(ref, str):
-            raise ValueError("ref must be a string (empty for default branch).")
-        key = (repo_id, ref)
-        if key in seen:
-            label = f"{repo_id} on {ref}" if ref else repo_id
-            raise ValueError(f"Repository already in the list: {label}.")
-        seen.add(key)
-        out.append({"repo_id": repo_id, "ref": ref})
-    return out
 
 
 def _validate(repos: list[RepoTarget]) -> None:

--- a/daiv/sessions/validators.py
+++ b/daiv/sessions/validators.py
@@ -1,0 +1,32 @@
+MAX_REPOS_PER_BATCH = 20
+
+
+def validate_repo_list(raw) -> list[dict]:
+    """Validate and normalize a list of ``{repo_id, ref}`` entries.
+
+    Raises ``ValueError`` on any violation. Returns a fresh list of normalized dicts
+    (guaranteed string keys/values, no duplicates, 1-20 entries).
+    """
+    if not isinstance(raw, list) or not raw:
+        raise ValueError("At least one repository is required.")
+    if len(raw) > MAX_REPOS_PER_BATCH:
+        raise ValueError(f"At most {MAX_REPOS_PER_BATCH} repositories allowed per submission.")
+
+    seen: set[tuple[str, str]] = set()
+    out: list[dict] = []
+    for entry in raw:
+        if not isinstance(entry, dict) or set(entry.keys()) != {"repo_id", "ref"}:
+            raise ValueError("Each entry must be an object with keys 'repo_id' and 'ref'.")
+        repo_id = entry["repo_id"]
+        ref = entry["ref"] or ""
+        if not isinstance(repo_id, str) or not repo_id.strip():
+            raise ValueError("repo_id must be a non-empty string.")
+        if not isinstance(ref, str):
+            raise ValueError("ref must be a string (empty for default branch).")
+        key = (repo_id, ref)
+        if key in seen:
+            label = f"{repo_id} on {ref}" if ref else repo_id
+            raise ValueError(f"Repository already in the list: {label}.")
+        seen.add(key)
+        out.append({"repo_id": repo_id, "ref": ref})
+    return out

--- a/daiv/slash_commands/actions/clear.py
+++ b/daiv/slash_commands/actions/clear.py
@@ -2,8 +2,6 @@ import logging
 
 from django.conf import settings as django_settings
 
-from langgraph.checkpoint.redis import RedisSaver
-
 from codebase.base import Scope
 from core.utils import generate_uuid
 from slash_commands.base import SlashCommand
@@ -43,6 +41,8 @@ class ClearSlashCommand(SlashCommand):
             thread_id = generate_uuid(f"{self.repo_id}:{self.scope.value}/{merge_request_id}")
         else:
             return f"The /{self.command} command is only available for issues and merge requests."
+
+        from langgraph.checkpoint.redis import RedisSaver
 
         try:
             with RedisSaver.from_conn_string(django_settings.DJANGO_REDIS_CHECKPOINT_URL) as checkpointer:

--- a/tests/unit_tests/automation/titling/test_tasks.py
+++ b/tests/unit_tests/automation/titling/test_tasks.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from sessions.models import Run, Session, SessionOrigin
 
-from automation.titling import tasks as titling_tasks
+from automation.agent.base import BaseAgent
 from automation.titling.tasks import GeneratedTitle, _ref_is_informative, generate_batch_title_task, generate_title_task
 
 
@@ -66,7 +66,7 @@ class TestGenerateTitleTask:
         )
 
     def test_returns_silently_when_entity_missing(self):
-        with patch.object(titling_tasks.BaseAgent, "get_model") as get_model:
+        with patch.object(BaseAgent, "get_model") as get_model:
             generate_title_task.func(
                 entity_type="run", pk="00000000-0000-0000-0000-000000000000", prompt="any", repo_id="x/y"
             )
@@ -78,28 +78,28 @@ class TestGenerateTitleTask:
         need to protect manual edits.)
         """
         run = self._make_run(title="Heuristic placeholder")
-        with patch.object(titling_tasks.BaseAgent, "get_model", return_value=_fake_chain(title="LLM generated")):
+        with patch.object(BaseAgent, "get_model", return_value=_fake_chain(title="LLM generated")):
             generate_title_task.func(entity_type="run", pk=str(run.pk), prompt="any", repo_id="group/repo")
         run.refresh_from_db()
         assert run.title == "LLM generated"
 
     def test_returns_when_model_not_configured(self):
         run = self._make_run()
-        with patch.object(titling_tasks.BaseAgent, "get_model", side_effect=RuntimeError("no key")):
+        with patch.object(BaseAgent, "get_model", side_effect=RuntimeError("no key")):
             generate_title_task.func(entity_type="run", pk=str(run.pk), prompt="any", repo_id="group/repo")
         run.refresh_from_db()
         assert run.title == ""
 
     def test_writes_generated_title(self):
         run = self._make_run()
-        with patch.object(titling_tasks.BaseAgent, "get_model", return_value=_fake_chain(title="Add login feature")):
+        with patch.object(BaseAgent, "get_model", return_value=_fake_chain(title="Add login feature")):
             generate_title_task.func(entity_type="run", pk=str(run.pk), prompt="add login", repo_id="group/repo")
         run.refresh_from_db()
         assert run.title == "Add login feature"
 
     def test_writes_generated_title_for_session_entity(self):
         session = Session.objects.create(thread_id=str(uuid.uuid4()), origin=SessionOrigin.CHAT, repo_id="group/repo")
-        with patch.object(titling_tasks.BaseAgent, "get_model", return_value=_fake_chain(title="Session title")):
+        with patch.object(BaseAgent, "get_model", return_value=_fake_chain(title="Session title")):
             generate_title_task.func(
                 entity_type="session", pk=session.thread_id, prompt="do a thing", repo_id="group/repo"
             )
@@ -111,7 +111,7 @@ class TestGenerateTitleTask:
             thread_id=str(uuid.uuid4()), origin=SessionOrigin.API_JOB, repo_id="group/repo"
         )
         run = Run.objects.create(session=session, trigger_type=SessionOrigin.API_JOB, repo_id="group/repo")
-        with patch.object(titling_tasks.BaseAgent, "get_model", return_value=_fake_chain(title="Run title")):
+        with patch.object(BaseAgent, "get_model", return_value=_fake_chain(title="Run title")):
             generate_title_task.func(entity_type="run", pk=str(run.pk), prompt="do a thing", repo_id="group/repo")
         run.refresh_from_db()
         assert run.title == "Run title"
@@ -119,7 +119,7 @@ class TestGenerateTitleTask:
     def test_user_text_includes_branch_when_informative(self):
         run = self._make_run()
         capture: dict = {}
-        with patch.object(titling_tasks.BaseAgent, "get_model", return_value=_fake_chain(capture=capture)):
+        with patch.object(BaseAgent, "get_model", return_value=_fake_chain(capture=capture)):
             generate_title_task.func(
                 entity_type="run", pk=str(run.pk), prompt="add login", repo_id="group/repo", ref="feat/copilotkit-chat"
             )
@@ -131,7 +131,7 @@ class TestGenerateTitleTask:
     def test_user_text_omits_branch_for_generic_ref(self):
         run = self._make_run()
         capture: dict = {}
-        with patch.object(titling_tasks.BaseAgent, "get_model", return_value=_fake_chain(capture=capture)):
+        with patch.object(BaseAgent, "get_model", return_value=_fake_chain(capture=capture)):
             generate_title_task.func(
                 entity_type="run", pk=str(run.pk), prompt="add login", repo_id="group/repo", ref="main"
             )
@@ -142,7 +142,7 @@ class TestGenerateTitleTask:
         run = self._make_run()
         capture: dict = {}
         long_prompt = "x" * 1000
-        with patch.object(titling_tasks.BaseAgent, "get_model", return_value=_fake_chain(capture=capture)):
+        with patch.object(BaseAgent, "get_model", return_value=_fake_chain(capture=capture)):
             generate_title_task.func(entity_type="run", pk=str(run.pk), prompt=long_prompt, repo_id="group/repo")
         human_text = capture["messages"][-1].content
         assert human_text.endswith("x" * 500)
@@ -163,7 +163,7 @@ class TestGenerateBatchTitleTask:
         batch_id = uuid.uuid4()
         members = [self._make_run(batch_id, repo_id=f"o/r{i}") for i in range(3)]
 
-        with patch.object(titling_tasks.BaseAgent, "get_model", return_value=_fake_chain(title="Add login feature")):
+        with patch.object(BaseAgent, "get_model", return_value=_fake_chain(title="Add login feature")):
             generate_batch_title_task.func(batch_id=str(batch_id), prompt="add login")
 
         for run in members:
@@ -175,7 +175,7 @@ class TestGenerateBatchTitleTask:
         batch_id = uuid.uuid4()
         run = self._make_run(batch_id, repo_id="o/r")
 
-        with patch.object(titling_tasks.BaseAgent, "get_model", return_value=_fake_chain(title="Batch title")):
+        with patch.object(BaseAgent, "get_model", return_value=_fake_chain(title="Batch title")):
             generate_batch_title_task.func(batch_id=str(batch_id), prompt="task")
 
         session = Session.objects.get(pk=run.session_id)
@@ -185,7 +185,7 @@ class TestGenerateBatchTitleTask:
         batch_id = uuid.uuid4()
         run = self._make_run(batch_id, repo_id="o/r", session_title="Session pinned")
 
-        with patch.object(titling_tasks.BaseAgent, "get_model", return_value=_fake_chain(title="LLM choice")):
+        with patch.object(BaseAgent, "get_model", return_value=_fake_chain(title="LLM choice")):
             generate_batch_title_task.func(batch_id=str(batch_id), prompt="task")
 
         session = Session.objects.get(pk=run.session_id)
@@ -197,7 +197,7 @@ class TestGenerateBatchTitleTask:
             self._make_run(batch_id, repo_id=f"o/r{i}")
 
         chain = _fake_chain(title="One shared title")
-        with patch.object(titling_tasks.BaseAgent, "get_model", return_value=chain):
+        with patch.object(BaseAgent, "get_model", return_value=chain):
             generate_batch_title_task.func(batch_id=str(batch_id), prompt="task")
 
         # ``invoke`` is the actual LLM call; building the chain may call other Mock methods
@@ -208,7 +208,7 @@ class TestGenerateBatchTitleTask:
         batch_id = uuid.uuid4()
         run = self._make_run(batch_id, title="Already set")
 
-        with patch.object(titling_tasks.BaseAgent, "get_model", return_value=_fake_chain(title="LLM choice")):
+        with patch.object(BaseAgent, "get_model", return_value=_fake_chain(title="LLM choice")):
             generate_batch_title_task.func(batch_id=str(batch_id), prompt="task")
 
         run.refresh_from_db()
@@ -220,7 +220,7 @@ class TestGenerateBatchTitleTask:
         prefilled = self._make_run(batch_id, title="job · run #1", repo_id="o/sched")
         empty = self._make_run(batch_id, repo_id="o/r")
 
-        with patch.object(titling_tasks.BaseAgent, "get_model", return_value=_fake_chain(title="LLM choice")):
+        with patch.object(BaseAgent, "get_model", return_value=_fake_chain(title="LLM choice")):
             generate_batch_title_task.func(batch_id=str(batch_id), prompt="task")
 
         prefilled.refresh_from_db()
@@ -235,7 +235,7 @@ class TestGenerateBatchTitleTask:
         self._make_run(batch_id, repo_id="o/r2")
         capture: dict = {}
 
-        with patch.object(titling_tasks.BaseAgent, "get_model", return_value=_fake_chain(capture=capture)):
+        with patch.object(BaseAgent, "get_model", return_value=_fake_chain(capture=capture)):
             generate_batch_title_task.func(batch_id=str(batch_id), prompt="add login")
 
         human_text = capture["messages"][-1].content
@@ -246,7 +246,7 @@ class TestGenerateBatchTitleTask:
     def test_returns_when_model_not_configured(self):
         batch_id = uuid.uuid4()
         run = self._make_run(batch_id)
-        with patch.object(titling_tasks.BaseAgent, "get_model", side_effect=RuntimeError("no key")):
+        with patch.object(BaseAgent, "get_model", side_effect=RuntimeError("no key")):
             generate_batch_title_task.func(batch_id=str(batch_id), prompt="task")
         run.refresh_from_db()
         assert run.title == ""

--- a/tests/unit_tests/daiv/test_import_hygiene.py
+++ b/tests/unit_tests/daiv/test_import_hygiene.py
@@ -1,0 +1,46 @@
+import os
+import subprocess  # noqa: S404
+import sys
+from pathlib import Path
+
+SOURCE_ROOT = Path(__file__).parents[3] / "daiv"
+
+# Roots of the agent stack (~160MB RSS). django.setup() must not load any of them:
+# every process (uvicorn app, db_worker, crontask scheduler) pays the cost otherwise.
+HEAVY_ROOTS = ("langchain", "langgraph", "deepagents", "langsmith", "anthropic", "openai", "numpy")
+
+PROBE = """
+import os
+import sys
+import django
+
+django.setup()
+heavy = tuple(os.environ["HEAVY_ROOTS"].split(","))
+roots = {m.split(".")[0] for m in sys.modules}
+offenders = sorted(r for r in roots if r.startswith(heavy))
+print("OFFENDERS:" + ",".join(offenders))
+"""
+
+
+def test_django_setup_does_not_load_agent_stack():
+    """Guards the lazy-import seams (jobs/codebase/memory/titling tasks, repo_config,
+    automation.agent.__getattr__): a new module-level import of the agent stack from any
+    eagerly-imported module (models, apps, signals, api views) regresses every process
+    back to ~+160MB RSS and shows up here as a non-empty offender list.
+    """
+    env = os.environ | {
+        "DJANGO_SETTINGS_MODULE": "daiv.settings.test",
+        "NINJA_SKIP_REGISTRY": "true",
+        "DB_PASSWORD": os.environ.get("DB_PASSWORD", "unused"),
+        "HEAVY_ROOTS": ",".join(HEAVY_ROOTS),
+    }
+    result = subprocess.run(  # noqa: S603
+        [sys.executable, "-c", PROBE], capture_output=True, text=True, cwd=SOURCE_ROOT, env=env, timeout=120
+    )
+    assert result.returncode == 0, f"probe failed:\n{result.stderr}"
+    offenders_line = next(line for line in result.stdout.splitlines() if line.startswith("OFFENDERS:"))
+    offenders = [o for o in offenders_line.removeprefix("OFFENDERS:").split(",") if o]
+    assert not offenders, (
+        f"django.setup() eagerly imports the agent stack via: {offenders}. "
+        "Defer the offending import into the function that uses it (see jobs/tasks.py)."
+    )

--- a/tests/unit_tests/jobs/test_tasks.py
+++ b/tests/unit_tests/jobs/test_tasks.py
@@ -20,17 +20,17 @@ async def test_run_job_task_uses_async_redis_saver_with_thread_id():
     agent.ainvoke = AsyncMock(return_value=fake_result)
 
     with (
-        patch("jobs.tasks.open_checkpointer") as cp_ctx,
-        patch("jobs.tasks.set_runtime_ctx") as rc_ctx,
-        patch("jobs.tasks.create_daiv_agent", new=AsyncMock(return_value=agent)) as create_agent_mock,
+        patch("core.checkpointer.open_checkpointer") as cp_ctx,
+        patch("codebase.context.set_runtime_ctx") as rc_ctx,
+        patch("automation.agent.graph.create_daiv_agent", new=AsyncMock(return_value=agent)) as create_agent_mock,
         patch(
-            "jobs.tasks.get_daiv_agent_kwargs",
+            "automation.agent.utils.get_daiv_agent_kwargs",
             return_value={"model_names": ["claude-4-7-opus"], "thinking_level": "medium"},
         ),
-        patch("jobs.tasks.build_langsmith_config", return_value={"configurable": {"thread_id": "t-123"}}),
-        patch("jobs.tasks.build_agent_result", new=AsyncMock(return_value={"response": "ok"})),
-        patch("jobs.tasks.build_usage_summary", return_value=MagicMock(to_dict=lambda: {})),
-        patch("jobs.tasks.track_usage_metadata"),
+        patch("automation.agent.utils.build_langsmith_config", return_value={"configurable": {"thread_id": "t-123"}}),
+        patch("automation.agent.results.build_agent_result", new=AsyncMock(return_value={"response": "ok"})),
+        patch("automation.agent.usage_tracking.build_usage_summary", return_value=MagicMock(to_dict=lambda: {})),
+        patch("automation.agent.usage_tracking.track_usage_metadata"),
     ):
         sentinel_checkpointer = object()
         cp_ctx.return_value.__aenter__.return_value = sentinel_checkpointer
@@ -68,13 +68,15 @@ async def test_run_job_task_threads_env_id_to_set_runtime_ctx():
     # the assertion below is what matters.
     with (
         patch("jobs.tasks._acquire_session_lock", new=AsyncMock(return_value=None)),
-        patch("jobs.tasks.set_runtime_ctx", _fake_set_runtime_ctx),
-        patch("jobs.tasks.open_checkpointer"),
-        patch("jobs.tasks.create_daiv_agent", AsyncMock()),
-        patch("jobs.tasks.get_daiv_agent_kwargs", return_value={"model_names": ["m"], "thinking_level": None}),
-        patch("jobs.tasks.build_langsmith_config", return_value={}),
-        patch("jobs.tasks.track_usage_metadata"),
-        patch("jobs.tasks.build_agent_result", AsyncMock(return_value="ok")),
+        patch("codebase.context.set_runtime_ctx", _fake_set_runtime_ctx),
+        patch("core.checkpointer.open_checkpointer"),
+        patch("automation.agent.graph.create_daiv_agent", AsyncMock()),
+        patch(
+            "automation.agent.utils.get_daiv_agent_kwargs", return_value={"model_names": ["m"], "thinking_level": None}
+        ),
+        patch("automation.agent.utils.build_langsmith_config", return_value={}),
+        patch("automation.agent.usage_tracking.track_usage_metadata"),
+        patch("automation.agent.results.build_agent_result", AsyncMock(return_value="ok")),
         suppress(Exception),
     ):
         await run_job_task.func(repo_id="r/p", prompt="p", thread_id="t1", sandbox_environment_id="env-uuid")
@@ -102,14 +104,14 @@ async def test_run_job_task_forwards_overrides():
         return {"model_names": ["captured"], "thinking_level": kwargs.get("agent_thinking_level")}
 
     with (
-        patch("jobs.tasks.open_checkpointer") as cp_ctx,
-        patch("jobs.tasks.set_runtime_ctx") as rc_ctx,
-        patch("jobs.tasks.create_daiv_agent", new=AsyncMock(return_value=agent)),
-        patch("jobs.tasks.get_daiv_agent_kwargs", side_effect=capture),
-        patch("jobs.tasks.build_langsmith_config", return_value={}),
-        patch("jobs.tasks.build_agent_result", new=AsyncMock(return_value={"response": "ok"})),
-        patch("jobs.tasks.build_usage_summary", return_value=MagicMock(to_dict=lambda: {})),
-        patch("jobs.tasks.track_usage_metadata"),
+        patch("core.checkpointer.open_checkpointer") as cp_ctx,
+        patch("codebase.context.set_runtime_ctx") as rc_ctx,
+        patch("automation.agent.graph.create_daiv_agent", new=AsyncMock(return_value=agent)),
+        patch("automation.agent.utils.get_daiv_agent_kwargs", side_effect=capture),
+        patch("automation.agent.utils.build_langsmith_config", return_value={}),
+        patch("automation.agent.results.build_agent_result", new=AsyncMock(return_value={"response": "ok"})),
+        patch("automation.agent.usage_tracking.build_usage_summary", return_value=MagicMock(to_dict=lambda: {})),
+        patch("automation.agent.usage_tracking.track_usage_metadata"),
     ):
         cp_ctx.return_value.__aenter__.return_value = object()
         rc_ctx.return_value.__aenter__.return_value = runtime_ctx
@@ -152,17 +154,17 @@ async def test_run_job_task_persists_resolved_model():
 
     with (
         patch("jobs.tasks._acquire_session_lock", new=AsyncMock(return_value=None)),
-        patch("jobs.tasks.open_checkpointer") as cp_ctx,
-        patch("jobs.tasks.set_runtime_ctx") as rc_ctx,
-        patch("jobs.tasks.create_daiv_agent", new=AsyncMock(return_value=agent)),
+        patch("core.checkpointer.open_checkpointer") as cp_ctx,
+        patch("codebase.context.set_runtime_ctx") as rc_ctx,
+        patch("automation.agent.graph.create_daiv_agent", new=AsyncMock(return_value=agent)),
         patch(
-            "jobs.tasks.get_daiv_agent_kwargs",
+            "automation.agent.utils.get_daiv_agent_kwargs",
             return_value={"model_names": ["openrouter:z-ai/glm-5.2", "fallback"], "thinking_level": "xhigh"},
         ),
-        patch("jobs.tasks.build_langsmith_config", return_value={}),
-        patch("jobs.tasks.build_agent_result", new=AsyncMock(return_value={"response": "ok"})),
-        patch("jobs.tasks.build_usage_summary", return_value=MagicMock(to_dict=lambda: {})),
-        patch("jobs.tasks.track_usage_metadata"),
+        patch("automation.agent.utils.build_langsmith_config", return_value={}),
+        patch("automation.agent.results.build_agent_result", new=AsyncMock(return_value={"response": "ok"})),
+        patch("automation.agent.usage_tracking.build_usage_summary", return_value=MagicMock(to_dict=lambda: {})),
+        patch("automation.agent.usage_tracking.track_usage_metadata"),
     ):
         cp_ctx.return_value.__aenter__.return_value = object()
         rc_ctx.return_value.__aenter__.return_value = runtime_ctx
@@ -197,9 +199,12 @@ async def test_run_job_task_leaves_model_empty_when_setup_fails_before_resolutio
 
     with (
         patch("jobs.tasks._acquire_session_lock", new=AsyncMock(return_value=None)),
-        patch("jobs.tasks.open_checkpointer"),
-        patch("jobs.tasks.set_runtime_ctx", _boom),
-        patch("jobs.tasks.get_daiv_agent_kwargs", return_value={"model_names": ["m"], "thinking_level": "high"}),
+        patch("core.checkpointer.open_checkpointer"),
+        patch("codebase.context.set_runtime_ctx", _boom),
+        patch(
+            "automation.agent.utils.get_daiv_agent_kwargs",
+            return_value={"model_names": ["m"], "thinking_level": "high"},
+        ),
         pytest.raises(RuntimeError, match="git clone failed"),
     ):
         await run_job_task.func(repo_id="owner/repo", prompt="hi", thread_id="t-fail", run_id=str(run.pk))

--- a/tests/unit_tests/memory/test_extraction_task.py
+++ b/tests/unit_tests/memory/test_extraction_task.py
@@ -94,7 +94,7 @@ async def test_extraction_creates_observation_rows():
 
     with (
         patch("memory.tasks.RepositoryConfig") as cfg,
-        patch("memory.tasks.open_checkpointer", _checkpointer_with(TRANSCRIPT)),
+        patch("core.checkpointer.open_checkpointer", _checkpointer_with(TRANSCRIPT)),
         patch("memory.tasks._build_structured_llm", return_value=_structured_llm_returning(extracted)),
     ):
         cfg.get_config.return_value = _enabled_config()
@@ -120,7 +120,7 @@ async def test_extraction_reconstructs_deltachannel_messages():
 
     with (
         patch("memory.tasks.RepositoryConfig") as cfg,
-        patch("memory.tasks.open_checkpointer", _checkpointer_with_delta(writes)),
+        patch("core.checkpointer.open_checkpointer", _checkpointer_with_delta(writes)),
         patch("memory.tasks._build_structured_llm", return_value=_structured_llm_returning(extracted)),
     ):
         cfg.get_config.return_value = _enabled_config()
@@ -137,7 +137,7 @@ async def test_extraction_skips_when_checkpoint_expired():
 
     with (
         patch("memory.tasks.RepositoryConfig") as cfg,
-        patch("memory.tasks.open_checkpointer", _checkpointer_with(None)),
+        patch("core.checkpointer.open_checkpointer", _checkpointer_with(None)),
         patch("memory.tasks._build_structured_llm") as build,
     ):
         cfg.get_config.return_value = _enabled_config()
@@ -155,7 +155,7 @@ async def test_extraction_warns_when_checkpoint_has_no_messages(caplog):
 
     with (
         patch("memory.tasks.RepositoryConfig") as cfg,
-        patch("memory.tasks.open_checkpointer", _checkpointer_with([])),
+        patch("core.checkpointer.open_checkpointer", _checkpointer_with([])),
         patch("memory.tasks._build_structured_llm") as build,
         caplog.at_level("WARNING", logger="daiv.memory"),
     ):
@@ -173,7 +173,7 @@ async def test_extraction_respects_daiv_yml_flag():
 
     with (
         patch("memory.tasks.RepositoryConfig") as cfg,
-        patch("memory.tasks.open_checkpointer", _checkpointer_with(TRANSCRIPT)),
+        patch("core.checkpointer.open_checkpointer", _checkpointer_with(TRANSCRIPT)),
         patch("memory.tasks._build_structured_llm") as build,
     ):
         cfg.get_config.return_value = _enabled_config(enabled=False)
@@ -200,7 +200,7 @@ async def test_extraction_uses_configured_models(fallback_model, expected_models
 
     with (
         patch("memory.tasks.RepositoryConfig") as cfg,
-        patch("memory.tasks.open_checkpointer", _checkpointer_with(TRANSCRIPT)),
+        patch("core.checkpointer.open_checkpointer", _checkpointer_with(TRANSCRIPT)),
         patch("memory.tasks._build_structured_llm", return_value=_structured_llm_returning(extracted)) as build,
         patch(
             "memory.tasks.site_settings",
@@ -224,7 +224,7 @@ async def test_extraction_noop_when_no_model_configured():
 
     with (
         patch("memory.tasks.RepositoryConfig") as cfg,
-        patch("memory.tasks.open_checkpointer", _checkpointer_with(TRANSCRIPT)),
+        patch("core.checkpointer.open_checkpointer", _checkpointer_with(TRANSCRIPT)),
         patch("memory.tasks._build_structured_llm") as build,
         patch(
             "memory.tasks.site_settings",
@@ -245,7 +245,7 @@ async def test_extraction_noop_when_site_disabled():
 
     with (
         patch("memory.tasks.RepositoryConfig") as cfg,
-        patch("memory.tasks.open_checkpointer", _checkpointer_with(TRANSCRIPT)),
+        patch("core.checkpointer.open_checkpointer", _checkpointer_with(TRANSCRIPT)),
         patch("memory.tasks._build_structured_llm") as build,
         patch("memory.tasks.site_settings", _site_settings(memory_enabled=False)),
     ):
@@ -292,7 +292,7 @@ async def test_extraction_noop_when_model_spec_invalid():
 
     with (
         patch("memory.tasks.RepositoryConfig") as cfg,
-        patch("memory.tasks.open_checkpointer", _checkpointer_with(TRANSCRIPT)),
+        patch("core.checkpointer.open_checkpointer", _checkpointer_with(TRANSCRIPT)),
         patch("memory.tasks._build_structured_llm", side_effect=ValueError("Unknown/Unsupported provider for model")),
     ):
         cfg.get_config.return_value = _enabled_config()
@@ -311,7 +311,7 @@ async def test_extraction_propagates_llm_failure_without_partial_writes():
 
     with (
         patch("memory.tasks.RepositoryConfig") as cfg,
-        patch("memory.tasks.open_checkpointer", _checkpointer_with(TRANSCRIPT)),
+        patch("core.checkpointer.open_checkpointer", _checkpointer_with(TRANSCRIPT)),
         patch("memory.tasks._build_structured_llm", return_value=failing_llm),
         pytest.raises(RuntimeError),
     ):

--- a/tests/unit_tests/sessions/test_services.py
+++ b/tests/unit_tests/sessions/test_services.py
@@ -17,8 +17,8 @@ from sessions.services import (
     aget_or_create_session,
     asubmit_batch_runs,
     submit_batch_runs,
-    validate_repo_list,
 )
+from sessions.validators import validate_repo_list
 
 pytestmark = pytest.mark.django_db
 

--- a/tests/unit_tests/slash_commands/actions/test_clear.py
+++ b/tests/unit_tests/slash_commands/actions/test_clear.py
@@ -38,7 +38,7 @@ def test_clear_command_has_correct_attributes():
 
 
 @override_settings(DJANGO_REDIS_CHECKPOINT_URL="redis://localhost:6379")
-@patch("slash_commands.actions.clear.RedisSaver")
+@patch("langgraph.checkpoint.redis.RedisSaver")
 async def test_clear_command_for_issue(mock_redis_saver: Mock, clear_slash_command_issue: ClearSlashCommand):
     """Test that ClearSlashCommand deletes the thread for an issue."""
     mock_checkpointer = MagicMock()
@@ -53,7 +53,7 @@ async def test_clear_command_for_issue(mock_redis_saver: Mock, clear_slash_comma
 
 
 @override_settings(DJANGO_REDIS_CHECKPOINT_URL="redis://localhost:6379")
-@patch("slash_commands.actions.clear.RedisSaver")
+@patch("langgraph.checkpoint.redis.RedisSaver")
 async def test_clear_command_for_merge_request(mock_redis_saver: Mock, clear_slash_command_mr: ClearSlashCommand):
     """Test that ClearSlashCommand deletes the thread for a merge request."""
     mock_checkpointer = MagicMock()
@@ -67,7 +67,7 @@ async def test_clear_command_for_merge_request(mock_redis_saver: Mock, clear_sla
     assert "✅" in message
 
 
-@patch("slash_commands.actions.clear.RedisSaver")
+@patch("langgraph.checkpoint.redis.RedisSaver")
 async def test_clear_command_without_issue_iid(mock_redis_saver: Mock, clear_slash_command_issue: ClearSlashCommand):
     """Test that ClearSlashCommand returns an error when issue_iid is missing."""
     message = await clear_slash_command_issue.execute_for_agent(args="")
@@ -78,7 +78,7 @@ async def test_clear_command_without_issue_iid(mock_redis_saver: Mock, clear_sla
 
 
 @override_settings(DJANGO_REDIS_CHECKPOINT_URL="redis://localhost:6379")
-@patch("slash_commands.actions.clear.RedisSaver")
+@patch("langgraph.checkpoint.redis.RedisSaver")
 async def test_clear_command_handles_exceptions(mock_redis_saver: Mock, clear_slash_command_issue: ClearSlashCommand):
     """Test that ClearSlashCommand handles exceptions gracefully."""
     mock_checkpointer = MagicMock()


### PR DESCRIPTION
## Why

Every DAIV process — the uvicorn app, each `db_worker`, and the `crontask` scheduler — paid ~160MB of RSS at startup because `django.setup()` transitively imported the entire agent stack (langchain, langgraph, deepagents, the anthropic/openai provider SDKs, langsmith, numpy): ~5,000 modules, **255MB** measured after setup. On a 4GB production host this baseline contributed to a global OOM incident (2026-07-30) where the kernel killed the app process mid chat-run.

After this change `django.setup()` loads **123MB / ~2,600 modules** and none of the heavy roots.

## What changed

- `automation/agent/__init__.py` no longer imports `.base` eagerly — `BaseAgent`/`ThinkingLevel` resolve via PEP 562 `__getattr__`. Any `automation.agent.*` submodule import previously paid for the full stack through the package init.
- `validate_repo_list` (+ `MAX_REPOS_PER_BATCH`) moved to a new light `sessions/validators.py`; `schedules/models.py` and `sessions/forms.py` import it from there instead of `sessions.services` (which pulls `jobs.tasks` → agent graph).
- Task modules (`jobs/tasks.py`, `codebase/tasks.py`, `memory/tasks.py`, `automation/titling/tasks.py`) import the agent graph, addressor managers, checkpointer, prompts, and langchain message classes inside the task bodies. Enqueue-side importers (webhook callbacks, signal receivers) stay light; workers pay the import cost on first execution instead.
- `codebase/repo_config.py` imports `ThinkingLevelChoices` from `core.models` (which `automation.agent.base` only re-exported) and `ModelName` from the now-cheap `automation.agent.constants`.
- `codebase/utils.py` and `slash_commands/actions/clear.py` defer their langchain/langgraph imports into the functions that use them.
- Harness-profile registration moved from `AutomationConfig.ready()` to `automation/agent/graph.py` module scope: it only needs to run before `create_deep_agent`, which is defined in that module, so registration now happens exactly when the graph is first imported.

## Impact

The scheduler never runs agent code in-process (its cron tasks enqueue into `db_worker`), so its steady-state footprint drops ~150MB. The app and workers load the stack lazily on their first agent run — their startup and restart-recovery get faster and lighter, steady-state is unchanged.

## Tests

- New `tests/unit_tests/daiv/test_import_hygiene.py` guards the seams: it runs `django.setup()` in a subprocess and fails if any heavy root (langchain/langgraph/deepagents/langsmith/anthropic/openai/numpy) is loaded, naming the offenders.
- Existing tests that patched deferred names on the task modules (`jobs.tasks.set_runtime_ctx`, `memory.tasks.open_checkpointer`, `titling_tasks.BaseAgent`, `clear.RedisSaver`, …) now patch the source modules — with function-body `from X import name` the lookup happens at call time, so patching the source is the correct seam.