### PR TITLE
feat(sessions): Add per-turn copy button and timestamps to chat transcript

### DIFF
--- a/daiv/chat/static/chat/js/chat-stream.js
+++ b/daiv/chat/static/chat/js/chat-stream.js
@@ -537,8 +537,9 @@
 
     // ---------- Per-turn action row (copy + timestamps) ---------------
 
-    // The copy payload and the gate for whether the copy button renders: raw markdown
-    // (the same source renderMarkdown consumes), or null for a tool-only turn.
+    // The copy payload and the gate for whether the copy button renders: the raw
+    // source the bubble rendered (markdown on assistant turns, plain text on user
+    // ones), or null for a tool-only turn.
     finalTextSegment(turn) {
       for (let i = turn.segments.length - 1; i >= 0; i--) {
         if (turn.segments[i].type === "text") return turn.segments[i];
@@ -546,8 +547,22 @@
       return null;
     },
 
-    canCopyTurn(turn) {
-      return turn.role === "assistant" && !turn.streaming && !!this.finalTextSegment(turn);
+    // Only a run's closing text turn is copyable; earlier ones are narration. Runs are serial
+    // and run_status markers terminal, so the next non-assistant turn is always the boundary.
+    isClosingTextTurn(ti) {
+      for (let i = ti + 1; i < this.turns.length; i++) {
+        const later = this.turns[i];
+        if (later.role !== "assistant") return true;
+        if (later.streaming || this.finalTextSegment(later)) return false;
+      }
+      return true;
+    },
+
+    // On a user turn this copies the whole message, including the part the
+    // "Show more" clamp is hiding.
+    canCopyTurn(turn, ti) {
+      if (turn.role === "run_status" || turn.streaming || !this.finalTextSegment(turn)) return false;
+      return turn.role === "user" || this.isClosingTextTurn(ti);
     },
 
     // Resolves true only once the write actually lands. The clipboard API is
@@ -566,8 +581,9 @@
       }
     },
 
-    turnHasActions(turn) {
-      return turn.role !== "run_status" && (this.canCopyTurn(turn) || !!turn.sent_at || !!turn.received_at);
+    // Timestamps first: they short-circuit finalTextSegment's segment scan on historical turns.
+    turnHasActions(turn, ti) {
+      return turn.role !== "run_status" && (!!turn.sent_at || !!turn.received_at || this.canCopyTurn(turn, ti));
     },
 
     // Reads `this.now` so the ticker's bumps recompute it; absolute date past a month.

--- a/daiv/chat/static/chat/js/chat-stream.js
+++ b/daiv/chat/static/chat/js/chat-stream.js
@@ -166,6 +166,10 @@
     _scrollListener: null,
     _thinkingPhrase: THINKING_LABELS[0],
     filesTouchedLimit: 20,
+    // Reactive clock backing relative timestamps: a single interval bumps it
+    // (init/destroy) so every `relativeTime()` label recomputes instead of freezing.
+    now: 0,
+    _nowTimer: null,
 
     // The new-chat repo picker is its own Alpine root; it dispatches the
     // `daiv:chat-repo-changed` window event whenever its single-repo selection
@@ -232,6 +236,10 @@
     },
 
     init() {
+      // Seed + 60s ticker (the `now` field explains why reassignment re-renders labels).
+      this.now = Date.now();
+      this._nowTimer = setInterval(() => { this.now = Date.now(); }, 60000);
+
       // Seed _filesSeen with any paths already present in hydrated history so
       // the "new row pulse" animation does not fire on initial load.
       for (const t of this.turns) {
@@ -299,6 +307,7 @@
         this._scrollEl.removeEventListener("scroll", this._scrollListener);
       }
       if (this._thinkingTimer) clearInterval(this._thinkingTimer);
+      if (this._nowTimer) clearInterval(this._nowTimer);
       if (this._source) this._source.close();
     },
 
@@ -526,6 +535,64 @@
       return turn.role === "assistant" && isLast && turn.streaming;
     },
 
+    // ---------- Per-turn action row (copy + timestamps) ---------------
+
+    // The copy payload and the gate for whether the copy button renders: raw markdown
+    // (the same source renderMarkdown consumes), or null for a tool-only turn.
+    finalTextSegment(turn) {
+      for (let i = turn.segments.length - 1; i >= 0; i--) {
+        if (turn.segments[i].type === "text") return turn.segments[i];
+      }
+      return null;
+    },
+
+    canCopyTurn(turn) {
+      return turn.role === "assistant" && !turn.streaming && !!this.finalTextSegment(turn);
+    },
+
+    // Resolves true only once the write actually lands. The clipboard API is
+    // absent in insecure contexts (plain-HTTP LAN) and writeText() can reject
+    // (permission / unfocused doc) — the caller drives its confirmation off this
+    // so the UI never claims a copy it didn't make.
+    async copyFinalText(turn) {
+      const seg = this.finalTextSegment(turn);
+      if (!seg || !navigator.clipboard) return false;
+      try {
+        await navigator.clipboard.writeText(seg.content);
+        return true;
+      } catch (e) {
+        console.warn("chat: clipboard write failed", e);
+        return false;
+      }
+    },
+
+    turnHasActions(turn) {
+      return turn.role !== "run_status" && (this.canCopyTurn(turn) || !!turn.sent_at || !!turn.received_at);
+    },
+
+    // Reads `this.now` so the ticker's bumps recompute it; absolute date past a month.
+    // Untranslated, matching the existing client-side elapsed timer.
+    relativeTime(iso) {
+      if (!iso) return "";
+      const then = new Date(iso).getTime();
+      if (!Number.isFinite(then)) return "";
+      const sec = Math.floor(Math.max(0, this.now - then) / 1000);
+      if (sec < 60) return "just now";
+      const min = Math.floor(sec / 60);
+      if (min < 60) return `${min} minute${min === 1 ? "" : "s"} ago`;
+      const hr = Math.floor(min / 60);
+      if (hr < 24) return `${hr} hour${hr === 1 ? "" : "s"} ago`;
+      const day = Math.floor(hr / 24);
+      if (day < 30) return `${day} day${day === 1 ? "" : "s"} ago`;
+      return new Date(iso).toLocaleDateString();
+    },
+
+    absoluteTime(iso) {
+      if (!iso) return "";
+      const d = new Date(iso);
+      return Number.isFinite(d.getTime()) ? d.toLocaleString() : "";
+    },
+
     toolSignature(seg) {
       if (!window.toolSignature) return { label: seg.name, path: "", badges: [] };
       return window.toolSignature(seg.name, seg.args, seg.result, seg.status);
@@ -587,6 +654,9 @@
         id: uuid(),
         role: "user",
         segments: [{ type: "text", content: this.draftMessage }],
+        // Optimistic stamp; a reload reconciles it to the server's Run.created_at and
+        // relative granularity hides the difference. `received_at` is server-owned.
+        sent_at: new Date().toISOString(),
       });
       this.turns.push({
         id: uuid(),

--- a/daiv/sessions/locale/pt/LC_MESSAGES/django.po
+++ b/daiv/sessions/locale/pt/LC_MESSAGES/django.po
@@ -443,3 +443,12 @@ msgstr "Mostrar mais"
 
 msgid "Show less"
 msgstr "Mostrar menos"
+
+msgid "Copy"
+msgstr "Copiar"
+
+msgid "Copied"
+msgstr "Copiado"
+
+msgid "Copy failed"
+msgstr "Falha ao copiar"

--- a/daiv/sessions/templates/sessions/session_detail.html
+++ b/daiv/sessions/templates/sessions/session_detail.html
@@ -255,6 +255,35 @@
                       </div>
                     </template>
                   </div>
+
+                  <template x-if="turnHasActions(turn)">
+                    <div class="chat-turn__actions">
+                      {# The shown span's text names the button (x-show=display:none drops the #}
+                      {# hidden one from the a11y tree), so no separate aria-label is needed. #}
+                      <button type="button" class="chat-turn__action-btn" x-show="canCopyTurn(turn)"
+                              x-data="{ state: '', _t: null, async copy() { this.state = await copyFinalText(turn) ? 'copied' : 'failed'; clearTimeout(this._t); this._t = setTimeout(() => { this.state = ''; }, 1500); } }"
+                              @click="copy()">
+                        <span x-show="!state" class="chat-turn__action-inner">
+                          {% icon "clipboard-document" "chat-turn__action-icon" %}
+                          <span>{% translate "Copy" %}</span>
+                        </span>
+                        <span x-show="state === 'copied'" x-cloak class="chat-turn__action-inner">
+                          {% icon "check" "chat-turn__action-icon" %}
+                          <span>{% translate "Copied" %}</span>
+                        </span>
+                        <span x-show="state === 'failed'" x-cloak class="chat-turn__action-inner">
+                          {% icon "x-mark" "chat-turn__action-icon" %}
+                          <span>{% translate "Copy failed" %}</span>
+                        </span>
+                      </button>
+                      <template x-if="turn.sent_at || turn.received_at">
+                        <time class="chat-turn__time"
+                              :datetime="turn.sent_at || turn.received_at"
+                              :title="absoluteTime(turn.sent_at || turn.received_at)"
+                              x-text="relativeTime(turn.sent_at || turn.received_at)"></time>
+                      </template>
+                    </div>
+                  </template>
                 </article>
               </template>
             </div>

--- a/daiv/sessions/templates/sessions/session_detail.html
+++ b/daiv/sessions/templates/sessions/session_detail.html
@@ -256,24 +256,26 @@
                     </template>
                   </div>
 
-                  <template x-if="turnHasActions(turn)">
+                  <template x-if="turnHasActions(turn, ti)">
                     <div class="chat-turn__actions">
-                      {# The shown span's text names the button (x-show=display:none drops the #}
-                      {# hidden one from the a11y tree), so no separate aria-label is needed. #}
-                      <button type="button" class="chat-turn__action-btn" x-show="canCopyTurn(turn)"
+                      {# Icon-only: the labels stay as sr-only text so the shown span still names #}
+                      {# the button (x-show=display:none drops the hidden ones from the a11y #}
+                      {# tree), which also announces the outcome without a live region. #}
+                      <button type="button" class="chat-turn__action-btn" x-show="canCopyTurn(turn, ti)"
+                              title="{% translate 'Copy' %}"
                               x-data="{ state: '', _t: null, async copy() { this.state = await copyFinalText(turn) ? 'copied' : 'failed'; clearTimeout(this._t); this._t = setTimeout(() => { this.state = ''; }, 1500); } }"
                               @click="copy()">
                         <span x-show="!state" class="chat-turn__action-inner">
                           {% icon "clipboard-document" "chat-turn__action-icon" %}
-                          <span>{% translate "Copy" %}</span>
+                          <span class="sr-only">{% translate "Copy" %}</span>
                         </span>
                         <span x-show="state === 'copied'" x-cloak class="chat-turn__action-inner">
                           {% icon "check" "chat-turn__action-icon" %}
-                          <span>{% translate "Copied" %}</span>
+                          <span class="sr-only">{% translate "Copied" %}</span>
                         </span>
                         <span x-show="state === 'failed'" x-cloak class="chat-turn__action-inner">
                           {% icon "x-mark" "chat-turn__action-icon" %}
-                          <span>{% translate "Copy failed" %}</span>
+                          <span class="sr-only">{% translate "Copy failed" %}</span>
                         </span>
                       </button>
                       <template x-if="turn.sent_at || turn.received_at">

--- a/daiv/sessions/transcript.py
+++ b/daiv/sessions/transcript.py
@@ -50,6 +50,21 @@ def _marker(run: Run) -> dict[str, Any] | None:
     return {"id": f"run-status-{run.id}", "role": "run_status", "status": status, "message": message}
 
 
+def _stamp_run_times(seg_turns: list[dict[str, Any]], run: Run) -> None:
+    """Stamp run-level timings onto a segment's boundary turns (machine ISO-8601).
+
+    ``sent_at`` (creation time) lands on the owning user turn — the segment's first
+    turn when it is a user turn — and ``received_at`` (finish time) on the run's last
+    turn, only once the run has finished.
+    """
+    if not seg_turns:
+        return
+    if run.created_at is not None and seg_turns[0].get("role") == "user":
+        seg_turns[0]["sent_at"] = run.created_at.isoformat()
+    if run.finished_at is not None:
+        seg_turns[-1]["received_at"] = run.finished_at.isoformat()
+
+
 def _synthetic_turns(run: Run) -> list[dict[str, Any]]:
     """A run that produced no visible user turn. Recover a FAILED run's prompt as a
     user turn plus its marker; a non-failed run with no turn contributes nothing."""
@@ -58,7 +73,10 @@ def _synthetic_turns(run: Run) -> list[dict[str, Any]]:
         return []
     out: list[dict[str, Any]] = []
     if run.prompt:
-        out.append({"id": f"run-{run.id}", "role": "user", "segments": [{"type": "text", "content": run.prompt}]})
+        user_turn = {"id": f"run-{run.id}", "role": "user", "segments": [{"type": "text", "content": run.prompt}]}
+        if run.created_at is not None:
+            user_turn["sent_at"] = run.created_at.isoformat()
+        out.append(user_turn)
     out.append(marker)
     return out
 
@@ -115,6 +133,9 @@ def annotate_transcript(turns: list[dict[str, Any]], runs: list[Run]) -> list[di
         while cursor < matched:
             result.extend(segments[cursor]["turns"])
             cursor += 1
+        # received_at targets the segment's own turns; the run_status marker is appended
+        # to `result` separately below, so it never receives a timestamp.
+        _stamp_run_times(segments[matched]["turns"], run)
         result.extend(segments[matched]["turns"])
         cursor = matched + 1
         if (marker := _marker(run)) is not None:

--- a/daiv/static_src/css/input.css
+++ b/daiv/static_src/css/input.css
@@ -915,18 +915,19 @@ main:has(.chat-shell) {
   .chat-turn__actions:focus-within {
     opacity: 1;
   }
+  /* Mirrors the assistant row: reversing packs the items against the right edge
+     and keeps the copy button on the outer side, nearest the bubble's corner. */
   .chat-turn--user .chat-turn__actions {
-    justify-content: flex-end;
+    flex-direction: row-reverse;
   }
   .chat-turn__action-btn {
     display: inline-flex;
     align-items: center;
-    padding: 2px 6px;
+    padding: 4px;
     border: 0;
     border-radius: 6px;
     background: none;
     color: inherit;
-    font-size: 12px;
     cursor: pointer;
   }
   .chat-turn__action-btn:hover {
@@ -937,13 +938,14 @@ main:has(.chat-shell) {
     outline: 2px solid rgba(147, 197, 253, 0.5);
     outline-offset: 2px;
   }
+  /* Load-bearing despite wrapping a single icon: the flex context blockifies it and
+     drops the inline strut, without which the button grows 24px -> 29px tall. */
   .chat-turn__action-inner {
     display: inline-flex;
     align-items: center;
-    gap: 0.3rem;
   }
   .chat-turn__action-icon {
-    @apply h-3.5 w-3.5;
+    @apply h-4 w-4;
   }
   .chat-turn__time {
     white-space: nowrap;

--- a/daiv/static_src/css/input.css
+++ b/daiv/static_src/css/input.css
@@ -899,6 +899,56 @@ main:has(.chat-shell) {
 
   .chat-turn-wrap { display: contents; }
 
+  /* Muted per-turn action row (copy + relative timestamp). Base opacity keeps it
+     tappable on touch (no hover to reveal); it only brightens on hover/focus. */
+  .chat-turn__actions {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin-top: 0.25rem;
+    font-size: 12px;
+    color: #64748b;
+    opacity: 0.6;
+    transition: opacity 0.15s ease;
+  }
+  .chat-turn:hover .chat-turn__actions,
+  .chat-turn__actions:focus-within {
+    opacity: 1;
+  }
+  .chat-turn--user .chat-turn__actions {
+    justify-content: flex-end;
+  }
+  .chat-turn__action-btn {
+    display: inline-flex;
+    align-items: center;
+    padding: 2px 6px;
+    border: 0;
+    border-radius: 6px;
+    background: none;
+    color: inherit;
+    font-size: 12px;
+    cursor: pointer;
+  }
+  .chat-turn__action-btn:hover {
+    background: rgba(148, 163, 184, 0.12);
+    color: #e2e8f0;
+  }
+  .chat-turn__action-btn:focus-visible {
+    outline: 2px solid rgba(147, 197, 253, 0.5);
+    outline-offset: 2px;
+  }
+  .chat-turn__action-inner {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+  }
+  .chat-turn__action-icon {
+    @apply h-3.5 w-3.5;
+  }
+  .chat-turn__time {
+    white-space: nowrap;
+  }
+
   .chat-run-status {
     @apply mx-auto my-2 flex max-w-2xl items-center gap-2 rounded-lg border px-3 py-2 text-sm;
   }

--- a/tests/unit_tests/sessions/test_transcript.py
+++ b/tests/unit_tests/sessions/test_transcript.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from datetime import UTC, datetime
 from types import SimpleNamespace
 
 from sessions.models import RunStatus, SessionOrigin
@@ -8,9 +9,20 @@ from sessions.transcript import annotate_transcript
 
 from core.constants import CANCELLED_BY_USER_MESSAGE, INTERRUPTED_MESSAGE, RUN_FAILED_MESSAGE
 
+CREATED_AT = datetime(2026, 7, 31, 12, 0, 0, tzinfo=UTC)
+FINISHED_AT = datetime(2026, 7, 31, 12, 5, 0, tzinfo=UTC)
+
 
 def _run(
-    rid, *, status=RunStatus.SUCCESSFUL, message_id="", error_message="", prompt="", trigger_type=SessionOrigin.CHAT
+    rid,
+    *,
+    status=RunStatus.SUCCESSFUL,
+    message_id="",
+    error_message="",
+    prompt="",
+    trigger_type=SessionOrigin.CHAT,
+    created_at=None,
+    finished_at=None,
 ):
     return SimpleNamespace(
         id=rid,
@@ -19,6 +31,8 @@ def _run(
         error_message=error_message,
         prompt=prompt,
         trigger_type=trigger_type,
+        created_at=created_at,
+        finished_at=finished_at,
     )
 
 
@@ -218,3 +232,94 @@ def test_unmatched_message_id_logs_only_for_non_failed_runs(caplog):
         result = annotate_transcript(turns, [_run("rs", message_id="gone", status=RunStatus.SUCCESSFUL)])
     assert [t["id"] for t in result] == ["h1", "a1"]  # non-failed run contributes nothing
     assert any("no matching" in r.message and "gone" in r.getMessage() for r in caplog.records)
+
+
+# --- Run-level sent/received timestamp stamping ---------------------------------
+
+
+def test_sent_and_received_stamped_on_run_boundaries():
+    # A completed run brackets its exchange: sent_at (created_at) on the owning user
+    # turn, received_at (finished_at) on the run's last turn — machine ISO-8601.
+    turns = [_user("h1"), _assistant("a1")]
+    runs = [_run("r1", message_id="h1", created_at=CREATED_AT, finished_at=FINISHED_AT)]
+    result = annotate_transcript(turns, runs)
+    assert result[0]["id"] == "h1"
+    assert result[0]["sent_at"] == CREATED_AT.isoformat()
+    assert "received_at" not in result[0]
+    assert result[1]["id"] == "a1"
+    assert result[1]["received_at"] == FINISHED_AT.isoformat()
+    assert "sent_at" not in result[1]
+
+
+def test_received_absent_when_finished_at_is_none():
+    # In-flight run (created but not finished): sent_at shows, no received_at anywhere.
+    turns = [_user("h1"), _assistant("a1")]
+    runs = [_run("r1", message_id="h1", created_at=CREATED_AT, finished_at=None)]
+    result = annotate_transcript(turns, runs)
+    assert result[0]["sent_at"] == CREATED_AT.isoformat()
+    assert all("received_at" not in t for t in result)
+
+
+def test_single_received_for_multiple_assistant_turns():
+    # One run producing several assistant turns gets exactly one received_at, on the
+    # segment's last turn; intermediate turns get neither timestamp.
+    turns = [_user("h1"), _assistant("a1"), _assistant("a2")]
+    runs = [_run("r1", message_id="h1", created_at=CREATED_AT, finished_at=FINISHED_AT)]
+    result = annotate_transcript(turns, runs)
+    assert result[0]["sent_at"] == CREATED_AT.isoformat()
+    assert "received_at" not in result[1]  # intermediate assistant turn
+    assert "sent_at" not in result[1]
+    assert result[2]["received_at"] == FINISHED_AT.isoformat()
+    assert [t for t in result if t.get("received_at")] == [result[2]]
+
+
+def test_ordinal_fallback_stamps_sent_at():
+    # Background/legacy run (no message_id) matched by ordinal still carries sent_at on
+    # its user turn and received_at on its last turn.
+    turns = [_user("h1"), _assistant("a1")]
+    runs = [_run("r1", created_at=CREATED_AT, finished_at=FINISHED_AT)]
+    result = annotate_transcript(turns, runs)
+    assert result[0]["sent_at"] == CREATED_AT.isoformat()
+    assert result[1]["received_at"] == FINISHED_AT.isoformat()
+
+
+def test_synthetic_recovered_user_turn_carries_sent_at():
+    # A FAILED run recovered via _synthetic_turns (its message never checkpointed) still
+    # carries sent_at on the recovered prompt turn; the status marker gets no received_at.
+    runs = [
+        _run(
+            "r1",
+            message_id="missing",
+            status=RunStatus.FAILED,
+            error_message="boom",
+            prompt="please fix X",
+            created_at=CREATED_AT,
+            finished_at=FINISHED_AT,
+        )
+    ]
+    result = annotate_transcript([], runs)
+    assert [t["id"] for t in result] == ["run-r1", "run-status-r1"]
+    assert result[0]["sent_at"] == CREATED_AT.isoformat()
+    assert "received_at" not in result[1]  # the run_status marker is not a real turn
+
+
+def test_stamping_is_noop_without_run_timestamps():
+    # Guard: runs lacking created_at/finished_at (the default helper shape used by the
+    # pre-existing tests) add no new keys, so the old exact-turn assertions still hold.
+    turns = [_user("h1"), _assistant("a1")]
+    result = annotate_transcript(turns, [_run("r1", message_id="h1")])
+    assert result == [_user("h1"), _assistant("a1")]
+    assert all("sent_at" not in t and "received_at" not in t for t in result)
+
+
+def test_sent_at_not_stamped_on_assistant_first_head_segment():
+    # A leading non-user turn buckets into the anonymous head segment (user_id=None),
+    # reachable only by ordinal fallback. The role guard must keep sent_at off its
+    # assistant turn; a regression dropping the guard would stamp sent_at on an AI turn.
+    turns = [_assistant("a0"), _user("h1"), _assistant("a1")]
+    runs = [_run("r1", created_at=CREATED_AT, finished_at=FINISHED_AT)]
+    result = annotate_transcript(turns, runs)
+    assert [t["id"] for t in result] == ["a0", "h1", "a1"]
+    assert "sent_at" not in result[0]  # assistant-first head turn: guard declines sent_at
+    assert result[0]["received_at"] == FINISHED_AT.isoformat()
+    assert all("sent_at" not in t for t in result)


### PR DESCRIPTION
## What

Adds a muted per-turn action row to the chat session detail view:

- **Copy button** on assistant turns — copies the raw markdown of the turn's final text segment. Confirmation is driven off the actual `navigator.clipboard.writeText` resolution, so the UI never claims a copy it didn't make (the API is absent on insecure-context LAN and can reject).
- **Relative timestamp** ("just now" → "X minutes/hours/days ago", absolute past a month) shown next to each turn, with the full local datetime on hover. A single 60s reactive clock (`now` field, seeded/cleared in init/destroy) recomputes the labels instead of freezing them.

Server-side, `annotate_transcript` stamps machine ISO-8601 timings onto the turn dicts:

- `sent_at` (`Run.created_at`) on the owning **user** turn.
- `received_at` (`Run.finished_at`) on the run's **last real** turn, only once the run has finished — never on the appended `run_status` marker.

The live/streaming path sets an optimistic `sent_at` on the user turn that reconciles to the server value on reload; `received_at` stays server-owned.

## Notes

- JS time labels are intentionally untranslated, matching the file's existing no-i18n boundary (`thinkingLabel`, run-status messages). The `Copy`/`Copied`/`Copy failed` strings live in the Django template and are translated (pt catalog updated).
- ISO strings are stamped at the transcript layer so both serialization paths (`json_script` hydration and the django-ninja `/turns` poller) emit identical, already-serialized values.

## Tests

8 new `annotate_transcript` tests covering sent/received stamping on run boundaries, the in-flight (no `received_at`) case, single `received_at` across multiple assistant turns, ordinal-fallback matching, synthetic FAILED-run recovery, the no-timestamp no-op, and the assistant-first head-segment guard. Full suite: 24/24 passing.