### PR TITLE
Take the sandbox read window from the sandbox, and drop the dead file-mutation schemas

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,10 +73,14 @@ In unit tests that call tools directly, check `isinstance(result, Command)` and 
 **Sandbox wire schemas** — `daiv/core/sandbox/schemas.dump.json` is the canonical sandbox-side schema dump. The `tests/unit_tests/core/sandbox/test_schema_consistency.py` test will fail if the daiv-side schemas drift from it. Regenerate after any change to `daiv_sandbox/schemas.py` in the [daiv-sandbox](https://github.com/srtab/daiv-sandbox) repo:
 
 ```bash
-# from a checkout of the daiv-sandbox repo
-uv run --all-extras python scripts/dump_schemas.py \
+# from a checkout of the daiv-sandbox repo (PYTHONPATH is required — that repo declares no build
+# backend, so `uv run` never puts `daiv_sandbox` on sys.path)
+PYTHONPATH=. uv run --all-extras python scripts/dump_schemas.py \
     > /path/to/daiv/daiv/core/sandbox/schemas.dump.json
 ```
+
+The dump is a full replacement, not a merge: a type the sandbox has deleted disappears from it, so a
+refresh can also require re-categorizing entries in that test (see `_REMOVED_FROM_SANDBOX`).
 
 **`thread_id` contract** — callers of `run_job_task` must supply a non-empty UUID `thread_id`. The `Activity` row and LangGraph checkpointer share this key; a missing ID breaks chat resume.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,8 +79,10 @@ PYTHONPATH=. uv run --all-extras python scripts/dump_schemas.py \
     > /path/to/daiv/daiv/core/sandbox/schemas.dump.json
 ```
 
-The dump is a full replacement, not a merge: a type the sandbox has deleted disappears from it, so a
-refresh can also require re-categorizing entries in that test (see `_REMOVED_FROM_SANDBOX`).
+A type the sandbox deletes disappears from the dump; if the daiv side still models it, delete the
+dead model rather than adding an exemption to that test. Note the comparison normalizes
+`title`/`description` away — field docstrings are *not* pinned and can silently drift from the
+sandbox's own wording.
 
 **`thread_id` contract** — callers of `run_job_task` must supply a non-empty UUID `thread_id`. The `Activity` row and LangGraph checkpointer share this key; a missing ID breaks chat resume.
 

--- a/daiv/automation/agent/middlewares/file_system.py
+++ b/daiv/automation/agent/middlewares/file_system.py
@@ -7,7 +7,7 @@ import re
 import stat
 import time
 from pathlib import Path
-from typing import TYPE_CHECKING, NamedTuple, Protocol, cast, runtime_checkable
+from typing import TYPE_CHECKING, Protocol, cast, runtime_checkable
 
 import httpx
 import wcmatch.glob as wcglob
@@ -668,34 +668,6 @@ def _fs_transport_failure_text(exc: httpx.HTTPError, op: str, target: str) -> st
     return _FS_TRANSPORT_PERMANENT_TEXT
 
 
-class _ReadWindow(NamedTuple):
-    """deepagents read-window fields for a sandbox text read (``total_lines`` stays unknown)."""
-
-    start_line: int | None
-    end_line: int | None
-    next_offset: int | None
-
-
-def _sandbox_read_window(content: str, offset: int, limit: int) -> _ReadWindow:
-    """Derive deepagents' read-window metadata (``start_line``, ``end_line``, ``next_offset``) from a
-    sandbox text read, so the filesystem middleware appends its "More lines remain from offset N"
-    notice on sandbox reads. Deepagents' own window logic needs the whole file and a total line
-    count; the sandbox windows server-side and ``fs_read`` returns neither, so it is derived here.
-
-    ``total_lines`` is left unset (deepagents' notice handles the unknown-total case) and
-    ``next_offset`` is a heuristic: a window filled to the requested ``limit`` signals more may
-    remain. A file whose length is an exact multiple of the window over-advertises a ``next_offset``
-    that a re-read then rejects as an invalid offset — self-correcting, and better than never
-    signalling truncation.
-    """
-    line_count = len(content.splitlines())
-    if line_count == 0:
-        return _ReadWindow(None, None, None)
-    end_line = offset + line_count
-    next_offset = end_line if line_count >= limit else None
-    return _ReadWindow(offset + 1, end_line, next_offset)
-
-
 class SandboxFileBackend(BackendProtocol):
     """Deepagents backend whose files live in a sandbox workspace, and the run's
     command-execution handle (``run_commands``).
@@ -841,9 +813,28 @@ class SandboxFileBackend(BackendProtocol):
         # file and the empty-file sentinel is not file content.
         if encoding == "base64" or content == EMPTY_CONTENT_WARNING:
             return ReadResult(file_data=file_data)
-        window = _sandbox_read_window(content, offset, limit)
+        if resp.truncated:
+            logger.warning(
+                "Sandbox read of %r was truncated at the response byte limit; window ends at line %s",
+                file_path,
+                resp.end_line,
+            )
+        if resp.total_lines is None:
+            # The sandbox predates the read-window fields, so the pagination notice silently
+            # disappears. Deriving a window from the returned text instead would count the
+            # truncation banner as source lines and skip real ones — never guess, but stay visible.
+            logger.warning("Sandbox read of %r returned no line metadata; deploy a newer sandbox", file_path)
+        start_line = offset + 1
+        end_line = resp.end_line
+        if end_line is None or end_line < start_line:
+            return ReadResult(file_data=file_data)
+        total_lines = resp.total_lines
         return ReadResult(
-            file_data=file_data, start_line=window.start_line, end_line=window.end_line, next_offset=window.next_offset
+            file_data=file_data,
+            start_line=start_line,
+            end_line=end_line,
+            total_lines=total_lines,
+            next_offset=end_line if total_lines is not None and end_line < total_lines else None,
         )
 
     async def agrep(

--- a/daiv/automation/agent/middlewares/file_system.py
+++ b/daiv/automation/agent/middlewares/file_system.py
@@ -7,7 +7,7 @@ import re
 import stat
 import time
 from pathlib import Path
-from typing import TYPE_CHECKING, Protocol, cast, runtime_checkable
+from typing import TYPE_CHECKING, NamedTuple, Protocol, cast, runtime_checkable
 
 import httpx
 import wcmatch.glob as wcglob
@@ -668,6 +668,42 @@ def _fs_transport_failure_text(exc: httpx.HTTPError, op: str, target: str) -> st
     return _FS_TRANSPORT_PERMANENT_TEXT
 
 
+class _ReadFault(NamedTuple):
+    """An unusable piece of sandbox read metadata. ``key`` dedupes the log across a run."""
+
+    key: str
+    level: int
+    detail: str
+
+
+_MISSING_READ_WINDOW = _ReadFault(
+    "no-line-metadata", logging.ERROR, "returned no read-window metadata; deploy a matching daiv-sandbox release"
+)
+
+
+def _read_window_fault(end_line: int, content: str, offset: int, limit: int) -> _ReadFault | None:
+    """Check the sandbox's reported read window against the request, or return ``None`` when it holds.
+
+    Every fault drops the window and keeps the content: the model loses the pagination notice but
+    still gets the page. Rebuilding the window from the returned text is never the fallback — a
+    byte-capped page carries the sandbox's banner inline, so counting its rows resumes past unread
+    source lines.
+    """
+    if end_line == offset:
+        # The page's first line alone exceeds the byte cap, so it holds no complete line — and
+        # deepagents cannot express a zero-line window.
+        return _ReadFault("empty-page", logging.WARNING, "returned no complete line (byte cap)")
+    if not offset < end_line <= offset + limit:
+        return _ReadFault(
+            "end-line-out-of-range", logging.ERROR, f"returned end_line={end_line} outside the requested window"
+        )
+    if not content:
+        return _ReadFault(
+            "window-over-empty-content", logging.ERROR, f"reported a window ending at {end_line} over empty content"
+        )
+    return None
+
+
 class SandboxFileBackend(BackendProtocol):
     """Deepagents backend whose files live in a sandbox workspace, and the run's
     command-execution handle (``run_commands``).
@@ -700,6 +736,7 @@ class SandboxFileBackend(BackendProtocol):
     def __init__(self, *, client: DAIVSandboxClient | None = None, session_id: str | None = None) -> None:
         self._client = client
         self._session_id = session_id
+        self._logged_read_faults: set[str] = set()
 
     def bind_session(self, session_id: str) -> None:
         """Attach the run's session id. The client is supplied at construction; this only sets the
@@ -813,28 +850,67 @@ class SandboxFileBackend(BackendProtocol):
         # file and the empty-file sentinel is not file content.
         if encoding == "base64" or content == EMPTY_CONTENT_WARNING:
             return ReadResult(file_data=file_data)
-        if resp.truncated:
-            logger.warning(
-                "Sandbox read of %r was truncated at the response byte limit; window ends at line %s",
-                file_path,
-                resp.end_line,
-            )
-        if resp.total_lines is None:
-            # The sandbox predates the read-window fields, so the pagination notice silently
-            # disappears. Deriving a window from the returned text instead would count the
-            # truncation banner as source lines and skip real ones — never guess, but stay visible.
-            logger.warning("Sandbox read of %r returned no line metadata; deploy a newer sandbox", file_path)
-        start_line = offset + 1
-        end_line = resp.end_line
-        if end_line is None or end_line < start_line:
+
+        if (end_line := resp.end_line) is None:
+            self._log_window_fault(_MISSING_READ_WINDOW, file_path, offset, limit)
             return ReadResult(file_data=file_data)
+        if fault := _read_window_fault(end_line, content, offset, limit):
+            self._log_window_fault(fault, file_path, offset, limit)
+            return ReadResult(file_data=file_data)
+
         total_lines = resp.total_lines
-        return ReadResult(
-            file_data=file_data,
-            start_line=start_line,
-            end_line=end_line,
-            total_lines=total_lines,
-            next_offset=end_line if total_lines is not None and end_line < total_lines else None,
+        if total_lines is not None and total_lines < end_line:
+            # Degrade to an unknown total rather than drop the window: a resume offset still works.
+            self._log_read_fault(
+                "total-below-end-line",
+                logging.ERROR,
+                "Sandbox read of %r reported total_lines=%s below end_line=%s; dropping the total",
+                file_path,
+                total_lines,
+                end_line,
+            )
+            total_lines = None
+        try:
+            return ReadResult(
+                file_data=file_data,
+                start_line=offset + 1,
+                end_line=end_line,
+                total_lines=total_lines,
+                # An unknown total over-advertises a resume offset at EOF, which the next read rejects as
+                # an invalid offset. A missing one would read as EOF and silently drop the rest of the file.
+                next_offset=None if total_lines is not None and end_line >= total_lines else end_line,
+            )
+        except ValueError as exc:
+            # ReadResult enforces more window invariants than the checks above mirror, and it enforces
+            # them by raising — which would escape the tool and kill the run.
+            self._log_read_fault(
+                "rejected-read-window",
+                logging.ERROR,
+                "Sandbox read of %r built a window deepagents rejects (%s); dropping it",
+                file_path,
+                exc,
+            )
+            return ReadResult(file_data=file_data)
+
+    def _log_read_fault(self, key: str, level: int, msg: str, *args) -> None:
+        """Report unusable read metadata once per fault kind per run. Every cause is systematic — a
+        version skew or a sandbox arithmetic slip repeats on every read — and each ERROR is a Sentry
+        event, so repeating one buries every other breadcrumb in the event it eventually attaches to.
+        """
+        if key in self._logged_read_faults:
+            return
+        self._logged_read_faults.add(key)
+        logger.log(level, msg, *args)
+
+    def _log_window_fault(self, fault: _ReadFault, file_path: str, offset: int, limit: int) -> None:
+        self._log_read_fault(
+            fault.key,
+            fault.level,
+            "Sandbox read of %r %s (offset=%s limit=%s); dropping the pagination window",
+            file_path,
+            fault.detail,
+            offset,
+            limit,
         )
 
     async def agrep(
@@ -851,7 +927,9 @@ class SandboxFileBackend(BackendProtocol):
         ``max_count`` is applied here rather than pushed down: ``FsGrepRequest`` carries no cap,
         so the sandbox always returns its full result and the trim happens on this side.
         ``context_lines`` is accepted for signature parity only — the RPC returns matching lines
-        with no surrounding context, and no DAIV caller requests it.
+        with no surrounding context, and no DAIV caller requests it. ``FsGrepRequest.exclude`` is
+        likewise never set (nor by :meth:`aglob`), so both searches get only the sandbox's own
+        default directory pruning.
         """
         client, session_id = self._require_bound()
         try:

--- a/daiv/core/sandbox/client.py
+++ b/daiv/core/sandbox/client.py
@@ -10,8 +10,6 @@ from core.conf import settings
 from core.site_settings import site_settings
 
 from .schemas import (
-    ApplyMutationsRequest,
-    ApplyMutationsResponse,
     EgressConfigRequest,
     FsDeleteRequest,
     FsDeleteResponse,
@@ -171,17 +169,6 @@ class DAIVSandboxClient:
             logger.info("Sandbox session %s already seeded; skipping", session_id)
             return
         response.raise_for_status()
-
-    async def apply_file_mutations(self, session_id: str, request: ApplyMutationsRequest) -> ApplyMutationsResponse:
-        """
-        Apply a batch of file mutations to /workspace/repo on the sandbox session.
-
-        Per-item failures are returned as `MutationResult(ok=False, error=...)`; the caller
-        decides how to react when `ok=False` or when this method raises.
-        """
-        response = await self._client.post(f"session/{session_id}/files/", json=request.model_dump(mode="json"))
-        response.raise_for_status()
-        return ApplyMutationsResponse.model_validate(response.json())
 
     async def fs_ls(self, session_id: str, request: FsLsRequest) -> FsLsResponse:
         """List a directory under ``/workspace`` on the sandbox session."""

--- a/daiv/core/sandbox/schemas.dump.json
+++ b/daiv/core/sandbox/schemas.dump.json
@@ -1,104 +1,4 @@
 {
-  "ApplyMutationsRequest": {
-    "$defs": {
-      "PutMutation": {
-        "properties": {
-          "content": {
-            "description": "Base64-encoded full file content.",
-            "format": "base64",
-            "title": "Content",
-            "type": "string"
-          },
-          "mode": {
-            "description": "POSIX mode bits to set on the file.",
-            "maximum": 4095,
-            "minimum": 0,
-            "title": "Mode",
-            "type": "integer"
-          },
-          "path": {
-            "description": "Absolute path inside the sandbox, must be under /workspace/repo.",
-            "title": "Path",
-            "type": "string"
-          }
-        },
-        "required": [
-          "path",
-          "content",
-          "mode"
-        ],
-        "title": "PutMutation",
-        "type": "object"
-      }
-    },
-    "properties": {
-      "mutations": {
-        "items": {
-          "$ref": "#/$defs/PutMutation"
-        },
-        "maxItems": 64,
-        "minItems": 1,
-        "title": "Mutations",
-        "type": "array"
-      }
-    },
-    "required": [
-      "mutations"
-    ],
-    "title": "ApplyMutationsRequest",
-    "type": "object"
-  },
-  "ApplyMutationsResponse": {
-    "$defs": {
-      "MutationResult": {
-        "properties": {
-          "error": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "default": null,
-            "description": "Per-item error message when ok=False.",
-            "title": "Error"
-          },
-          "ok": {
-            "description": "Whether the mutation was applied successfully.",
-            "title": "Ok",
-            "type": "boolean"
-          },
-          "path": {
-            "description": "The path the mutation targeted.",
-            "title": "Path",
-            "type": "string"
-          }
-        },
-        "required": [
-          "path",
-          "ok"
-        ],
-        "title": "MutationResult",
-        "type": "object"
-      }
-    },
-    "properties": {
-      "results": {
-        "items": {
-          "$ref": "#/$defs/MutationResult"
-        },
-        "title": "Results",
-        "type": "array"
-      }
-    },
-    "required": [
-      "results"
-    ],
-    "title": "ApplyMutationsResponse",
-    "type": "object"
-  },
   "EgressConfigRequest": {
     "$defs": {
       "EgressPolicy": {
@@ -115,7 +15,7 @@
           },
           "intercept": {
             "default": "all",
-            "description": "'all' MITMs every reachable host; 'credentialed' MITMs only inject hosts.",
+            "description": "'all' MITMs every reachable host; 'credentialed' MITMs only hosts that inject a credential or carry a per-host methods restriction (others are tunnelled untouched).",
             "enum": [
               "all",
               "credentialed"
@@ -207,18 +107,6 @@
     "title": "EgressConfigRequest",
     "type": "object"
   },
-  "EgressConfigResponse": {
-    "properties": {
-      "ok": {
-        "default": true,
-        "description": "True when the policy was provisioned to the sidecar.",
-        "title": "Ok",
-        "type": "boolean"
-      }
-    },
-    "title": "EgressConfigResponse",
-    "type": "object"
-  },
   "EgressPolicy": {
     "$defs": {
       "EgressRule": {
@@ -270,7 +158,7 @@
       },
       "intercept": {
         "default": "all",
-        "description": "'all' MITMs every reachable host; 'credentialed' MITMs only inject hosts.",
+        "description": "'all' MITMs every reachable host; 'credentialed' MITMs only hosts that inject a credential or carry a per-host methods restriction (others are tunnelled untouched).",
         "enum": [
           "all",
           "credentialed"
@@ -551,6 +439,14 @@
   },
   "FsGlobRequest": {
     "properties": {
+      "exclude": {
+        "description": "Directory basenames/globs to prune from the search (extends the server defaults).",
+        "items": {
+          "type": "string"
+        },
+        "title": "Exclude",
+        "type": "array"
+      },
       "path": {
         "description": "Absolute base directory under /workspace.",
         "title": "Path",
@@ -684,6 +580,14 @@
   },
   "FsGrepRequest": {
     "properties": {
+      "exclude": {
+        "description": "Directory basenames/globs to prune from the search (extends the server defaults).",
+        "items": {
+          "type": "string"
+        },
+        "title": "Exclude",
+        "type": "array"
+      },
       "glob": {
         "anyOf": [
           {
@@ -703,7 +607,7 @@
         "type": "string"
       },
       "pattern": {
-        "description": "Literal substring to search for (not a regex).",
+        "description": "Regular expression to search for (POSIX extended / ERE syntax).",
         "title": "Pattern",
         "type": "string"
       }
@@ -1016,6 +920,19 @@
         "description": "Encoding of `content`: 'utf-8' for text, 'base64' for binary.",
         "title": "Encoding"
       },
+      "end_line": {
+        "anyOf": [
+          {
+            "type": "integer"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "description": "1-indexed last *complete* source line in `content`. Text reads only. Equals the request's `offset` (an empty window) when a byte-capped page holds no complete line at all, i.e. a single line longer than the read limit \u2014 expected, not a bug.",
+        "title": "End Line"
+      },
       "error": {
         "anyOf": [
           {
@@ -1027,6 +944,25 @@
         ],
         "default": null,
         "description": "Structured error; null on success."
+      },
+      "total_lines": {
+        "anyOf": [
+          {
+            "type": "integer"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "description": "Total source lines in the file. Text reads only; null for binary reads, the empty-file sentinel, and every error.",
+        "title": "Total Lines"
+      },
+      "truncated": {
+        "default": false,
+        "description": "True when the body was cut by the read byte limit; the text past `end_line` is a partial line.",
+        "title": "Truncated",
+        "type": "boolean"
       }
     },
     "title": "FsReadResponse",
@@ -1118,68 +1054,6 @@
       }
     },
     "title": "FsWriteResponse",
-    "type": "object"
-  },
-  "MutationResult": {
-    "properties": {
-      "error": {
-        "anyOf": [
-          {
-            "type": "string"
-          },
-          {
-            "type": "null"
-          }
-        ],
-        "default": null,
-        "description": "Per-item error message when ok=False.",
-        "title": "Error"
-      },
-      "ok": {
-        "description": "Whether the mutation was applied successfully.",
-        "title": "Ok",
-        "type": "boolean"
-      },
-      "path": {
-        "description": "The path the mutation targeted.",
-        "title": "Path",
-        "type": "string"
-      }
-    },
-    "required": [
-      "path",
-      "ok"
-    ],
-    "title": "MutationResult",
-    "type": "object"
-  },
-  "PutMutation": {
-    "properties": {
-      "content": {
-        "description": "Base64-encoded full file content.",
-        "format": "base64",
-        "title": "Content",
-        "type": "string"
-      },
-      "mode": {
-        "description": "POSIX mode bits to set on the file.",
-        "maximum": 4095,
-        "minimum": 0,
-        "title": "Mode",
-        "type": "integer"
-      },
-      "path": {
-        "description": "Absolute path inside the sandbox, must be under /workspace/repo.",
-        "title": "Path",
-        "type": "string"
-      }
-    },
-    "required": [
-      "path",
-      "content",
-      "mode"
-    ],
-    "title": "PutMutation",
     "type": "object"
   },
   "RunRequest": {
@@ -1303,6 +1177,114 @@
     "type": "object"
   },
   "StartSessionRequest": {
+    "$defs": {
+      "EgressConfigRequest": {
+        "properties": {
+          "policy": {
+            "$ref": "#/$defs/EgressPolicy"
+          },
+          "secrets": {
+            "additionalProperties": {
+              "$ref": "#/$defs/EgressSecret"
+            },
+            "title": "Secrets",
+            "type": "object"
+          }
+        },
+        "title": "EgressConfigRequest",
+        "type": "object"
+      },
+      "EgressPolicy": {
+        "properties": {
+          "default": {
+            "default": "deny",
+            "description": "Reachability for unlisted hosts.",
+            "enum": [
+              "deny",
+              "allow"
+            ],
+            "title": "Default",
+            "type": "string"
+          },
+          "intercept": {
+            "default": "all",
+            "description": "'all' MITMs every reachable host; 'credentialed' MITMs only hosts that inject a credential or carry a per-host methods restriction (others are tunnelled untouched).",
+            "enum": [
+              "all",
+              "credentialed"
+            ],
+            "title": "Intercept",
+            "type": "string"
+          },
+          "rules": {
+            "items": {
+              "$ref": "#/$defs/EgressRule"
+            },
+            "title": "Rules",
+            "type": "array"
+          }
+        },
+        "title": "EgressPolicy",
+        "type": "object"
+      },
+      "EgressRule": {
+        "properties": {
+          "host": {
+            "description": "Destination host glob (e.g. 'github.com', '*.githubusercontent.com').",
+            "title": "Host",
+            "type": "string"
+          },
+          "inject": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": null,
+            "description": "Name of the secret whose header is injected for this host.",
+            "title": "Inject"
+          },
+          "methods": {
+            "description": "Allowed HTTP methods, or ['*'] for any.",
+            "items": {
+              "type": "string"
+            },
+            "title": "Methods",
+            "type": "array"
+          }
+        },
+        "required": [
+          "host"
+        ],
+        "title": "EgressRule",
+        "type": "object"
+      },
+      "EgressSecret": {
+        "properties": {
+          "header": {
+            "description": "Header name to set (e.g. 'Authorization', 'PRIVATE-TOKEN').",
+            "title": "Header",
+            "type": "string"
+          },
+          "value": {
+            "description": "Header value; redacted in logs/repr.",
+            "format": "password",
+            "title": "Value",
+            "type": "string",
+            "writeOnly": true
+          }
+        },
+        "required": [
+          "header",
+          "value"
+        ],
+        "title": "EgressSecret",
+        "type": "object"
+      }
+    },
     "properties": {
       "base_image": {
         "description": "Docker image to be used as the base image for the sandbox.",
@@ -1321,6 +1303,18 @@
         "default": null,
         "description": "CPUs to be used for the sandbox.",
         "title": "Cpus"
+      },
+      "egress": {
+        "anyOf": [
+          {
+            "$ref": "#/$defs/EgressConfigRequest"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "default": null,
+        "description": "Egress policy + secrets. Omit for a network-isolated sandbox (network_mode=none); provide to route the sandbox through the per-session egress proxy with this policy. Immutable for the session's life."
       },
       "environment": {
         "anyOf": [
@@ -1350,12 +1344,6 @@
         "default": null,
         "description": "Memory in bytes to be used for the sandbox.",
         "title": "Memory Bytes"
-      },
-      "network_enabled": {
-        "default": false,
-        "description": "Whether to enable network for the sandbox.",
-        "title": "Network Enabled",
-        "type": "boolean"
       }
     },
     "required": [

--- a/daiv/core/sandbox/schemas.py
+++ b/daiv/core/sandbox/schemas.py
@@ -147,6 +147,25 @@ class FsReadResponse(BaseModel):
     encoding: Literal["utf-8", "base64"] | None = Field(
         default=None, description="Encoding of `content`: 'utf-8' for text, 'base64' for binary."
     )
+    total_lines: int | None = Field(
+        default=None,
+        description=(
+            "Total source lines in the file. Text reads only; null for binary reads, the empty-file "
+            "sentinel, and every error."
+        ),
+    )
+    end_line: int | None = Field(
+        default=None,
+        description=(
+            "1-indexed last *complete* source line in `content`. Text reads only. Equals the request's "
+            "`offset` (an empty window) when a byte-capped page holds no complete line at all, i.e. a "
+            "single line longer than the read limit."
+        ),
+    )
+    truncated: bool = Field(
+        default=False,
+        description="True when the body was cut by the read byte limit; the text past `end_line` is a partial line.",
+    )
     error: FsError | None = Field(default=None, description="Structured error; null on success.")
 
 
@@ -154,6 +173,10 @@ class FsGrepRequest(BaseModel):
     pattern: str = Field(description="Regular expression to search for (POSIX extended / ERE syntax).")
     path: str = Field(description="Absolute directory/file path under /workspace.")
     glob: str | None = Field(default=None, description="Optional filename glob to restrict the search.")
+    exclude: list[str] = Field(
+        default_factory=list,
+        description="Directory basenames/globs to prune from the search (extends the server defaults).",
+    )
 
 
 class FsGrepMatch(BaseModel):
@@ -173,6 +196,10 @@ class FsGrepResponse(BaseModel):
 class FsGlobRequest(BaseModel):
     pattern: str = Field(description="Glob pattern (supports *, **, ?, [abc]).")
     path: str = Field(description="Absolute base directory under /workspace.")
+    exclude: list[str] = Field(
+        default_factory=list,
+        description="Directory basenames/globs to prune from the search (extends the server defaults).",
+    )
 
 
 class FsGlobResponse(BaseModel):

--- a/daiv/core/sandbox/schemas.py
+++ b/daiv/core/sandbox/schemas.py
@@ -56,34 +56,6 @@ class RunCommandsResponse(BaseModel):
     results: list[RunCommandResult]
 
 
-class PutMutation(BaseModel):
-    path: str = Field(description="Absolute path inside the sandbox, must be under /workspace/repo.")
-    content: Base64Bytes = Field(description="Base64-encoded full file content.")
-    mode: int = Field(ge=0, le=0o7777, description="POSIX mode bits to set on the file.")
-
-
-class ApplyMutationsRequest(BaseModel):
-    mutations: list[PutMutation] = Field(min_length=1, max_length=64)
-
-
-class MutationResult(BaseModel):
-    path: str
-    ok: bool
-    error: str | None = None
-
-    @model_validator(mode="after")
-    def _ok_xor_error(self) -> MutationResult:
-        if self.ok and self.error is not None:
-            raise ValueError("MutationResult: ok=True must have error=None")
-        if not self.ok and self.error is None:
-            raise ValueError("MutationResult: ok=False must include an error message")
-        return self
-
-
-class ApplyMutationsResponse(BaseModel):
-    results: list[MutationResult]
-
-
 # --- /workspace file-op wire schemas -----------------------------------------
 #
 # Mirror of the daiv-sandbox ``Fs*`` schemas. Kept structurally identical (field
@@ -158,13 +130,16 @@ class FsReadResponse(BaseModel):
         default=None,
         description=(
             "1-indexed last *complete* source line in `content`. Text reads only. Equals the request's "
-            "`offset` (an empty window) when a byte-capped page holds no complete line at all, i.e. a "
-            "single line longer than the read limit."
+            "`offset` (an empty window) when the page's first line alone exceeds the response byte cap, "
+            "so the page holds no complete line — expected, not a bug."
         ),
     )
     truncated: bool = Field(
         default=False,
-        description="True when the body was cut by the read byte limit; the text past `end_line` is a partial line.",
+        description=(
+            "True when the body was cut by the response byte cap; `content` then ends with a partial "
+            "line followed by a multi-line truncation banner, both past `end_line`."
+        ),
     )
     error: FsError | None = Field(default=None, description="Structured error; null on success.")
 
@@ -361,10 +336,6 @@ class EgressConfigRequest(BaseModel):
                 name: {"header": s.header, "value": s.value.get_secret_value()} for name, s in self.secrets.items()
             },
         }
-
-
-class EgressConfigResponse(BaseModel):
-    ok: bool = Field(default=True, description="True when the policy was provisioned to the sidecar.")
 
 
 StartSessionRequest.model_rebuild()

--- a/tests/unit_tests/automation/agent/middlewares/test_file_system.py
+++ b/tests/unit_tests/automation/agent/middlewares/test_file_system.py
@@ -673,8 +673,9 @@ class TestSandboxGrepTruncation:
 
 
 class TestSandboxReadPagination:
-    """`SandboxFileBackend.aread` must populate deepagents' read-window fields so the middleware
-    emits its truncation notice on sandbox reads (see `_sandbox_read_window`)."""
+    """`SandboxFileBackend.aread` maps the sandbox's reported line window onto deepagents'
+    read-window fields, so the middleware's pagination notice is server-side truth rather than a
+    count of the returned text (which would also count the truncation banner's rows)."""
 
     def _bound_backend(self, fs_read_response):
         from unittest.mock import AsyncMock
@@ -685,89 +686,94 @@ class TestSandboxReadPagination:
         client.fs_read = AsyncMock(return_value=fs_read_response)
         return SandboxFileBackend(client=client, session_id="sess-1")
 
-    async def test_full_window_advertises_more_lines(self):
-        from automation.agent.constants import REPO_PATH
-        from core.sandbox.schemas import FsReadResponse
-
-        content = "".join(f"line {i}\n" for i in range(1, 101))  # exactly `limit` lines
-        backend = self._bound_backend(FsReadResponse(content=content, encoding="utf-8"))
-
-        result = await backend.aread(f"{REPO_PATH}/f.py", offset=0, limit=100)
-
-        assert result.start_line == 1
-        assert result.end_line == 100
-        assert result.next_offset == 100, "a filled window signals more lines may remain"
-        assert result.total_lines is None, "the sandbox never reports a total line count"
-
-    async def test_partial_window_reports_end_of_file(self):
-        from automation.agent.constants import REPO_PATH
-        from core.sandbox.schemas import FsReadResponse
-
-        content = "".join(f"line {i}\n" for i in range(1, 43))  # fewer than `limit` lines
-        backend = self._bound_backend(FsReadResponse(content=content, encoding="utf-8"))
-
-        result = await backend.aread(f"{REPO_PATH}/f.py", offset=0, limit=100)
-
-        assert result.start_line == 1
-        assert result.end_line == 42
-        assert result.next_offset is None, "an unfilled window means EOF was reached"
-
-    async def test_window_is_anchored_at_the_requested_offset(self):
-        from automation.agent.constants import REPO_PATH
-        from core.sandbox.schemas import FsReadResponse
-
-        content = "".join(f"line {i}\n" for i in range(51, 101))  # 50 lines starting at source line 51
-        backend = self._bound_backend(FsReadResponse(content=content, encoding="utf-8"))
-
-        result = await backend.aread(f"{REPO_PATH}/f.py", offset=50, limit=50)
-
-        assert result.start_line == 51
-        assert result.end_line == 100
-        assert result.next_offset == 100
-
-    async def test_partial_window_at_a_nonzero_offset_reports_eof(self):
-        """A later page that comes back unfilled must report EOF with `end_line` anchored at the
-        offset — the arithmetic where an offset-ignoring bug would hide."""
-        from automation.agent.constants import REPO_PATH
-        from core.sandbox.schemas import FsReadResponse
-
-        content = "".join(f"line {i}\n" for i in range(51, 81))  # 30 lines from source line 51
-        backend = self._bound_backend(FsReadResponse(content=content, encoding="utf-8"))
-
-        result = await backend.aread(f"{REPO_PATH}/f.py", offset=50, limit=100)
-
-        assert result.start_line == 51
-        assert result.end_line == 80
-        assert result.next_offset is None
-
-    async def test_contentless_read_carries_no_window(self):
-        """Empty content (the `resp.content or ""` coercion can reach the helper) must never
-        advertise a window — a zero-line window has nothing to paginate."""
-        from automation.agent.constants import REPO_PATH
-        from core.sandbox.schemas import FsReadResponse
-
-        backend = self._bound_backend(FsReadResponse(content="", encoding="utf-8"))
-
-        result = await backend.aread(f"{REPO_PATH}/f.py", offset=0, limit=100)
-
-        assert result.start_line is None
-        assert result.end_line is None
-        assert result.next_offset is None
-
-    async def test_notice_tells_the_model_more_lines_remain(self):
-        """End-to-end: the window fields must drive deepagents' actual truncation notice — the
-        behaviour the trace showed missing on sandbox reads."""
+    async def test_mid_file_page_reports_the_exact_remainder(self):
+        """The notice names the window and the exact number of lines left, which only the sandbox's
+        `total_lines` makes possible."""
         from deepagents.middleware.filesystem import _remaining_lines_notice
 
         from automation.agent.constants import REPO_PATH
         from core.sandbox.schemas import FsReadResponse
 
+        content = "".join(f"line {i}\n" for i in range(101, 151))
+        backend = self._bound_backend(FsReadResponse(content=content, encoding="utf-8", total_lines=400, end_line=150))
+
+        result = await backend.aread(f"{REPO_PATH}/f.py", offset=100, limit=50)
+
+        assert result.start_line == 101
+        assert result.end_line == 150
+        assert result.total_lines == 400
+        assert result.next_offset == 150
+        assert "lines 101-150 of 400 total" in _remaining_lines_notice(result)
+        assert "250 lines remaining from offset 150" in _remaining_lines_notice(result)
+
+    async def test_final_page_emits_no_notice(self):
+        from deepagents.middleware.filesystem import _remaining_lines_notice
+
+        from automation.agent.constants import REPO_PATH
+        from core.sandbox.schemas import FsReadResponse
+
+        content = "".join(f"line {i}\n" for i in range(351, 401))
+        backend = self._bound_backend(FsReadResponse(content=content, encoding="utf-8", total_lines=400, end_line=400))
+
+        result = await backend.aread(f"{REPO_PATH}/f.py", offset=350, limit=50)
+
+        assert result.end_line == 400
+        assert result.next_offset is None, "the window reached EOF"
+        assert _remaining_lines_notice(result) == ""
+
+    async def test_file_length_that_is_an_exact_multiple_of_limit_has_no_next_offset(self):
+        """The regression the derived-window heuristic knowingly shipped: a filled window used to
+        imply more lines remain, so this file advertised an offset the next read rejects."""
+        from automation.agent.constants import REPO_PATH
+        from core.sandbox.schemas import FsReadResponse
+
         content = "".join(f"line {i}\n" for i in range(1, 101))
-        backend = self._bound_backend(FsReadResponse(content=content, encoding="utf-8"))
+        backend = self._bound_backend(FsReadResponse(content=content, encoding="utf-8", total_lines=100, end_line=100))
 
         result = await backend.aread(f"{REPO_PATH}/f.py", offset=0, limit=100)
 
-        assert "More lines remain from offset 100" in _remaining_lines_notice(result)
+        assert result.end_line == 100
+        assert result.next_offset is None
+
+    async def test_byte_capped_page_resumes_at_the_partial_line(self, caplog):
+        """A capped page ends mid-line and carries a banner. The window must exclude both, so the
+        resume offset points *at* the partial line and re-reads it whole."""
+        import logging
+
+        from automation.agent.constants import REPO_PATH
+        from core.sandbox.schemas import FsReadResponse
+
+        content = "".join(f"line {i}\n" for i in range(1, 98)) + "line 98 is cut he"
+        content += "\n\n[Output truncated: exceeded the 512000-byte read limit.]"
+        backend = self._bound_backend(
+            FsReadResponse(content=content, encoding="utf-8", total_lines=400, end_line=97, truncated=True)
+        )
+
+        with caplog.at_level(logging.WARNING, logger="daiv.tools"):
+            result = await backend.aread(f"{REPO_PATH}/f.py", offset=0, limit=100)
+
+        assert result.start_line == 1
+        assert result.end_line == 97, "the banner rows and the cut line are not source lines"
+        assert result.total_lines == 400
+        assert result.next_offset == 97, "0-indexed 97 is 1-indexed line 98 — the line that was cut"
+        assert "truncated" in caplog.text
+
+    async def test_byte_capped_single_huge_line_carries_no_window(self):
+        """One line longer than the cap yields zero complete lines; there is no window to report and
+        the model is left with the sandbox's banner."""
+        from automation.agent.constants import REPO_PATH
+        from core.sandbox.schemas import FsReadResponse
+
+        backend = self._bound_backend(
+            FsReadResponse(content="x" * 100, encoding="utf-8", total_lines=1, end_line=0, truncated=True)
+        )
+
+        result = await backend.aread(f"{REPO_PATH}/f.py", offset=0, limit=100)
+
+        assert result.start_line is None
+        assert result.end_line is None
+        assert result.total_lines is None
+        assert result.next_offset is None
 
     async def test_binary_read_carries_no_window(self):
         from automation.agent.constants import REPO_PATH
@@ -782,8 +788,8 @@ class TestSandboxReadPagination:
         assert result.next_offset is None
 
     async def test_empty_file_sentinel_carries_no_window(self):
-        """The sandbox returns a sentinel string (not the file's bytes) for an empty file; it must
-        not be line-windowed, even when `limit` is small enough to trip the full-window heuristic."""
+        """The sandbox returns a sentinel string (not the file's bytes) for an empty file; it is not
+        file content, so it is not line-windowed."""
         from deepagents.middleware.filesystem import EMPTY_CONTENT_WARNING
 
         from automation.agent.constants import REPO_PATH
@@ -796,3 +802,23 @@ class TestSandboxReadPagination:
         assert result.start_line is None
         assert result.end_line is None
         assert result.next_offset is None
+
+    async def test_sandbox_without_line_metadata_drops_the_window_and_warns(self, caplog):
+        """A sandbox predating the wire fields returns them unset. Losing the notice is acceptable;
+        guessing a window is not — but the version skew must be visible to operators."""
+        import logging
+
+        from automation.agent.constants import REPO_PATH
+        from core.sandbox.schemas import FsReadResponse
+
+        content = "".join(f"line {i}\n" for i in range(1, 101))
+        backend = self._bound_backend(FsReadResponse(content=content, encoding="utf-8"))
+
+        with caplog.at_level(logging.WARNING, logger="daiv.tools"):
+            result = await backend.aread(f"{REPO_PATH}/f.py", offset=0, limit=100)
+
+        assert result.start_line is None
+        assert result.end_line is None
+        assert result.total_lines is None
+        assert result.next_offset is None
+        assert "no line metadata" in caplog.text

--- a/tests/unit_tests/automation/agent/middlewares/test_file_system.py
+++ b/tests/unit_tests/automation/agent/middlewares/test_file_system.py
@@ -722,8 +722,8 @@ class TestSandboxReadPagination:
         assert _remaining_lines_notice(result) == ""
 
     async def test_file_length_that_is_an_exact_multiple_of_limit_has_no_next_offset(self):
-        """The regression the derived-window heuristic knowingly shipped: a filled window used to
-        imply more lines remain, so this file advertised an offset the next read rejects."""
+        """A window ending exactly at `total_lines` is EOF, not a full page — advertising a resume
+        offset here would name an offset the next read rejects as invalid."""
         from automation.agent.constants import REPO_PATH
         from core.sandbox.schemas import FsReadResponse
 
@@ -735,32 +735,32 @@ class TestSandboxReadPagination:
         assert result.end_line == 100
         assert result.next_offset is None
 
-    async def test_byte_capped_page_resumes_at_the_partial_line(self, caplog):
+    async def test_byte_capped_page_resumes_at_the_partial_line(self):
         """A capped page ends mid-line and carries a banner. The window must exclude both, so the
         resume offset points *at* the partial line and re-reads it whole."""
-        import logging
-
         from automation.agent.constants import REPO_PATH
         from core.sandbox.schemas import FsReadResponse
 
+        # The banner text is illustrative; `aread` never parses `content`.
         content = "".join(f"line {i}\n" for i in range(1, 98)) + "line 98 is cut he"
         content += "\n\n[Output truncated: exceeded the 512000-byte read limit.]"
         backend = self._bound_backend(
             FsReadResponse(content=content, encoding="utf-8", total_lines=400, end_line=97, truncated=True)
         )
 
-        with caplog.at_level(logging.WARNING, logger="daiv.tools"):
-            result = await backend.aread(f"{REPO_PATH}/f.py", offset=0, limit=100)
+        result = await backend.aread(f"{REPO_PATH}/f.py", offset=0, limit=100)
 
         assert result.start_line == 1
         assert result.end_line == 97, "the banner rows and the cut line are not source lines"
         assert result.total_lines == 400
         assert result.next_offset == 97, "0-indexed 97 is 1-indexed line 98 — the line that was cut"
-        assert "truncated" in caplog.text
 
-    async def test_byte_capped_single_huge_line_carries_no_window(self):
-        """One line longer than the cap yields zero complete lines; there is no window to report and
-        the model is left with the sandbox's banner."""
+    async def test_byte_capped_single_huge_line_carries_no_window(self, caplog):
+        """A page whose first line alone exceeds the byte cap holds zero complete lines. deepagents
+        cannot express an empty window, so the model gets none — and no resume offset, which is a
+        dead end worth an operator warning."""
+        import logging
+
         from automation.agent.constants import REPO_PATH
         from core.sandbox.schemas import FsReadResponse
 
@@ -768,12 +768,14 @@ class TestSandboxReadPagination:
             FsReadResponse(content="x" * 100, encoding="utf-8", total_lines=1, end_line=0, truncated=True)
         )
 
-        result = await backend.aread(f"{REPO_PATH}/f.py", offset=0, limit=100)
+        with caplog.at_level(logging.WARNING, logger="daiv.tools"):
+            result = await backend.aread(f"{REPO_PATH}/f.py", offset=0, limit=100)
 
         assert result.start_line is None
         assert result.end_line is None
         assert result.total_lines is None
         assert result.next_offset is None
+        assert "no complete line" in caplog.text
 
     async def test_binary_read_carries_no_window(self):
         from automation.agent.constants import REPO_PATH
@@ -821,4 +823,98 @@ class TestSandboxReadPagination:
         assert result.end_line is None
         assert result.total_lines is None
         assert result.next_offset is None
-        assert "no line metadata" in caplog.text
+        assert "no read-window metadata" in caplog.text
+
+    @pytest.mark.parametrize(
+        ("response_kwargs", "expected"),
+        [({}, "no read-window metadata"), ({"total_lines": 9999, "end_line": 9000}, "outside the requested window")],
+        ids=["version-skew", "malformed-window"],
+    )
+    async def test_read_faults_are_reported_once_per_run(self, caplog, response_kwargs, expected):
+        """Every cause here is systematic — a version skew or a sandbox arithmetic slip repeats on
+        every read — and each ERROR is a Sentry event, so one per run is the whole point."""
+        import logging
+
+        from automation.agent.constants import REPO_PATH
+        from core.sandbox.schemas import FsReadResponse
+
+        content = "".join(f"line {i}\n" for i in range(1, 11))
+        backend = self._bound_backend(FsReadResponse(content=content, encoding="utf-8", **response_kwargs))
+
+        with caplog.at_level(logging.WARNING, logger="daiv.tools"):
+            for _ in range(5):
+                await backend.aread(f"{REPO_PATH}/f.py", offset=0, limit=100)
+
+        assert caplog.text.count(expected) == 1
+
+    async def test_total_lines_below_end_line_degrades_instead_of_raising(self, caplog):
+        """deepagents' `ReadResult` rejects this pair outright, and `aread` is called unguarded, so
+        passing it through would abort the run over a sandbox arithmetic slip."""
+        import logging
+
+        from automation.agent.constants import REPO_PATH
+        from core.sandbox.schemas import FsReadResponse
+
+        content = "".join(f"line {i}\n" for i in range(101, 151))
+        backend = self._bound_backend(FsReadResponse(content=content, encoding="utf-8", total_lines=120, end_line=150))
+
+        with caplog.at_level(logging.ERROR, logger="daiv.tools"):
+            result = await backend.aread(f"{REPO_PATH}/f.py", offset=100, limit=50)
+
+        assert result.file_data is not None, "the content still reaches the model"
+        assert result.total_lines is None, "an impossible total is dropped, not clamped"
+        assert result.next_offset == 150
+        assert "total_lines=120 below end_line=150" in caplog.text
+
+    async def test_end_line_past_the_requested_window_drops_the_window(self, caplog):
+        """`end_line` cannot exceed `offset + limit`. Trusting a larger one hands the model a resume
+        offset past source lines it was never shown."""
+        import logging
+
+        from automation.agent.constants import REPO_PATH
+        from core.sandbox.schemas import FsReadResponse
+
+        content = "".join(f"line {i}\n" for i in range(1, 11))
+        backend = self._bound_backend(
+            FsReadResponse(content=content, encoding="utf-8", total_lines=9999, end_line=9000)
+        )
+
+        with caplog.at_level(logging.ERROR, logger="daiv.tools"):
+            result = await backend.aread(f"{REPO_PATH}/f.py", offset=0, limit=100)
+
+        assert result.next_offset is None
+        assert result.start_line is None
+        assert "outside the requested window" in caplog.text
+
+    async def test_window_over_empty_content_drops_the_window(self, caplog):
+        """A window with no text behind it would page the model forward over lines it never read."""
+        import logging
+
+        from automation.agent.constants import REPO_PATH
+        from core.sandbox.schemas import FsReadResponse
+
+        backend = self._bound_backend(FsReadResponse(content="", encoding="utf-8", total_lines=400, end_line=150))
+
+        with caplog.at_level(logging.ERROR, logger="daiv.tools"):
+            result = await backend.aread(f"{REPO_PATH}/f.py", offset=100, limit=50)
+
+        assert result.start_line is None
+        assert result.next_offset is None
+        assert "over empty content" in caplog.text
+
+    async def test_window_without_a_total_still_advertises_a_resume_offset(self):
+        """Half-populated metadata must not read as EOF: an over-advertised offset self-corrects on
+        the next read, a missing one silently drops the rest of the file."""
+        from deepagents.middleware.filesystem import _remaining_lines_notice
+
+        from automation.agent.constants import REPO_PATH
+        from core.sandbox.schemas import FsReadResponse
+
+        content = "".join(f"line {i}\n" for i in range(1, 51))
+        backend = self._bound_backend(FsReadResponse(content=content, encoding="utf-8", end_line=50))
+
+        result = await backend.aread(f"{REPO_PATH}/f.py", offset=0, limit=100)
+
+        assert result.total_lines is None
+        assert result.next_offset == 50
+        assert "More lines remain from offset 50" in _remaining_lines_notice(result)

--- a/tests/unit_tests/core/sandbox/test_client.py
+++ b/tests/unit_tests/core/sandbox/test_client.py
@@ -96,32 +96,6 @@ async def test_seed_session_treats_409_as_already_seeded(fake_settings, mock_pos
         await client.seed_session("sid-123", repo_archive=b"tar")
 
 
-async def test_apply_file_mutations_posts_payload(fake_settings, mock_post):
-    from core.sandbox.client import DAIVSandboxClient
-    from core.sandbox.schemas import ApplyMutationsRequest, PutMutation
-
-    mock_post["json_body"] = {"results": [{"path": "/repo/x.py", "ok": True, "error": None}]}
-    req = ApplyMutationsRequest(mutations=[PutMutation(path="/repo/x.py", content=base64.b64encode(b"hi"), mode=0o644)])
-    async with DAIVSandboxClient() as client:
-        resp = await client.apply_file_mutations("sid", req)
-
-    assert mock_post["url"] == "session/sid/files/"
-    assert resp.results[0].ok is True
-
-
-async def test_apply_file_mutations_returns_per_item_failures(fake_settings, mock_post):
-    from core.sandbox.client import DAIVSandboxClient
-    from core.sandbox.schemas import ApplyMutationsRequest, PutMutation
-
-    mock_post["json_body"] = {"results": [{"path": "/skills/x", "ok": False, "error": "must be under /repo"}]}
-    req = ApplyMutationsRequest(mutations=[PutMutation(path="/skills/x", content=base64.b64encode(b""), mode=0o644)])
-    async with DAIVSandboxClient() as client:
-        resp = await client.apply_file_mutations("sid", req)
-
-    assert resp.results[0].ok is False
-    assert resp.results[0].error == "must be under /repo"
-
-
 async def test_connection_pool_reused_across_calls_in_one_block(fake_settings, mock_post):
     """One ``async with`` block must reuse a single httpx.AsyncClient across N calls."""
     from core.sandbox.client import DAIVSandboxClient

--- a/tests/unit_tests/core/sandbox/test_schema_consistency.py
+++ b/tests/unit_tests/core/sandbox/test_schema_consistency.py
@@ -52,19 +52,6 @@ _SHARED_TYPES = [
 # Types that exist on both sides but are deliberately allowed to diverge.
 _INTENTIONALLY_DIVERGENT = {"RunCommandsRequest", "RunCommandsResponse", "RunCommandResult", "StartSessionRequest"}
 
-# Daiv-side models whose sandbox counterparts were deleted, so there is nothing left to pin them
-# against: the ``POST /session/{id}/files/`` endpoint behind ``ApplyMutations*``/``PutMutation``/
-# ``MutationResult`` was replaced by ``fs/*``, and ``EgressConfigResponse`` went with the standalone
-# egress endpoint. They survived only as stale keys in an un-refreshed dump. Absence is asserted
-# below so re-adding one on the sandbox side forces a conscious re-categorization here.
-_REMOVED_FROM_SANDBOX = {
-    "ApplyMutationsRequest",
-    "ApplyMutationsResponse",
-    "MutationResult",
-    "PutMutation",
-    "EgressConfigResponse",
-}
-
 
 @pytest.mark.parametrize("type_name", _SHARED_TYPES)
 def test_daiv_schema_matches_sandbox_dump(type_name):
@@ -100,10 +87,4 @@ def test_shared_types_list_covers_dump():
     assert not untracked, (
         f"Types {sorted(untracked)} exist in both repos' schemas but are neither in _SHARED_TYPES "
         "nor in _INTENTIONALLY_DIVERGENT. Categorize them in the test."
-    )
-
-    resurrected = _REMOVED_FROM_SANDBOX & set(sandbox_dump)
-    assert not resurrected, (
-        f"Types {sorted(resurrected)} are back in the sandbox dump but are still listed as removed. "
-        "Move them to _SHARED_TYPES so they are pinned again."
     )

--- a/tests/unit_tests/core/sandbox/test_schema_consistency.py
+++ b/tests/unit_tests/core/sandbox/test_schema_consistency.py
@@ -27,10 +27,6 @@ def _normalize(schema):
 # StartSessionRequest accepts a Dockerfile alternative, and StartSessionResponse
 # isn't modelled on the daiv side.
 _SHARED_TYPES = [
-    "ApplyMutationsRequest",
-    "ApplyMutationsResponse",
-    "MutationResult",
-    "PutMutation",
     "FsLsRequest",
     "FsEntry",
     "FsLsResponse",
@@ -51,11 +47,23 @@ _SHARED_TYPES = [
     "EgressSecret",
     "EgressPolicy",
     "EgressConfigRequest",
-    "EgressConfigResponse",
 ]
 
 # Types that exist on both sides but are deliberately allowed to diverge.
 _INTENTIONALLY_DIVERGENT = {"RunCommandsRequest", "RunCommandsResponse", "RunCommandResult", "StartSessionRequest"}
+
+# Daiv-side models whose sandbox counterparts were deleted, so there is nothing left to pin them
+# against: the ``POST /session/{id}/files/`` endpoint behind ``ApplyMutations*``/``PutMutation``/
+# ``MutationResult`` was replaced by ``fs/*``, and ``EgressConfigResponse`` went with the standalone
+# egress endpoint. They survived only as stale keys in an un-refreshed dump. Absence is asserted
+# below so re-adding one on the sandbox side forces a conscious re-categorization here.
+_REMOVED_FROM_SANDBOX = {
+    "ApplyMutationsRequest",
+    "ApplyMutationsResponse",
+    "MutationResult",
+    "PutMutation",
+    "EgressConfigResponse",
+}
 
 
 @pytest.mark.parametrize("type_name", _SHARED_TYPES)
@@ -92,4 +100,10 @@ def test_shared_types_list_covers_dump():
     assert not untracked, (
         f"Types {sorted(untracked)} exist in both repos' schemas but are neither in _SHARED_TYPES "
         "nor in _INTENTIONALLY_DIVERGENT. Categorize them in the test."
+    )
+
+    resurrected = _REMOVED_FROM_SANDBOX & set(sandbox_dump)
+    assert not resurrected, (
+        f"Types {sorted(resurrected)} are back in the sandbox dump but are still listed as removed. "
+        "Move them to _SHARED_TYPES so they are pinned again."
     )

--- a/tests/unit_tests/core/sandbox/test_schemas.py
+++ b/tests/unit_tests/core/sandbox/test_schemas.py
@@ -1,16 +1,4 @@
-import base64
-
 import pytest
-
-
-def test_put_mutation_validates_mode_range():
-    from core.sandbox.schemas import PutMutation
-
-    PutMutation(path="/repo/foo.py", content=base64.b64encode(b"x"), mode=0o644)
-    with pytest.raises(ValueError):
-        PutMutation(path="/repo/foo.py", content=base64.b64encode(b"x"), mode=-1)
-    with pytest.raises(ValueError):
-        PutMutation(path="/repo/foo.py", content=base64.b64encode(b"x"), mode=0o10000)
 
 
 def test_run_commands_request_no_archive():


### PR DESCRIPTION
Sandbox text reads used to *derive* deepagents' pagination window by counting lines in the returned text — a heuristic that counted the truncation banner's rows as source lines. `dd06f8b3` replaced it with the sandbox's own `total_lines`/`end_line`/`truncated` wire fields. `ed93835f` is a quality pass over that commit, plus the dead-code removal it uncovered.

## `aread` restructuring

The five sequential guards each repeated the same `(file_path, offset, limit)` log context and the same bail-out. They now go through one pure `_read_window_fault()` helper, so the "drop the window, keep the content" policy is stated once instead of re-decided per block.

**Log-once generalized from version-skew to every read fault.** Each ERROR is a full Sentry *event* (not a breadcrumb), and a sandbox off-by-one fires the malformed-window branches on *every* read — enough volume to trip the client-side rate limiter and start dropping unrelated events. The bool flag became a `set` of fault keys.

**`ReadResult` construction wrapped in `try/except ValueError`**, matching what deepagents' own sandbox backend does in `_parse_read_output`. `ReadResult.__post_init__` enforces four window invariants by raising; the hand-mirrored guards only covered the ones that were remembered, and an escaped `ValueError` kills the run.

**Dropped the `truncated` DEBUG block** — the flag was read there and nowhere else in `aread`, its whole payload was already in scope, and the `daiv` logger is pinned to DEBUG in production, so it wrote to stderr on every byte-capped read.

## Dead schema removal

`dd06f8b3` added a `_REMOVED_FROM_SANDBOX` test category to pin the *absence* of five daiv-side models. They turned out to be dead on the daiv side too:

- `DAIVSandboxClient.apply_file_mutations` has zero production callers and POSTs to `session/{id}/files/` — a route the sandbox replaced with `fs/*`. Both its tests mock the POST, so a live 404 would never surface in CI.
- `EgressConfigResponse` had zero references anywhere.

Deleting the models, the client method and their tests removes the need for the test category entirely. `AGENTS.md` now says to delete the dead model rather than add an exemption.

## Verification

- `make test` — 4036 passed
- `make lint` — clean
- `make lint-typing` — 436 → 435 diagnostics (no new errors; the drop is the deleted client method)
