### PR TITLE
fix(repo-picker): Disable native autocomplete on picker search inputs

### DIFF
--- a/daiv/codebase/templates/codebase/_repo_picker.html
+++ b/daiv/codebase/templates/codebase/_repo_picker.html
@@ -93,7 +93,7 @@ Parameters:
          @click.outside="closePopover()"
          @keydown.escape.window="closePopover()"
          class="picker-popover left-3 w-80">
-        <input type="search" name="q" autofocus
+        <input type="search" name="q" autofocus autocomplete="off"
                x-ref="repoSearch"
                placeholder="{{ search_repos_placeholder }}"
                hx-get="{{ repo_picker_url }}"
@@ -129,7 +129,7 @@ Parameters:
          @click.outside="closePopover()"
          @keydown.escape.window="closePopover()"
          class="picker-popover left-3 w-80">
-        <input type="search" name="q" autofocus
+        <input type="search" name="q" autofocus autocomplete="off"
                x-ref="branchSearch"
                placeholder="{{ search_branches_placeholder }}"
                hx-get="{{ branch_picker_template }}"


### PR DESCRIPTION
## What

The repo and branch search inputs in the repo picker are `type="search" name="q"` without an `autocomplete` attribute. The browser therefore saved past search terms for the `q` field and offered them in a native autocomplete dropdown that rendered on top of the repository results list.

## Fix

Added `autocomplete="off"` to both the repo-search and branch-search inputs in `_repo_picker.html`, so the browser no longer surfaces saved-search suggestions over the list.