### PR TITLE
fix(file-system): Emit truncation notice on paginated sandbox reads

### DIFF
--- a/daiv/automation/agent/middlewares/file_system.py
+++ b/daiv/automation/agent/middlewares/file_system.py
@@ -7,7 +7,7 @@ import re
 import stat
 import time
 from pathlib import Path
-from typing import TYPE_CHECKING, Protocol, cast, runtime_checkable
+from typing import TYPE_CHECKING, NamedTuple, Protocol, cast, runtime_checkable
 
 import httpx
 import wcmatch.glob as wcglob
@@ -29,11 +29,17 @@ from deepagents.backends.protocol import (
     WriteResult,
 )
 from deepagents.middleware.filesystem import EDIT_FILE_TOOL_DESCRIPTION as EDIT_FILE_TOOL_DESCRIPTION_BASE
+from deepagents.middleware.filesystem import (
+    EMPTY_CONTENT_WARNING,
+    FilesystemPermission,
+    FsToolName,
+    GlobSchema,
+    GrepSchema,
+)
 from deepagents.middleware.filesystem import GLOB_TOOL_DESCRIPTION as GLOB_TOOL_DESCRIPTION_BASE
 from deepagents.middleware.filesystem import LIST_FILES_TOOL_DESCRIPTION as LIST_FILES_TOOL_DESCRIPTION_BASE
 from deepagents.middleware.filesystem import READ_FILE_TOOL_DESCRIPTION as READ_FILE_TOOL_DESCRIPTION_BASE
 from deepagents.middleware.filesystem import WRITE_FILE_TOOL_DESCRIPTION as WRITE_FILE_TOOL_DESCRIPTION_BASE
-from deepagents.middleware.filesystem import FilesystemPermission, FsToolName, GlobSchema, GrepSchema
 
 from automation.agent.constants import REPO_PATH, SKILLS_CACHE_PATH, SKILLS_PATH, TMP_PATH, WORKSPACE_PATH
 from core.sandbox.client import DAIVSandboxClient, is_transient_sandbox_error
@@ -662,6 +668,34 @@ def _fs_transport_failure_text(exc: httpx.HTTPError, op: str, target: str) -> st
     return _FS_TRANSPORT_PERMANENT_TEXT
 
 
+class _ReadWindow(NamedTuple):
+    """deepagents read-window fields for a sandbox text read (``total_lines`` stays unknown)."""
+
+    start_line: int | None
+    end_line: int | None
+    next_offset: int | None
+
+
+def _sandbox_read_window(content: str, offset: int, limit: int) -> _ReadWindow:
+    """Derive deepagents' read-window metadata (``start_line``, ``end_line``, ``next_offset``) from a
+    sandbox text read, so the filesystem middleware appends its "More lines remain from offset N"
+    notice on sandbox reads. Deepagents' own window logic needs the whole file and a total line
+    count; the sandbox windows server-side and ``fs_read`` returns neither, so it is derived here.
+
+    ``total_lines`` is left unset (deepagents' notice handles the unknown-total case) and
+    ``next_offset`` is a heuristic: a window filled to the requested ``limit`` signals more may
+    remain. A file whose length is an exact multiple of the window over-advertises a ``next_offset``
+    that a re-read then rejects as an invalid offset — self-correcting, and better than never
+    signalling truncation.
+    """
+    line_count = len(content.splitlines())
+    if line_count == 0:
+        return _ReadWindow(None, None, None)
+    end_line = offset + line_count
+    next_offset = end_line if line_count >= limit else None
+    return _ReadWindow(offset + 1, end_line, next_offset)
+
+
 class SandboxFileBackend(BackendProtocol):
     """Deepagents backend whose files live in a sandbox workspace, and the run's
     command-execution handle (``run_commands``).
@@ -800,7 +834,17 @@ class SandboxFileBackend(BackendProtocol):
             return ReadResult(error=f"File '{file_path}': {_fs_transport_failure_text(exc, 'read', file_path)}")
         if resp.error is not None:
             return ReadResult(error=f"File '{file_path}': {_fs_error_text(resp.error)}")
-        return ReadResult(file_data=FileData(content=resp.content or "", encoding=resp.encoding or "utf-8"))
+        content = resp.content or ""
+        encoding = resp.encoding or "utf-8"
+        file_data = FileData(content=content, encoding=encoding)
+        # Only line-windowed text reads carry a pagination window; binary (base64) reads the whole
+        # file and the empty-file sentinel is not file content.
+        if encoding == "base64" or content == EMPTY_CONTENT_WARNING:
+            return ReadResult(file_data=file_data)
+        window = _sandbox_read_window(content, offset, limit)
+        return ReadResult(
+            file_data=file_data, start_line=window.start_line, end_line=window.end_line, next_offset=window.next_offset
+        )
 
     async def agrep(
         self,

--- a/tests/unit_tests/automation/agent/middlewares/test_file_system.py
+++ b/tests/unit_tests/automation/agent/middlewares/test_file_system.py
@@ -670,3 +670,129 @@ class TestSandboxGrepTruncation:
         assert result.error.startswith("Grep 'foo(': ")
         assert "not a valid regular expression" in result.error
         assert "escape regex metacharacters" in result.error
+
+
+class TestSandboxReadPagination:
+    """`SandboxFileBackend.aread` must populate deepagents' read-window fields so the middleware
+    emits its truncation notice on sandbox reads (see `_sandbox_read_window`)."""
+
+    def _bound_backend(self, fs_read_response):
+        from unittest.mock import AsyncMock
+
+        from automation.agent.middlewares.file_system import SandboxFileBackend
+
+        client = AsyncMock()
+        client.fs_read = AsyncMock(return_value=fs_read_response)
+        return SandboxFileBackend(client=client, session_id="sess-1")
+
+    async def test_full_window_advertises_more_lines(self):
+        from automation.agent.constants import REPO_PATH
+        from core.sandbox.schemas import FsReadResponse
+
+        content = "".join(f"line {i}\n" for i in range(1, 101))  # exactly `limit` lines
+        backend = self._bound_backend(FsReadResponse(content=content, encoding="utf-8"))
+
+        result = await backend.aread(f"{REPO_PATH}/f.py", offset=0, limit=100)
+
+        assert result.start_line == 1
+        assert result.end_line == 100
+        assert result.next_offset == 100, "a filled window signals more lines may remain"
+        assert result.total_lines is None, "the sandbox never reports a total line count"
+
+    async def test_partial_window_reports_end_of_file(self):
+        from automation.agent.constants import REPO_PATH
+        from core.sandbox.schemas import FsReadResponse
+
+        content = "".join(f"line {i}\n" for i in range(1, 43))  # fewer than `limit` lines
+        backend = self._bound_backend(FsReadResponse(content=content, encoding="utf-8"))
+
+        result = await backend.aread(f"{REPO_PATH}/f.py", offset=0, limit=100)
+
+        assert result.start_line == 1
+        assert result.end_line == 42
+        assert result.next_offset is None, "an unfilled window means EOF was reached"
+
+    async def test_window_is_anchored_at_the_requested_offset(self):
+        from automation.agent.constants import REPO_PATH
+        from core.sandbox.schemas import FsReadResponse
+
+        content = "".join(f"line {i}\n" for i in range(51, 101))  # 50 lines starting at source line 51
+        backend = self._bound_backend(FsReadResponse(content=content, encoding="utf-8"))
+
+        result = await backend.aread(f"{REPO_PATH}/f.py", offset=50, limit=50)
+
+        assert result.start_line == 51
+        assert result.end_line == 100
+        assert result.next_offset == 100
+
+    async def test_partial_window_at_a_nonzero_offset_reports_eof(self):
+        """A later page that comes back unfilled must report EOF with `end_line` anchored at the
+        offset — the arithmetic where an offset-ignoring bug would hide."""
+        from automation.agent.constants import REPO_PATH
+        from core.sandbox.schemas import FsReadResponse
+
+        content = "".join(f"line {i}\n" for i in range(51, 81))  # 30 lines from source line 51
+        backend = self._bound_backend(FsReadResponse(content=content, encoding="utf-8"))
+
+        result = await backend.aread(f"{REPO_PATH}/f.py", offset=50, limit=100)
+
+        assert result.start_line == 51
+        assert result.end_line == 80
+        assert result.next_offset is None
+
+    async def test_contentless_read_carries_no_window(self):
+        """Empty content (the `resp.content or ""` coercion can reach the helper) must never
+        advertise a window — a zero-line window has nothing to paginate."""
+        from automation.agent.constants import REPO_PATH
+        from core.sandbox.schemas import FsReadResponse
+
+        backend = self._bound_backend(FsReadResponse(content="", encoding="utf-8"))
+
+        result = await backend.aread(f"{REPO_PATH}/f.py", offset=0, limit=100)
+
+        assert result.start_line is None
+        assert result.end_line is None
+        assert result.next_offset is None
+
+    async def test_notice_tells_the_model_more_lines_remain(self):
+        """End-to-end: the window fields must drive deepagents' actual truncation notice — the
+        behaviour the trace showed missing on sandbox reads."""
+        from deepagents.middleware.filesystem import _remaining_lines_notice
+
+        from automation.agent.constants import REPO_PATH
+        from core.sandbox.schemas import FsReadResponse
+
+        content = "".join(f"line {i}\n" for i in range(1, 101))
+        backend = self._bound_backend(FsReadResponse(content=content, encoding="utf-8"))
+
+        result = await backend.aread(f"{REPO_PATH}/f.py", offset=0, limit=100)
+
+        assert "More lines remain from offset 100" in _remaining_lines_notice(result)
+
+    async def test_binary_read_carries_no_window(self):
+        from automation.agent.constants import REPO_PATH
+        from core.sandbox.schemas import FsReadResponse
+
+        backend = self._bound_backend(FsReadResponse(content="Zm9vYmFy", encoding="base64"))
+
+        result = await backend.aread(f"{REPO_PATH}/img.png", offset=0, limit=100)
+
+        assert result.start_line is None
+        assert result.end_line is None
+        assert result.next_offset is None
+
+    async def test_empty_file_sentinel_carries_no_window(self):
+        """The sandbox returns a sentinel string (not the file's bytes) for an empty file; it must
+        not be line-windowed, even when `limit` is small enough to trip the full-window heuristic."""
+        from deepagents.middleware.filesystem import EMPTY_CONTENT_WARNING
+
+        from automation.agent.constants import REPO_PATH
+        from core.sandbox.schemas import FsReadResponse
+
+        backend = self._bound_backend(FsReadResponse(content=EMPTY_CONTENT_WARNING, encoding="utf-8"))
+
+        result = await backend.aread(f"{REPO_PATH}/empty.py", offset=0, limit=1)
+
+        assert result.start_line is None
+        assert result.end_line is None
+        assert result.next_offset is None


### PR DESCRIPTION
## What

`SandboxFileBackend.aread` now populates deepagents' read-window fields (`start_line`, `end_line`, `next_offset`) so the filesystem middleware emits its **"More lines remain from offset N"** notice on sandbox reads.

## Why

Sandbox reads window server-side — the sandbox's `fs_read` returns only the sliced content, never the full file or a total line count. Because `SandboxFileBackend` overrides `aread` (rather than deriving the window from a whole file in hand like the disk backend does), those read-window fields were left unset. The middleware only appends its truncation notice when they're populated, so on sandbox reads the model never learned a read was truncated and wouldn't page to the rest of a file.

## How

A small `_sandbox_read_window` helper derives the window from the returned slice:

- `total_lines` stays unknown (the sandbox never sends a total; deepagents' notice handles the unknown-total case).
- `next_offset` is a heuristic: a window filled to the requested `limit` signals more may remain. A file whose length is an exact multiple of the window over-advertises `next_offset` by one page, which a re-read then self-corrects (rejected as an invalid offset) — strictly better than never signalling truncation.

Binary (`base64`) reads and the empty-file sentinel are excluded from windowing.

## Tests

Adds `TestSandboxReadPagination` covering full/partial windows, non-zero offsets, EOF, binary reads, the empty-file sentinel, and an end-to-end check that the fields drive deepagents' actual `_remaining_lines_notice`.