### PR TITLE
fix(diff-to-metadata): Normalize PR branch name instead of rejecting it

### DIFF
--- a/daiv/automation/agent/diff_to_metadata/schemas.py
+++ b/daiv/automation/agent/diff_to_metadata/schemas.py
@@ -1,6 +1,29 @@
 from __future__ import annotations
 
-from pydantic import BaseModel, Field
+import re
+from typing import Annotated
+
+from pydantic import AfterValidator, BaseModel
+
+DEFAULT_BRANCH_NAME = "daiv/changes"
+
+_DISALLOWED = re.compile(r"[^a-z0-9._/-]+")
+
+
+def normalize_branch_name(value: str) -> str:
+    """Coerce a model-proposed branch name into a valid git branch name.
+
+    Normalizes rather than rejects: the branch name is cosmetic metadata DAIV owns
+    downstream (deduped by ``unique_branch_name``, shell-quoted at push), so a bad
+    value must never raise and abort the publish. Dots are kept — they are git-legal,
+    so ``chore/release-1.0.0`` survives verbatim (the Sentry DAIV-AV input).
+    """
+    name = _DISALLOWED.sub("-", value.strip().lower())
+    name = re.sub(r"\.{2,}", ".", name)
+    name = re.sub(r"/{2,}", "/", name)
+    name = re.sub(r"-{2,}", "-", name)
+    name = re.sub(r"\.lock$", "", name)
+    return name.strip("./-") or DEFAULT_BRANCH_NAME
 
 
 class CommitMetadata(BaseModel):
@@ -9,5 +32,5 @@ class CommitMetadata(BaseModel):
 
 class PullRequestMetadata(BaseModel):
     title: str
-    branch: str = Field(pattern=r"^[a-z0-9\-_/]+$")
+    branch: Annotated[str, AfterValidator(normalize_branch_name)]
     description: str

--- a/tests/unit_tests/automation/agent/test_diff_to_metadata_schemas.py
+++ b/tests/unit_tests/automation/agent/test_diff_to_metadata_schemas.py
@@ -1,0 +1,48 @@
+import pytest
+
+from automation.agent.diff_to_metadata.schemas import DEFAULT_BRANCH_NAME, PullRequestMetadata, normalize_branch_name
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        # Well-formed names pass through untouched (dots are git-legal).
+        ("chore/release-1.0.0", "chore/release-1.0.0"),  # the exact Sentry DAIV-AV input
+        ("feat/add-export", "feat/add-export"),
+        # Casing and disallowed characters are normalized.
+        ("Feature/Add-Export", "feature/add-export"),
+        ("feat/add export", "feat/add-export"),
+        ("feat/fix~^:?*bug", "feat/fix-bug"),
+        ("fix\\bug", "fix-bug"),
+        ("Feat: Big Change!", "feat-big-change"),
+        # git ref-format guards.
+        ("-feat/x-", "feat/x"),
+        ("/feat/x/", "feat/x"),
+        ("feat..x", "feat.x"),
+        ("feat//x", "feat/x"),
+        ("feat/x.lock", "feat/x"),
+        # Degenerate input falls back to a valid default.
+        ("", DEFAULT_BRANCH_NAME),
+        ("   ", DEFAULT_BRANCH_NAME),
+        ("!!!", DEFAULT_BRANCH_NAME),
+        ("..", DEFAULT_BRANCH_NAME),
+    ],
+)
+def test_normalize_branch_name(value: str, expected: str) -> None:
+    assert normalize_branch_name(value) == expected
+
+
+def test_pull_request_metadata_accepts_dotted_version_branch() -> None:
+    """The Sentry DAIV-AV input must parse without raising and be kept verbatim."""
+    metadata = PullRequestMetadata(branch="chore/release-1.0.0", title="Release 1.0.0", description="desc")
+    assert metadata.branch == "chore/release-1.0.0"
+
+
+def test_pull_request_metadata_normalizes_invalid_branch_instead_of_raising() -> None:
+    metadata = PullRequestMetadata(branch="Feat: Big Change!", title="t", description="d")
+    assert metadata.branch == "feat-big-change"
+
+
+def test_pull_request_metadata_falls_back_on_empty_branch() -> None:
+    metadata = PullRequestMetadata(branch="", title="t", description="d")
+    assert metadata.branch == DEFAULT_BRANCH_NAME


### PR DESCRIPTION
## Why

Sentry `DAIV-AV`: the `branch` field of `PullRequestMetadata` was declared `Field(pattern=r"^[a-z0-9\-_/]+$")`, which **forbids dots**. When the diff-to-metadata model returned the perfectly valid git branch name `chore/release-1.0.0` (dots from the semver), pydantic rejected it and LangChain re-raised a fatal `StructuredOutputValidationError`. That aborted `_diff_to_metadata` → `publish` → `_recover_draft` — and since it fired inside **draft recovery** (the last-chance save after an agent error), the run's changes were discarded.

The branch name is cosmetic metadata DAIV fully controls downstream (`unique_branch_name` dedupe, shell-quoted `git push`), so it must never be able to crash a publish.

## What changed

- Replace the rejecting `pattern` on `PullRequestMetadata.branch` with a pydantic `AfterValidator` (`normalize_branch_name`) that **normalizes** any model output into a valid git branch name instead of raising:
  - lowercases; keeps the git-legal set `a-z 0-9 . _ / -` (dots included, so versions survive); replaces everything else with `-`
  - applies git ref-format guards: collapses `..`, consecutive slashes and hyphen runs, strips a trailing `.lock` and leading/trailing separators
  - falls back to a stable `daiv/changes` when the input reduces to empty
- Well-formed names pass through verbatim — `chore/release-1.0.0` stays `chore/release-1.0.0`.
- No consumer change: `publishers.py` / `git_manager.py` already treat the value as an opaque, shell-quoted string.

## Why normalize instead of loosening the regex

Adding `.` to the pattern would fix only this one input while keeping the field *rejecting* — the model could still emit uppercase, spaces, `..`, or a `feat: x` colon and re-crash the publish. Normalizing makes the failure mode structurally impossible, matching the codebase's consistent "never discard the agent's work" handling.

## Tests

New `tests/unit_tests/automation/agent/test_diff_to_metadata_schemas.py` covering the exact `DAIV-AV` input (preserved verbatim), character normalization, git ref-format guards, and the empty-input fallback. Full run: `test_diff_to_metadata_schemas.py` + `test_publishers.py` + `test_git_manager.py` → **121 passed**.

Fixes DAIV-AV
