### PR TITLE
docs: cross-reference the README, CONTRIBUTING and docs site, and guard it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,9 @@ jobs:
         run: sudo apt-get install -y libomp-dev
 
       - uses: actions/checkout@v7
+        with:
+          # test_docs_links resolves `latest` doc URLs against the tag that alias serves.
+          fetch-tags: true
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,22 +23,79 @@ We expect all contributors to be respectful and constructive. Please ensure that
 
 ## Development Environment
 
-To get started quickly:
+**Prerequisites:** Docker and Docker Compose.
 
-```bash
-git clone https://github.com/srtab/daiv.git && cd daiv
-make setup                    # creates config files from templates
-docker compose up --build     # starts core services (db, redis, app, worker, scheduler)
-```
+1. **Clone and configure**
 
-Optional services are available via Docker Compose profiles:
+   ```bash
+   git clone https://github.com/srtab/daiv.git && cd daiv
+   make setup
+   ```
 
-- `--profile gitlab` — local GitLab instance and runner
-- `--profile sandbox` — sandbox code executor
-- `--profile mcp` — MCP proxy
-- `--profile full` — all services
+   `make setup` creates `config.secrets.env` and `config.toml` from their templates. Edit `docker/local/app/config.secrets.env` and add your API keys — at minimum one LLM provider key (Anthropic, OpenAI, Google, or OpenRouter), plus `CODEBASE_GITLAB_AUTH_TOKEN` if you are using GitLab.
 
-See the [README](README.md) for full setup details.
+2. **Install dependencies** (optional)
+
+   DAIV uses [uv](https://docs.astral.sh/uv/) for dependency management:
+
+   ```bash
+   uv sync
+   ```
+
+   This installs into a virtual environment — useful for running linters outside Docker or for editor autocompletion.
+
+3. **Start core services**
+
+   ```bash
+   docker compose up --build
+   ```
+
+   Starts db, redis, app, worker, and scheduler. SSL certificates are generated on first run. The API docs are then at <https://localhost:8000/api/docs/>.
+
+4. **Start optional services** as needed
+
+   ```bash
+   docker compose --profile gitlab up     # local GitLab instance + runner
+   docker compose --profile sandbox up    # sandbox code executor
+   docker compose --profile mcp up        # MCP servers
+   docker compose --profile full up       # everything
+   ```
+
+   Profiles combine: `docker compose --profile gitlab --profile sandbox up`.
+
+### Testing against a local GitLab
+
+1. **Start GitLab**
+
+   ```bash
+   docker compose --profile gitlab up
+   ```
+
+2. **Get the root password**
+
+   ```bash
+   docker compose exec -it gitlab grep 'Password:' /etc/gitlab/initial_root_password
+   ```
+
+3. **Create a personal access token** at <http://localhost:8929> and add it to `docker/local/app/config.secrets.env` as `CODEBASE_GITLAB_AUTH_TOKEN`.
+
+4. **Create a test project** and push some code to it.
+
+   To import an existing repository: `Admin Area` → `Settings` → `General` → `Import and export settings`, and enable `Repository by URL`.
+
+5. **Set up webhooks**
+
+   ```bash
+   docker compose exec -it app django-admin setup_webhooks
+   ```
+
+   If this fails with `Invalid url given`, go to `Admin Area` → `Settings` → `Network` → `Outbound requests` and enable `Allow requests to the local network from webhooks and integrations`.
+
+6. **Try it** — create an issue labelled `daiv`. DAIV will respond with a plan.
+
+For GitHub, use GitHub.com or a GitHub Enterprise instance: set `CODEBASE_CLIENT=github` in `docker/local/app/config.env` and configure the GitHub App credentials.
+
+Deploying DAIV for real use is a different path — see the [Deployment guide](https://srtab.github.io/daiv/latest/getting-started/deployment/).
 
 ## Development Guidelines
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,7 @@ Thank you for your interest in contributing to DAIV! This document provides guid
 
 - [Code of Conduct](#code-of-conduct)
 - [Development Environment](#development-environment)
+  - [Testing against a local GitLab](#testing-against-a-local-gitlab)
 - [Development Guidelines](#development-guidelines)
   - [Code Style](#code-style)
   - [Testing](#testing)
@@ -32,17 +33,17 @@ We expect all contributors to be respectful and constructive. Please ensure that
    make setup
    ```
 
-   `make setup` creates `config.secrets.env` and `config.toml` from their templates. Edit `docker/local/app/config.secrets.env` and add your API keys — at minimum one LLM provider key (Anthropic, OpenAI, Google, or OpenRouter), plus `CODEBASE_GITLAB_AUTH_TOKEN` if you are using GitLab.
+   `make setup` creates `docker/local/app/config.secrets.env` and `docker/local/gitlab-runner/config.toml` from their templates. Edit `docker/local/app/config.secrets.env` and add your API keys — at minimum one LLM provider key (Anthropic, OpenAI, Google, or OpenRouter), plus `CODEBASE_GITLAB_AUTH_TOKEN` if you are using GitLab.
 
-2. **Install dependencies** (optional)
+2. **Install dependencies**
 
-   DAIV uses [uv](https://docs.astral.sh/uv/) for dependency management:
+   DAIV uses [uv](https://docs.astral.sh/uv/) for dependency management. Required if you run `make test` or `make lint*` on the host:
 
    ```bash
    uv sync
    ```
 
-   This installs into a virtual environment — useful for running linters outside Docker or for editor autocompletion.
+   Skip this step if you run all commands inside the Docker container (`docker compose exec -it app bash`).
 
 3. **Start core services**
 
@@ -57,7 +58,7 @@ We expect all contributors to be respectful and constructive. Please ensure that
    ```bash
    docker compose --profile gitlab up     # local GitLab instance + runner
    docker compose --profile sandbox up    # sandbox code executor
-   docker compose --profile mcp up        # MCP servers
+   docker compose --profile github up     # smee webhook forwarder for GitHub deliveries
    docker compose --profile full up       # everything
    ```
 
@@ -93,7 +94,7 @@ We expect all contributors to be respectful and constructive. Please ensure that
 
 6. **Try it** — create an issue labelled `daiv`. DAIV will respond with a plan.
 
-For GitHub, use GitHub.com or a GitHub Enterprise instance: set `CODEBASE_CLIENT=github` in `docker/local/app/config.env` and configure the GitHub App credentials.
+For GitHub, use GitHub.com or a GitHub Enterprise instance: set `CODEBASE_CLIENT=github` in `docker/local/app/config.env` and configure the GitHub App credentials. To receive webhook deliveries locally, start the `github` profile — it runs a [smee](https://smee.io/) client that forwards GitHub events to the local app.
 
 Deploying DAIV for real use is a different path — see the [Deployment guide](https://srtab.github.io/daiv/latest/getting-started/deployment/).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ We expect all contributors to be respectful and constructive. Please ensure that
    docker compose --profile gitlab up     # local GitLab instance + runner
    docker compose --profile sandbox up    # sandbox code executor
    docker compose --profile github up     # smee webhook forwarder for GitHub deliveries
-   docker compose --profile full up       # everything
+   docker compose --profile full up       # gitlab + runner + sandbox (not smee)
    ```
 
    Profiles combine: `docker compose --profile gitlab --profile sandbox up`.
@@ -96,7 +96,7 @@ We expect all contributors to be respectful and constructive. Please ensure that
 
 For GitHub, use GitHub.com or a GitHub Enterprise instance: set `CODEBASE_CLIENT=github` in `docker/local/app/config.env` and configure the GitHub App credentials. To receive webhook deliveries locally, start the `github` profile — it runs a [smee](https://smee.io/) client that forwards GitHub events to the local app.
 
-Deploying DAIV for real use is a different path — see the [Deployment guide](https://srtab.github.io/daiv/latest/getting-started/deployment/).
+Deploying DAIV for real use is a different path — see the [Deployment guide](https://srtab.github.io/daiv/dev/getting-started/deployment/).
 
 ## Development Guidelines
 

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ setup:
 	@echo "       docker compose --profile gitlab up    # local GitLab instance"
 	@echo "       docker compose --profile sandbox up   # sandbox code executor"
 	@echo "       docker compose --profile github up    # smee webhook forwarder for GitHub"
-	@echo "       docker compose --profile full up      # all services"
+	@echo "       docker compose --profile full up      # gitlab + runner + sandbox (not smee)"
 
 test:
 	LANGCHAIN_TRACING_V2=false uv run pytest -s tests/unit_tests -n auto

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ setup:
 	@echo "  3. Optional services:"
 	@echo "       docker compose --profile gitlab up    # local GitLab instance"
 	@echo "       docker compose --profile sandbox up   # sandbox code executor"
-	@echo "       docker compose --profile mcp up       # MCP proxy"
+	@echo "       docker compose --profile github up    # smee webhook forwarder for GitHub"
 	@echo "       docker compose --profile full up      # all services"
 
 test:

--- a/README.md
+++ b/README.md
@@ -15,30 +15,36 @@
 
 ---
 
+<p align="center">
+  <a href="https://srtab.github.io/daiv/latest/"><strong>Documentation</strong></a> ·
+  <a href="https://daivagent.com"><strong>Website</strong></a> ·
+  <a href="https://srtab.github.io/daiv/latest/getting-started/deployment/"><strong>Deploy</strong></a> ·
+  <a href="https://github.com/srtab/daiv/blob/main/CONTRIBUTING.md"><strong>Contributing</strong></a>
+</p>
+
 DAIV integrates directly with **GitLab** and **GitHub** through webhooks — no new tools to adopt, no context-switching. Beyond your Git workflow, DAIV plugs into your editor over **MCP** and ships with an optional **self-hosted dashboard** to chat with the agent, start and watch runs, schedule jobs, and review what changed. You host it, you pick the model, and every task executes in an isolated sandbox whose network access you define.
 
 ## Three ways to put DAIV to work
 
 ### In your Git platform — webhooks, zero setup
 
-- **Issue Addressing** — DAIV reads a labelled issue, proposes a plan, and — once you approve — opens a merge/pull request with the implementation.
-- **Pull Request Assistant** — answers reviewer comments, applies requested changes, and repairs failing CI/CD pipelines, all inside the merge/pull request thread.
-- **Slash Commands & Skills** — invoke `/plan`, `/code-review`, `/help`, and your own custom skills straight from issues and merge requests.
+- **[Issue Addressing](https://srtab.github.io/daiv/latest/features/issue-addressing/)** — DAIV reads a labelled issue, proposes a plan, and — once you approve — opens a merge/pull request with the implementation.
+- **[Pull Request Assistant](https://srtab.github.io/daiv/latest/features/pull-request-assistant/)** — answers reviewer comments, applies requested changes, and repairs failing CI/CD pipelines, all inside the merge/pull request thread.
+- **[Slash Commands & Skills](https://srtab.github.io/daiv/latest/features/slash-commands/)** — invoke `/plan`, `/code-review`, `/help`, and your own custom skills straight from issues and merge requests.
 
 ### From your editor and pipelines
 
-- **MCP Endpoint** — connect Claude Code, Cursor, or Codex CLI over the [Model Context Protocol](https://modelcontextprotocol.io/) and delegate tasks without leaving your editor.
-- **Jobs API** — trigger agents programmatically from CI, scripts, or other tools, then poll for the result.
+- **[MCP Endpoint](https://srtab.github.io/daiv/latest/features/mcp-endpoint/)** — connect Claude Code, Cursor, or Codex CLI over the [Model Context Protocol](https://modelcontextprotocol.io/) and delegate tasks without leaving your editor.
+- **[Jobs API](https://srtab.github.io/daiv/latest/features/jobs-api/)** — trigger agents programmatically from CI, scripts, or other tools, then poll for the result.
 
 ### From the dashboard
 
-- **Chat** — a live workspace: prompt the agent and watch it read, edit, and run commands in real time, on a thread you can leave and return to.
-- **Activity & run composer** — start runs from the UI and see every execution — webhook, API, MCP, scheduled, or manual — in one log, with retries.
-- **Scheduled Jobs** — run agents on any cron schedule: dependency audits, code-quality scans, stale-branch cleanup, and more.
-- **Sandbox Environments** — define a reusable runtime once: base image, CPU/memory, **network egress policy**, and encrypted secrets, scoped to the repositories you choose.
+- **[Sessions](https://srtab.github.io/daiv/latest/features/sessions/)** — a unified workspace and history: chat with the agent live, start background runs, and see every execution — webhook, API, MCP, scheduled, or manual — in one list, with retries.
+- **[Scheduled Jobs](https://srtab.github.io/daiv/latest/features/scheduled-jobs/)** — run agents on any cron schedule: dependency audits, code-quality scans, stale-branch cleanup, and more.
+- **[Sandbox Environments](https://srtab.github.io/daiv/latest/features/sandbox-environments/)** — define a reusable runtime once: base image, CPU/memory, **network egress policy**, and encrypted secrets, scoped to the repositories you choose.
 - **Per-run model & effort** — pick the LLM and thinking effort for each run.
-- **Notifications** — know the moment work finishes, via the in-app bell, email, or Rocket Chat.
-- **Merge Metrics** — track code velocity with commit-level DAIV-vs-human attribution.
+- **[Notifications](https://srtab.github.io/daiv/latest/features/notifications/)** — know the moment work finishes, via the in-app bell, email, or Rocket Chat.
+- **[Merge Metrics](https://srtab.github.io/daiv/latest/features/merge-metrics/)** — track code velocity with commit-level DAIV-vs-human attribution.
 
 ## Quick example
 
@@ -53,12 +59,12 @@ DAIV integrates directly with **GitLab** and **GitHub** through webhooks — no 
 
 DAIV is powered by [Deep Agents](https://github.com/langchain-ai/deepagents), a general-purpose deep-agent framework built on [LangGraph](https://langchain-ai.github.io/langgraph/) with sub-agent spawning, a middleware stack, and a virtual filesystem. On top of it, DAIV adds:
 
-- **Subagents** — specialized agents for fast codebase exploration and complex multi-step tasks.
-- **Sandbox** — secure command execution for tests, builds, linters, and package management inside an isolated Docker container.
-- **MCP Tools** — external integrations over the [Model Context Protocol](https://modelcontextprotocol.io/), such as Sentry for error tracking.
-- **Monitoring** — trace every agent execution with [LangSmith](https://www.langchain.com/langsmith) to analyze performance and spot issues.
+- **[Subagents](https://srtab.github.io/daiv/latest/features/subagents/)** — specialized agents for fast codebase exploration and complex multi-step tasks.
+- **[Sandbox](https://srtab.github.io/daiv/latest/features/sandbox/)** — secure command execution for tests, builds, linters, and package management inside an isolated Docker container.
+- **[MCP Tools](https://srtab.github.io/daiv/latest/customization/mcp-tools/)** — external integrations over the [Model Context Protocol](https://modelcontextprotocol.io/), such as Sentry for error tracking.
+- **[Monitoring](https://srtab.github.io/daiv/latest/reference/monitoring/)** — trace every agent execution with [LangSmith](https://www.langchain.com/langsmith) to analyze performance and spot issues.
 - **Scalable Workers** — background workers scale horizontally by adding replicas, with a dedicated scheduler for recurring jobs.
-- **LLM Providers** — run on OpenRouter, Anthropic, OpenAI, or Google — your keys, your choice.
+- **[LLM Providers](https://srtab.github.io/daiv/latest/getting-started/llm-providers/)** — run on OpenRouter, Anthropic, OpenAI, or Google — your keys, your choice.
 
 ## Technology Stack
 
@@ -71,113 +77,16 @@ DAIV is powered by [Deep Agents](https://github.com/langchain-ai/deepagents), a 
 
 ## Getting Started
 
-### Prerequisites
+```bash
+git clone https://github.com/srtab/daiv.git && cd daiv
+make setup                 # creates config files from templates
+docker compose up --build  # db, redis, app, worker, scheduler
+```
 
-- **Docker & Docker Compose**
+Then add at least one LLM provider key to `docker/local/app/config.secrets.env`.
 
-### Local Development Setup
-
-1. **Clone the repository**:
-
-   ```bash
-   git clone https://github.com/srtab/daiv.git
-   cd daiv
-   ```
-
-2. **Run setup**:
-
-   ```bash
-   make setup
-   ```
-
-   This creates config files from their templates (`config.secrets.env` and `config.toml`). Edit `docker/local/app/config.secrets.env` and add your API keys — at minimum one LLM provider key (Anthropic, OpenAI, Google, or OpenRouter) and `CODEBASE_GITLAB_AUTH_TOKEN` if using GitLab.
-
-3. **Install Dependencies** (optional):
-   We use [uv](https://docs.astral.sh/uv/) to manage dependencies on DAIV.
-
-   ```bash
-   uv sync
-   ```
-
-   > [!NOTE]
-   > This will install the project dependencies into a virtual environment. Useful for running linting outside of Docker or enabling autocompletion in VSCode.
-
-4. **Start core services**:
-
-   ```bash
-   docker compose up --build
-   ```
-
-   This starts the core services (db, redis, app, worker, scheduler). SSL certificates are auto-generated on first run.
-
-   - DAIV API documentation: https://localhost:8000/api/docs/
-
-5. **Start optional services** (as needed):
-
-   ```bash
-   docker compose --profile gitlab up     # local GitLab instance + runner
-   docker compose --profile sandbox up    # sandbox code executor
-   docker compose --profile mcp up        # MCP servers
-   docker compose --profile full up       # all services
-   ```
-
-   > [!NOTE]
-   > Profiles can be combined: `docker compose --profile gitlab --profile sandbox up`
-
-6. **Run the tests** (optional):
-   DAIV includes a comprehensive test suite. To run tests with coverage:
-
-   ```bash
-   $ docker compose exec -it app bash
-   $ make test
-   ```
-
-7. **Run linting** (optional):
-   To ensure code quality:
-
-   ```bash
-   $ docker compose exec -it app bash
-   $ make lint      # to check for linting and formatting issues
-   $ make lint-fix  # to automatically fix linting and formatting issues
-   ```
-
-### Optional: Local GitLab
-
-To test DAIV with a local GitLab instance:
-
-1. **Start GitLab**:
-
-   ```bash
-   docker compose --profile gitlab up
-   ```
-
-2. **Get the root password**:
-
-   ```bash
-   docker compose exec -it gitlab grep 'Password:' /etc/gitlab/initial_root_password
-   ```
-
-3. **Configure a personal access token** at [http://localhost:8929](http://localhost:8929) (use the root user or create a new user) and add it to `docker/local/app/config.secrets.env` as `CODEBASE_GITLAB_AUTH_TOKEN`.
-
-4. **Create a test project** in GitLab and push your testing code to it.
-
-   > [!TIP]
-   > You can import using repository URL: go to `Admin Area` -> `Settings` -> `General` -> `Import and export settings` and check the `Repository by URL` option.
-
-5. **Set up webhooks**:
-
-   ```bash
-   docker compose exec -it app django-admin setup_webhooks
-   ```
-
-   > [!NOTE]
-   > If you get the error `Invalid url given`, go to `Admin Area` -> `Settings` -> `Network` -> `Outbound requests` and check `Allow requests to the local network from webhooks and integrations`.
-
-6. **Test DAIV** by creating an issue in your repository with the `daiv` label. DAIV will automatically present a plan to address the issue.
-
-> [!NOTE]
-> For GitHub integration, you'll need to use GitHub.com or your own GitHub Enterprise instance. Set `CODEBASE_CLIENT=github` in `docker/local/app/config.env` and configure the GitHub App credentials.
-
+- **Running DAIV for real** → [Deployment](https://srtab.github.io/daiv/latest/getting-started/deployment/), then [Platform Setup](https://srtab.github.io/daiv/latest/getting-started/platform-setup/) to connect GitLab or GitHub.
+- **Developing DAIV** → [CONTRIBUTING.md](CONTRIBUTING.md) covers Compose profiles, the local GitLab instance, webhooks, tests, and linting.
 
 ## Roadmap
 
@@ -199,4 +108,4 @@ This project is licensed under the [Apache 2.0 License](LICENSE).
 
 ## Support & Community
 
-For questions or support, please open an issue in the GitHub repository. Contributions, suggestions, and feedback are greatly appreciated!
+For questions or support, [open an issue](https://github.com/srtab/daiv/issues). See the [Community page](https://srtab.github.io/daiv/latest/community/) for contribution paths and project links.

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@
 ---
 
 <p align="center">
-  <a href="https://srtab.github.io/daiv/latest/"><strong>Documentation</strong></a> ·
+  <a href="https://srtab.github.io/daiv/dev/"><strong>Documentation</strong></a> ·
   <a href="https://daivagent.com"><strong>Website</strong></a> ·
-  <a href="https://srtab.github.io/daiv/latest/getting-started/deployment/"><strong>Deploy</strong></a> ·
+  <a href="https://srtab.github.io/daiv/dev/getting-started/deployment/"><strong>Deploy</strong></a> ·
   <a href="https://github.com/srtab/daiv/blob/main/CONTRIBUTING.md"><strong>Contributing</strong></a>
 </p>
 
@@ -28,23 +28,23 @@ DAIV integrates directly with **GitLab** and **GitHub** through webhooks — no 
 
 ### In your Git platform — webhooks, zero setup
 
-- **[Issue Addressing](https://srtab.github.io/daiv/latest/features/issue-addressing/)** — DAIV reads a labelled issue, proposes a plan, and — once you approve — opens a merge/pull request with the implementation.
-- **[Pull Request Assistant](https://srtab.github.io/daiv/latest/features/pull-request-assistant/)** — answers reviewer comments, applies requested changes, and repairs failing CI/CD pipelines, all inside the merge/pull request thread.
-- **[Slash Commands & Skills](https://srtab.github.io/daiv/latest/features/slash-commands/)** — invoke `/plan`, `/code-review`, `/help`, and your own custom skills straight from issues and merge requests.
+- **[Issue Addressing](https://srtab.github.io/daiv/dev/features/issue-addressing/)** — DAIV reads a labelled issue, proposes a plan, and — once you approve — opens a merge/pull request with the implementation.
+- **[Pull Request Assistant](https://srtab.github.io/daiv/dev/features/pull-request-assistant/)** — answers reviewer comments, applies requested changes, and repairs failing CI/CD pipelines, all inside the merge/pull request thread.
+- **[Slash Commands & Skills](https://srtab.github.io/daiv/dev/features/slash-commands/)** — invoke `/plan`, `/code-review`, `/help`, and your own custom skills straight from issues and merge requests.
 
 ### From your editor and pipelines
 
-- **[MCP Endpoint](https://srtab.github.io/daiv/latest/features/mcp-endpoint/)** — connect Claude Code, Cursor, or Codex CLI over the [Model Context Protocol](https://modelcontextprotocol.io/) and delegate tasks without leaving your editor.
-- **[Jobs API](https://srtab.github.io/daiv/latest/features/jobs-api/)** — trigger agents programmatically from CI, scripts, or other tools, then poll for the result.
+- **[MCP Endpoint](https://srtab.github.io/daiv/dev/features/mcp-endpoint/)** — connect Claude Code, Cursor, or Codex CLI over the [Model Context Protocol](https://modelcontextprotocol.io/) and delegate tasks without leaving your editor.
+- **[Jobs API](https://srtab.github.io/daiv/dev/features/jobs-api/)** — trigger agents programmatically from CI, scripts, or other tools, then poll for the result.
 
 ### From the dashboard
 
-- **[Sessions](https://srtab.github.io/daiv/latest/features/sessions/)** — a unified workspace and history: chat with the agent live, start background runs, and see every execution — webhook, API, MCP, scheduled, or manual — in one list, with retries.
-- **[Scheduled Jobs](https://srtab.github.io/daiv/latest/features/scheduled-jobs/)** — run agents on any cron schedule: dependency audits, code-quality scans, stale-branch cleanup, and more.
-- **[Sandbox Environments](https://srtab.github.io/daiv/latest/features/sandbox-environments/)** — define a reusable runtime once: base image, CPU/memory, **network egress policy**, and encrypted secrets, scoped to the repositories you choose.
+- **[Sessions](https://srtab.github.io/daiv/dev/features/sessions/)** — a unified workspace and history: chat with the agent live, start background runs, and see every execution — webhook, API, MCP, scheduled, or manual — in one list, with retries.
+- **[Scheduled Jobs](https://srtab.github.io/daiv/dev/features/scheduled-jobs/)** — run agents on any cron schedule: dependency audits, code-quality scans, stale-branch cleanup, and more.
+- **[Sandbox Environments](https://srtab.github.io/daiv/dev/features/sandbox-environments/)** — define a reusable runtime once: base image, CPU/memory, **network egress policy**, and encrypted secrets, scoped to the repositories you choose.
 - **Per-run model & effort** — pick the LLM and thinking effort for each run.
-- **[Notifications](https://srtab.github.io/daiv/latest/features/notifications/)** — know the moment work finishes, via the in-app bell, email, or Rocket Chat.
-- **[Merge Metrics](https://srtab.github.io/daiv/latest/features/merge-metrics/)** — track code velocity with commit-level DAIV-vs-human attribution.
+- **[Notifications](https://srtab.github.io/daiv/dev/features/notifications/)** — know the moment work finishes, via the in-app bell, email, or Rocket Chat.
+- **[Merge Metrics](https://srtab.github.io/daiv/dev/features/merge-metrics/)** — track code velocity with commit-level DAIV-vs-human attribution.
 
 ## Quick example
 
@@ -59,12 +59,12 @@ DAIV integrates directly with **GitLab** and **GitHub** through webhooks — no 
 
 DAIV is powered by [Deep Agents](https://github.com/langchain-ai/deepagents), a general-purpose deep-agent framework built on [LangGraph](https://langchain-ai.github.io/langgraph/) with sub-agent spawning, a middleware stack, and a virtual filesystem. On top of it, DAIV adds:
 
-- **[Subagents](https://srtab.github.io/daiv/latest/features/subagents/)** — specialized agents for fast codebase exploration and complex multi-step tasks.
-- **[Sandbox](https://srtab.github.io/daiv/latest/features/sandbox/)** — secure command execution for tests, builds, linters, and package management inside an isolated Docker container.
-- **[MCP Tools](https://srtab.github.io/daiv/latest/customization/mcp-tools/)** — external integrations over the [Model Context Protocol](https://modelcontextprotocol.io/), such as Sentry for error tracking.
-- **[Monitoring](https://srtab.github.io/daiv/latest/reference/monitoring/)** — trace every agent execution with [LangSmith](https://www.langchain.com/langsmith) to analyze performance and spot issues.
+- **[Subagents](https://srtab.github.io/daiv/dev/features/subagents/)** — specialized agents for fast codebase exploration and complex multi-step tasks.
+- **[Sandbox](https://srtab.github.io/daiv/dev/features/sandbox/)** — secure command execution for tests, builds, linters, and package management inside an isolated Docker container.
+- **[MCP Tools](https://srtab.github.io/daiv/dev/customization/mcp-tools/)** — external integrations over the [Model Context Protocol](https://modelcontextprotocol.io/), such as Sentry for error tracking.
+- **[Monitoring](https://srtab.github.io/daiv/dev/reference/monitoring/)** — trace every agent execution with [LangSmith](https://www.langchain.com/langsmith) to analyze performance and spot issues.
 - **Scalable Workers** — background workers scale horizontally by adding replicas, with a dedicated scheduler for recurring jobs.
-- **[LLM Providers](https://srtab.github.io/daiv/latest/getting-started/llm-providers/)** — run on OpenRouter, Anthropic, OpenAI, or Google — your keys, your choice.
+- **[LLM Providers](https://srtab.github.io/daiv/dev/getting-started/llm-providers/)** — run on OpenRouter, Anthropic, OpenAI, or Google — your keys, your choice.
 
 ## Technology Stack
 
@@ -80,12 +80,16 @@ DAIV is powered by [Deep Agents](https://github.com/langchain-ai/deepagents), a 
 ```bash
 git clone https://github.com/srtab/daiv.git && cd daiv
 make setup                 # creates config files from templates
+```
+
+Add at least one LLM provider key to `docker/local/app/config.secrets.env` — it is read at
+container start — then bring the stack up:
+
+```bash
 docker compose up --build  # db, redis, app, worker, scheduler
 ```
 
-Then add at least one LLM provider key to `docker/local/app/config.secrets.env`.
-
-- **Running DAIV for real** → [Deployment](https://srtab.github.io/daiv/latest/getting-started/deployment/), then [Platform Setup](https://srtab.github.io/daiv/latest/getting-started/platform-setup/) to connect GitLab or GitHub.
+- **Running DAIV for real** → [Deployment](https://srtab.github.io/daiv/dev/getting-started/deployment/), then [Platform Setup](https://srtab.github.io/daiv/dev/getting-started/platform-setup/) to connect GitLab or GitHub.
 - **Developing DAIV** → [CONTRIBUTING.md](CONTRIBUTING.md) covers Compose profiles, the local GitLab instance, webhooks, tests, and linting.
 
 ## Roadmap
@@ -108,4 +112,4 @@ This project is licensed under the [Apache 2.0 License](LICENSE).
 
 ## Support & Community
 
-For questions or support, [open an issue](https://github.com/srtab/daiv/issues). See the [Community page](https://srtab.github.io/daiv/latest/community/) for contribution paths and project links.
+For questions or support, [open an issue](https://github.com/srtab/daiv/issues). See the [Community page](https://srtab.github.io/daiv/dev/community/) for contribution paths and project links.

--- a/daiv/codebase/management/commands/setup_webhooks.py
+++ b/daiv/codebase/management/commands/setup_webhooks.py
@@ -37,7 +37,7 @@ class Command(BaseCommand):
         if settings.CLIENT == GitPlatform.GITHUB:
             logger.warning(
                 "GitHub webhooks must be set on the GitHub App configuration: "
-                "https://srtab.github.io/daiv/latest/getting-started/platform-setup/#step-4-verify-webhook-configuration"
+                "https://srtab.github.io/daiv/dev/getting-started/platform-setup/#step-4-verify-webhook-configuration"
             )
             return
 

--- a/daiv/codebase/management/commands/setup_webhooks.py
+++ b/daiv/codebase/management/commands/setup_webhooks.py
@@ -37,7 +37,7 @@ class Command(BaseCommand):
         if settings.CLIENT == GitPlatform.GITHUB:
             logger.warning(
                 "GitHub webhooks must be set on the GitHub App configuration: "
-                "https://srtab.github.io/daiv/dev/getting-started/configuration/#step-4-verify-webhook-configuration"
+                "https://srtab.github.io/daiv/latest/getting-started/platform-setup/#step-4-verify-webhook-configuration"
             )
             return
 

--- a/daiv/public/llms.txt
+++ b/daiv/public/llms.txt
@@ -6,8 +6,8 @@ DAIV turns issues into working code. You create an issue, DAIV analyzes your cod
 
 - License: Apache 2.0
 - Source: https://github.com/srtab/daiv
-- Documentation: https://srtab.github.io/daiv/latest/
-- Documentation for LLMs: https://srtab.github.io/daiv/latest/llms.txt
+- Documentation: https://srtab.github.io/daiv/dev/
+- Documentation for LLMs: https://srtab.github.io/daiv/dev/llms.txt
 
 ## Capabilities
 

--- a/docs/community.md
+++ b/docs/community.md
@@ -17,6 +17,5 @@ Use [GitHub Issues](https://github.com/srtab/daiv/issues) for bug reports, featu
 ## Resources
 
 - [GitHub Repository](https://github.com/srtab/daiv)
-- [Documentation](https://srtab.github.io/daiv/)
 - [Issue Tracker](https://github.com/srtab/daiv/issues)
 - [CONTRIBUTING.md](https://github.com/srtab/daiv/blob/main/CONTRIBUTING.md)

--- a/docs/customization/mcp-tools.md
+++ b/docs/customization/mcp-tools.md
@@ -155,3 +155,10 @@ servers, but cannot edit them or view their header values.
   filter does.
 - **Network** — MCP connections originate from the DAIV app/worker containers; the sandbox egress
   proxy does not apply to them. Restrict outbound access at your network layer if needed.
+
+## Related pages
+
+- [MCP Endpoint](../features/mcp-endpoint.md) — the inverse direction: exposing DAIV *itself* as an MCP server, so Claude Code, Cursor, or Codex CLI can delegate to it
+- [Request Tracker Triage](../integrations/rt/index.md) — a worked example of DAIV driven from an external system
+- [Agent Architecture](../reference/agent-architecture.md) — how MCP tools are loaded into the agent's tool set
+- [Environment Variables](../reference/env-variables.md) — the MCP-related settings

--- a/docs/features/issue-addressing.md
+++ b/docs/features/issue-addressing.md
@@ -92,3 +92,10 @@ Issue addressing is enabled by default. To disable it, add the following to your
 issue_addressing:
   enabled: false
 ```
+
+## Related pages
+
+- [Repository Config](../customization/repository-config.md) — control which issues DAIV picks up and how it plans
+- [Slash Commands & Skills](slash-commands.md) — steer an issue with `/plan` and custom skills
+- [Pull Request Assistant](pull-request-assistant.md) — what happens once the merge request is open
+- [Sandbox](sandbox.md) — where the implementation is built and tested

--- a/docs/features/issue-addressing.md
+++ b/docs/features/issue-addressing.md
@@ -95,7 +95,7 @@ issue_addressing:
 
 ## Related pages
 
-- [Repository Config](../customization/repository-config.md) — control which issues DAIV picks up and how it plans
+- [Repository Config](../customization/repository-config.md) — turn issue addressing on or off, restrict who can trigger DAIV, and set branch and commit conventions
 - [Slash Commands & Skills](slash-commands.md) — steer an issue with `/plan` and custom skills
 - [Pull Request Assistant](pull-request-assistant.md) — what happens once the merge request is open
 - [Sandbox](sandbox.md) — where the implementation is built and tested

--- a/docs/features/jobs-api.md
+++ b/docs/features/jobs-api.md
@@ -256,6 +256,6 @@ triage-and-create-issues:
 !!! tip
     Store `DAIV_URL` and `DAIV_API_KEY` as CI/CD variables in your GitLab project settings. Mark the API key as **masked** and **protected**.
 
-## See also
+## Related pages
 
 - [Request Tracker Triage](../integrations/rt/index.md) — an end-to-end example of using the Jobs API from an RT Scrip to triage new support tickets automatically.

--- a/docs/features/merge-metrics.md
+++ b/docs/features/merge-metrics.md
@@ -130,3 +130,8 @@ Each merge event is stored as a `MergeMetric` record:
 | `platform` | enum | `gitlab` or `github` |
 
 Records are unique per `(repo_id, merge_request_iid, platform)`. Duplicate webhook deliveries are handled via upsert.
+
+## Related pages
+
+- [Sessions](sessions.md) — the run history behind the DAIV-authored commits these metrics attribute
+- [Issue Addressing](issue-addressing.md) — the workflow that produces most DAIV-authored merges

--- a/docs/features/notifications.md
+++ b/docs/features/notifications.md
@@ -110,7 +110,7 @@ When a run finishes, DAIV records the notification and one delivery row per exte
 - Transient failures are retried up to three attempts with a backoff between tries; a permanent failure (such as a refused recipient or a disabled channel) is marked **failed** and not retried.
 - The in-app bell entry is independent of external delivery — it is written even when every external channel is skipped or fails.
 
-## Related
+## Related pages
 
 <div class="grid cards" markdown>
 

--- a/docs/features/pull-request-assistant.md
+++ b/docs/features/pull-request-assistant.md
@@ -113,3 +113,10 @@ The code review agent checks for rule sources at the start of every review and, 
 You don't need a dedicated `.agents/review-rules.md`: rules already written in your repository's `AGENTS.md` and `.agents/AGENTS.md` are picked up as a **secondary** source — the agent mines them for concrete, diff-checkable conventions. When sources disagree, `.agents/review-rules.md` wins. The detector is skipped only when none of these files exist.
 
 Every custom-rule finding passes the same confidence gate and skeptical aggregation as built-in findings, so a noisy `AGENTS.md` will not flood the review.
+
+## Related pages
+
+- [Slash Commands & Skills](slash-commands.md) — invoke `/code-review` from a merge request and define per-repository review rules
+- [Sandbox](sandbox.md) — the isolated container where DAIV reproduces and repairs failing pipelines
+- [Sessions](sessions.md) — follow a running review and revisit what the agent changed
+- [Repository Config](../customization/repository-config.md) — tune review behaviour per repository with `.daiv.yml`

--- a/docs/features/pull-request-assistant.md
+++ b/docs/features/pull-request-assistant.md
@@ -116,7 +116,7 @@ Every custom-rule finding passes the same confidence gate and skeptical aggregat
 
 ## Related pages
 
-- [Slash Commands & Skills](slash-commands.md) — invoke `/code-review` from a merge request and define per-repository review rules
+- [Slash Commands & Skills](slash-commands.md) — invoke `/code-review` from a merge request, and write custom skills to extend it
 - [Sandbox](sandbox.md) — the isolated container where DAIV reproduces and repairs failing pipelines
 - [Sessions](sessions.md) — follow a running review and revisit what the agent changed
 - [Repository Config](../customization/repository-config.md) — tune review behaviour per repository with `.daiv.yml`

--- a/docs/features/sessions.md
+++ b/docs/features/sessions.md
@@ -183,7 +183,7 @@ Old bookmarks to `/dashboard/activity/<id>/` and `/dashboard/chat/<thread_id>/` 
 
 ---
 
-## Related
+## Related pages
 
 <div class="grid cards" markdown>
 

--- a/docs/features/subagents.md
+++ b/docs/features/subagents.md
@@ -112,3 +112,9 @@ description: >
 # Bad — too vague
 description: Helps with API stuff.
 ```
+
+## Related pages
+
+- [Agent Architecture](../reference/agent-architecture.md) — where subagents sit in the middleware stack and how their context stays isolated
+- [Agent Skills](../customization/agent-skills.md) — package reusable instructions that subagents and the main agent both load
+- [Slash Commands & Skills](slash-commands.md) — run `/agents` to list every subagent available in a repository

--- a/docs/features/subagents.md
+++ b/docs/features/subagents.md
@@ -115,6 +115,6 @@ description: Helps with API stuff.
 
 ## Related pages
 
-- [Agent Architecture](../reference/agent-architecture.md) — where subagents sit in the middleware stack and how their context stays isolated
-- [Agent Skills](../customization/agent-skills.md) — package reusable instructions that subagents and the main agent both load
+- [Agent Architecture](../reference/agent-architecture.md) — which model each subagent runs, its tool stack, and its fallback behaviour
+- [Agent Skills](../customization/agent-skills.md) — author the reusable instruction packages the main agent loads from `.agents/skills/`
 - [Slash Commands & Skills](slash-commands.md) — run `/agents` to list every subagent available in a repository

--- a/docs/getting-started/accounts.md
+++ b/docs/getting-started/accounts.md
@@ -139,7 +139,7 @@ Every signed-in user — member or admin — has these self-service pages:
 
 API keys authenticate calls to the [Jobs API](../features/jobs-api.md) and the [MCP endpoint](../features/mcp-endpoint.md). Members see only their own keys; admins see every user's keys in the list.
 
-## Next steps
+## Related pages
 
 <div class="grid cards" markdown>
 

--- a/docs/getting-started/accounts.md
+++ b/docs/getting-started/accounts.md
@@ -139,7 +139,7 @@ Every signed-in user — member or admin — has these self-service pages:
 
 API keys authenticate calls to the [Jobs API](../features/jobs-api.md) and the [MCP endpoint](../features/mcp-endpoint.md). Members see only their own keys; admins see every user's keys in the list.
 
-## Related pages
+## Next steps
 
 <div class="grid cards" markdown>
 

--- a/docs/getting-started/deployment.md
+++ b/docs/getting-started/deployment.md
@@ -607,6 +607,7 @@ Your DAIV instance is now running and accessible. Continue with:
 1. **[Platform Setup](platform-setup.md)** — connect DAIV to your GitLab or GitHub repositories
 2. **[LLM Providers](llm-providers.md)** — configure your LLM provider and API keys
 3. **[Repository Config](../customization/repository-config.md)** — customize DAIV's behavior per repository
+4. **[Site Configuration](../reference/site-configuration.md)** — manage settings from the admin UI instead of environment variables
 
 !!! tip "First Login & User Management"
     On a fresh install with OAuth enabled, the first user to sign in via a social provider (GitHub or GitLab) is automatically assigned the **admin** role. Alternatively, you can bootstrap the initial admin via the management command:

--- a/docs/index.md
+++ b/docs/index.md
@@ -57,9 +57,9 @@ DAIV is powered by [Deep Agents](https://github.com/langchain-ai/deepagents), a 
 - **[Subagents](features/subagents.md)** — specialized agents for fast codebase exploration and complex multi-step tasks.
 - **[Sandbox](features/sandbox.md)** — secure command execution for tests, builds, linters, and package management inside an isolated Docker container.
 - **[MCP Tools](customization/mcp-tools.md)** — external integrations over the [Model Context Protocol](https://modelcontextprotocol.io/), such as Sentry for error tracking.
-- **Monitoring** — trace every agent execution with [LangSmith](https://www.langchain.com/langsmith) to analyze performance and spot issues. See [Monitoring](reference/monitoring.md).
+- **[Monitoring](reference/monitoring.md)** — trace every agent execution with [LangSmith](https://www.langchain.com/langsmith) to analyze performance and spot issues.
 - **Scalable Workers** — background workers scale horizontally by adding replicas, with a dedicated scheduler for recurring jobs.
-- **LLM Providers** — run on OpenRouter, Anthropic, OpenAI, or Google — your keys, your choice. See [LLM Providers](getting-started/llm-providers.md).
+- **[LLM Providers](getting-started/llm-providers.md)** — run on OpenRouter, Anthropic, OpenAI, or Google — your keys, your choice.
 
 For how these pieces fit together — the middleware stack, skill loading, and how a single run is assembled — see [Agent Architecture](reference/agent-architecture.md).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,12 +54,14 @@ DAIV integrates directly with **GitLab** and **GitHub** through webhooks — no 
 
 DAIV is powered by [Deep Agents](https://github.com/langchain-ai/deepagents), a general-purpose deep-agent framework built on [LangGraph](https://langchain-ai.github.io/langgraph/) with sub-agent spawning, a middleware stack, and a virtual filesystem. On top of it, DAIV adds:
 
-- **Subagents** — specialized agents for fast codebase exploration and complex multi-step tasks.
-- **Sandbox** — secure command execution for tests, builds, linters, and package management inside an isolated Docker container.
-- **MCP Tools** — external integrations over the [Model Context Protocol](https://modelcontextprotocol.io/), such as Sentry for error tracking.
+- **[Subagents](features/subagents.md)** — specialized agents for fast codebase exploration and complex multi-step tasks.
+- **[Sandbox](features/sandbox.md)** — secure command execution for tests, builds, linters, and package management inside an isolated Docker container.
+- **[MCP Tools](customization/mcp-tools.md)** — external integrations over the [Model Context Protocol](https://modelcontextprotocol.io/), such as Sentry for error tracking.
 - **Monitoring** — trace every agent execution with [LangSmith](https://www.langchain.com/langsmith) to analyze performance and spot issues. See [Monitoring](reference/monitoring.md).
 - **Scalable Workers** — background workers scale horizontally by adding replicas, with a dedicated scheduler for recurring jobs.
 - **LLM Providers** — run on OpenRouter, Anthropic, OpenAI, or Google — your keys, your choice. See [LLM Providers](getting-started/llm-providers.md).
+
+For how these pieces fit together — the middleware stack, skill loading, and how a single run is assembled — see [Agent Architecture](reference/agent-architecture.md).
 
 ## Supported platforms
 
@@ -132,3 +134,7 @@ DAIV is powered by [Deep Agents](https://github.com/langchain-ai/deepagents), a 
     [:octicons-arrow-right-24: Scheduled Jobs](features/scheduled-jobs.md)
 
 </div>
+
+## Contributing
+
+DAIV is open-source under Apache 2.0. See [Community](community.md) for how to contribute, report issues, and get support.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,6 +6,13 @@ site_author: Sandro Rodrigues
 strict: true
 edit_uri: edit/main/docs/
 
+validation:
+  anchors: warn
+
+# Gitignored local scratch (.gitignore: docs/superpowers/) that lives inside docs_dir.
+exclude_docs: |
+  superpowers/
+
 theme:
   name: material
   logo: assets/logo.svg

--- a/tests/unit_tests/test_docs_links.py
+++ b/tests/unit_tests/test_docs_links.py
@@ -109,3 +109,30 @@ def test_absolute_docs_urls_resolve():
             if fragment and fragment not in anchors_of(target):
                 failures.append(f"{rel}: anchor '#{fragment}' missing from {target.relative_to(REPO_ROOT)}")
     assert not failures, "Broken documentation URLs:\n" + "\n".join(failures)
+
+
+def test_no_orphan_docs_pages():
+    """Every docs page needs at least one inbound link.
+
+    Only the site root is exempt. Section index pages such as
+    integrations/rt/index.md are not — they are exactly the kind of page
+    that goes orphaned.
+    """
+    pages = [p for p in DOCS_DIR.rglob("*.md") if not is_skipped(p)]
+    linked: set[Path] = set()
+    for page in pages:
+        for match in MD_LINK_RE.finditer(page.read_text(encoding="utf-8")):
+            target = match.group("target").split("#")[0]
+            if not target or target.startswith(("http://", "https://", "mailto:")):
+                continue
+            if not target.endswith(".md"):
+                continue
+            resolved = (page.parent / target).resolve()
+            if resolved != page.resolve():
+                linked.add(resolved)
+
+    root_index = (DOCS_DIR / "index.md").resolve()
+    orphans = sorted(
+        str(p.relative_to(REPO_ROOT)) for p in pages if p.resolve() != root_index and p.resolve() not in linked
+    )
+    assert not orphans, "Docs pages with no inbound link:\n" + "\n".join(orphans)

--- a/tests/unit_tests/test_docs_links.py
+++ b/tests/unit_tests/test_docs_links.py
@@ -1,0 +1,111 @@
+"""Repository-wide documentation cross-reference checks.
+
+Lives at the top of tests/unit_tests/ rather than mirroring an app package: it
+covers the repository — README, CONTRIBUTING, docs/, and doc URLs embedded in
+source — not a daiv module.
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DOCS_DIR = REPO_ROOT / "docs"
+
+ALLOWED_VERSION = "latest"
+
+GENERATED_PAGES = {"llms.txt"}
+
+SCANNED_SUFFIXES = {".md", ".py", ".html", ".txt", ".yml", ".yaml"}
+SKIPPED_DIR_NAMES = {
+    ".git",
+    ".venv",
+    ".ruff_cache",
+    ".pytest_cache",
+    ".claude",
+    ".superpowers",
+    "__pycache__",
+    "node_modules",
+    "site",
+    "htmlcov",
+}
+SKIPPED_PATHS = {DOCS_DIR / "superpowers"}
+
+DOCS_URL_RE = re.compile(r"https://srtab\.github\.io/daiv(?P<rest>/[^\s\"'<>)\]]*)?")
+MD_LINK_RE = re.compile(r"\]\(\s*(?P<target>[^)\s]+?)\s*(?:\s+\"[^\"]*\")?\)")
+HEADING_RE = re.compile(r"^(?P<hashes>#{1,6})\s+(?P<text>.+?)\s*$", re.MULTILINE)
+
+
+def slugify(text: str) -> str:
+    """Reproduce python-markdown's default TOC slugify."""
+    value = unicodedata.normalize("NFKD", text).encode("ascii", "ignore").decode("ascii")
+    value = re.sub(r"[^\w\s-]", "", value).strip().lower()
+    return re.sub(r"[-\s]+", "-", value)
+
+
+def heading_text(raw: str) -> str:
+    """Strip inline markdown so a heading slugifies like its rendered text."""
+    text = re.sub(r"\[([^\]]+)\]\([^)]*\)", r"\1", raw)
+    return text.replace("`", "").replace("*", "")
+
+
+def anchors_of(path: Path) -> set[str]:
+    content = path.read_text(encoding="utf-8")
+    return {slugify(heading_text(m.group("text"))) for m in HEADING_RE.finditer(content)}
+
+
+def docs_file_for(url_path: str) -> Path | None:
+    """Map a mkdocs directory-style URL path to its source .md file."""
+    clean = url_path.strip("/")
+    if not clean:
+        return DOCS_DIR / "index.md"
+    for candidate in (DOCS_DIR / f"{clean}.md", DOCS_DIR / clean / "index.md"):
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def is_skipped(path: Path) -> bool:
+    rel = path.relative_to(REPO_ROOT)
+    if any(part in SKIPPED_DIR_NAMES for part in rel.parts):
+        return True
+    return any(skipped in path.parents for skipped in SKIPPED_PATHS)
+
+
+def iter_repo_files() -> Iterator[Path]:
+    for path in REPO_ROOT.rglob("*"):
+        if path.is_file() and path.suffix in SCANNED_SUFFIXES and not is_skipped(path):
+            yield path
+
+
+def test_absolute_docs_urls_resolve():
+    failures = []
+    for path in iter_repo_files():
+        content = path.read_text(encoding="utf-8", errors="ignore")
+        for match in DOCS_URL_RE.finditer(content):
+            rest = match.group("rest")
+            if rest is None or not rest.strip("/"):
+                continue  # bare project URL, e.g. the OpenRouter HTTP-Referer header
+            url_path, _, fragment = rest.partition("#")
+            segments = url_path.strip("/").split("/")
+            version, page_segments = segments[0], segments[1:]
+            rel = path.relative_to(REPO_ROOT)
+            if version != ALLOWED_VERSION:
+                failures.append(f"{rel}: pins '{version}', expected '{ALLOWED_VERSION}' -> {match.group(0)}")
+                continue
+            page_path = "/".join(page_segments)
+            if page_path in GENERATED_PAGES:
+                continue
+            target = docs_file_for(page_path)
+            if target is None:
+                failures.append(f"{rel}: no docs page for {match.group(0)}")
+                continue
+            if fragment and fragment not in anchors_of(target):
+                failures.append(f"{rel}: anchor '#{fragment}' missing from {target.relative_to(REPO_ROOT)}")
+    assert not failures, "Broken documentation URLs:\n" + "\n".join(failures)

--- a/tests/unit_tests/test_docs_links.py
+++ b/tests/unit_tests/test_docs_links.py
@@ -51,7 +51,8 @@ def slugify(text: str) -> str:
 
 def heading_text(raw: str) -> str:
     """Strip inline markdown so a heading slugifies like its rendered text."""
-    text = re.sub(r"\[([^\]]+)\]\([^)]*\)", r"\1", raw)
+    text = re.sub(r":[a-z0-9_+-]+:", "", raw)  # pymdownx.emoji shortcodes render to nothing in the TOC
+    text = re.sub(r"\[([^\]]+)\]\([^)]*\)", r"\1", text)
     return text.replace("`", "").replace("*", "")
 
 
@@ -86,12 +87,14 @@ def iter_repo_files() -> Iterator[Path]:
 
 def test_absolute_docs_urls_resolve():
     failures = []
+    checked_count = 0
     for path in iter_repo_files():
         content = path.read_text(encoding="utf-8", errors="ignore")
         for match in DOCS_URL_RE.finditer(content):
             rest = match.group("rest")
             if rest is None or not rest.strip("/"):
                 continue  # bare project URL, e.g. the OpenRouter HTTP-Referer header
+            checked_count += 1
             url_path, _, fragment = rest.partition("#")
             segments = url_path.strip("/").split("/")
             version, page_segments = segments[0], segments[1:]
@@ -108,6 +111,10 @@ def test_absolute_docs_urls_resolve():
                 continue
             if fragment and fragment not in anchors_of(target):
                 failures.append(f"{rel}: anchor '#{fragment}' missing from {target.relative_to(REPO_ROOT)}")
+    assert checked_count > 20, (
+        f"Only {checked_count} docs URLs evaluated — DOCS_URL_RE or SKIPPED_DIR_NAMES may have drifted "
+        f"(base URL changed, or skip logic now matches everything)"
+    )
     assert not failures, "Broken documentation URLs:\n" + "\n".join(failures)
 
 
@@ -134,5 +141,9 @@ def test_no_orphan_docs_pages():
     root_index = (DOCS_DIR / "index.md").resolve()
     orphans = sorted(
         str(p.relative_to(REPO_ROOT)) for p in pages if p.resolve() != root_index and p.resolve() not in linked
+    )
+    assert len(pages) > 20, (
+        f"Only {len(pages)} docs pages collected — DOCS_DIR or SKIPPED_DIR_NAMES may have drifted "
+        f"(docs directory moved, or skip logic now matches everything)"
     )
     assert not orphans, "Docs pages with no inbound link:\n" + "\n".join(orphans)

--- a/tests/unit_tests/test_docs_links.py
+++ b/tests/unit_tests/test_docs_links.py
@@ -3,24 +3,37 @@
 Lives at the top of tests/unit_tests/ rather than mirroring an app package: it
 covers the repository — README, CONTRIBUTING, docs/, and doc URLs embedded in
 source — not a daiv module.
+
+Anchors are resolved by instantiating the site's real renderer, so this module needs
+the `docs` dependency group. It is in `tool.uv.default-groups`, which is why a plain
+`uv sync` installs it; dropping it from there would make these tests fail to import.
 """
 
 from __future__ import annotations
 
+import os
 import re
-import unicodedata
+import subprocess  # noqa: S404
+from collections import Counter, deque
+from functools import cache, partial
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, NamedTuple
+
+import markdown
+from mkdocs.config import load_config
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
+    from collections.abc import Callable, Iterator
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DOCS_DIR = REPO_ROOT / "docs"
 
-ALLOWED_VERSION = "latest"
+# mike republishes `dev` on every push to main but moves `latest` only on tag pushes, so the
+# two aliases serve different trees and each must be resolved against its own.
+TREE_VERSION = "dev"
+RELEASED_VERSION = "latest"
 
-GENERATED_PAGES = {"llms.txt"}
+GENERATED_PAGES = {"llms.txt", "llms-full.txt"}
 
 SCANNED_SUFFIXES = {".md", ".py", ".html", ".txt", ".yml", ".yaml"}
 SKIPPED_DIR_NAMES = {
@@ -35,40 +48,106 @@ SKIPPED_DIR_NAMES = {
     "site",
     "htmlcov",
 }
+# Untracked, developer-local scratch: absent in CI, present after a local superpowers run.
 SKIPPED_PATHS = {DOCS_DIR / "superpowers"}
 
 DOCS_URL_RE = re.compile(r"https://srtab\.github\.io/daiv(?P<rest>/[^\s\"'<>)\]]*)?")
 MD_LINK_RE = re.compile(r"\]\(\s*(?P<target>[^)\s]+?)\s*(?:\s+\"[^\"]*\")?\)")
-HEADING_RE = re.compile(r"^(?P<hashes>#{1,6})\s+(?P<text>.+?)\s*$", re.MULTILINE)
+HTML_LINK_RE = re.compile(r"<a\s[^>]*?href=[\"'](?P<target>[^\"']+)[\"']", re.IGNORECASE)
 
 
-def slugify(text: str) -> str:
-    """Reproduce python-markdown's default TOC slugify."""
-    value = unicodedata.normalize("NFKD", text).encode("ascii", "ignore").decode("ascii")
-    value = re.sub(r"[^\w\s-]", "", value).strip().lower()
-    return re.sub(r"[-\s]+", "-", value)
+def read_text(path: Path) -> str | None:
+    """Return the file's text, or None if it is not valid UTF-8."""
+    try:
+        return path.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        return None
 
 
-def heading_text(raw: str) -> str:
-    """Strip inline markdown so a heading slugifies like its rendered text."""
-    text = re.sub(r":[a-z0-9_+-]+:", "", raw)  # pymdownx.emoji shortcodes render to nothing in the TOC
-    text = re.sub(r"\[([^\]]+)\]\([^)]*\)", r"\1", text)
-    return text.replace("`", "").replace("*", "")
+@cache
+def _renderer() -> markdown.Markdown:
+    """The site's own markdown renderer, built from the extension set mkdocs.yml declares."""
+    config = load_config(str(REPO_ROOT / "mkdocs.yml"))
+    return markdown.Markdown(extensions=config["markdown_extensions"], extension_configs=config["mdx_configs"])
 
 
-def anchors_of(path: Path) -> set[str]:
-    content = path.read_text(encoding="utf-8")
-    return {slugify(heading_text(m.group("text"))) for m in HEADING_RE.finditer(content)}
+def _toc_ids(tokens: list[dict]) -> set[str]:
+    ids = set()
+    for token in tokens:
+        ids.add(token["id"])
+        ids |= _toc_ids(token["children"])
+    return ids
 
 
-def docs_file_for(url_path: str) -> Path | None:
-    """Map a mkdocs directory-style URL path to its source .md file."""
+def anchors_in(content: str) -> set[str]:
+    """Anchor ids a markdown source renders to, as produced by the real toc extension."""
+    renderer = _renderer()
+    renderer.reset()  # toc ids are per-document; without this they would collide across pages
+    renderer.convert(content)
+    return _toc_ids(renderer.toc_tokens)
+
+
+class PageRef(NamedTuple):
+    """A resolved docs page: how to name it in a failure, and how to read its source."""
+
+    label: str
+    read: Callable[[], str | None]
+
+
+def page_candidates(url_path: str) -> tuple[str, ...]:
+    """The docs/-relative sources a mkdocs directory-style URL path could come from."""
     clean = url_path.strip("/")
     if not clean:
-        return DOCS_DIR / "index.md"
-    for candidate in (DOCS_DIR / f"{clean}.md", DOCS_DIR / clean / "index.md"):
-        if candidate.is_file():
-            return candidate
+        return ("index.md",)
+    return (f"{clean}.md", f"{clean}/index.md")
+
+
+def tree_page_for(url_path: str) -> PageRef | None:
+    """Resolve a URL path against the working tree."""
+    for candidate in page_candidates(url_path):
+        target = DOCS_DIR / candidate
+        if target.is_file():
+            return PageRef(str(target.relative_to(REPO_ROOT)), partial(read_text, target))
+    return None
+
+
+def git_output(*args: str) -> str | None:
+    try:
+        result = subprocess.run(  # noqa: S603
+            ["git", *args],  # noqa: S607
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=30,
+        )
+    except OSError, subprocess.SubprocessError:
+        return None
+    return result.stdout
+
+
+def released_docs_tree() -> tuple[str, set[str]] | None:
+    """The tag `latest` points at, plus its docs/-relative sources. None if tags are unavailable.
+
+    Restricted to the `v*.*.*` pattern that docs.yml publishes from, since no other tag can
+    have moved the alias. Sorted by version rather than `git describe`, which needs history a
+    shallow CI clone lacks.
+    """
+    tags = (git_output("tag", "--sort=-v:refname", "--list", "v*.*.*") or "").split()
+    if not tags:
+        return None
+    tag = tags[0]
+    listing = git_output("ls-tree", "-r", "--name-only", f"{tag}:docs")
+    if listing is None:
+        return None
+    return tag, {line.strip() for line in listing.splitlines() if line.strip()}
+
+
+def released_page_for(url_path: str, tag: str, tree: set[str]) -> PageRef | None:
+    """Resolve a URL path against the docs sources of an already-released tag."""
+    for candidate in page_candidates(url_path):
+        if candidate in tree:
+            return PageRef(f"docs/{candidate} at {tag}", partial(git_output, "show", f"{tag}:docs/{candidate}"))
     return None
 
 
@@ -80,70 +159,162 @@ def is_skipped(path: Path) -> bool:
 
 
 def iter_repo_files() -> Iterator[Path]:
-    for path in REPO_ROOT.rglob("*"):
-        if path.is_file() and path.suffix in SCANNED_SUFFIXES and not is_skipped(path):
-            yield path
+    """Scannable repository files, pruning skipped trees as the walk descends.
+
+    Pruning matters: an unpruned walk of this repo stats ~52k paths (~50k of them in .venv)
+    to keep ~900.
+    """
+    for dirpath, dirnames, filenames in os.walk(REPO_ROOT):
+        root = Path(dirpath)
+        dirnames[:] = [d for d in dirnames if d not in SKIPPED_DIR_NAMES and root / d not in SKIPPED_PATHS]
+        for name in filenames:
+            if (path := root / name).suffix in SCANNED_SUFFIXES:
+                yield path
+
+
+def test_anchors_in_reproduces_the_rendered_ids():
+    """Pin the renderer wiring: the cases below only come out right with the site's own extensions.
+
+    `#` inside a fence is not a heading (superfences), repeated headings gain `_N` (toc),
+    emoji shortcodes vanish (pymdownx.emoji), and attr_list ids win over the slug. If
+    mkdocs.yml stops loading one of those, this fails instead of silently under-reporting.
+    """
+    source = """# Getting Started
+
+## Prerequisites
+
+```bash
+# Install the deps
+uv sync
+```
+
+## Prerequisites
+
+## :simple-swarm: Docker Swarm (*Recommended*)
+
+## Custom Heading {#explicit-id}
+"""
+    assert anchors_in(source) == {
+        "getting-started",
+        "prerequisites",
+        "prerequisites_1",
+        "docker-swarm-recommended",
+        "explicit-id",
+    }
 
 
 def test_absolute_docs_urls_resolve():
-    failures = []
-    checked_count = 0
-    for path in iter_repo_files():
-        content = path.read_text(encoding="utf-8", errors="ignore")
+    """Every published docs URL in the repository resolves to a real page and anchor.
+
+    `dev` URLs are checked against the working tree; `latest` URLs against the tag that
+    alias actually serves, so a link to an unreleased page fails here rather than in
+    production.
+    """
+    failures: list[str] = []
+    scanned = list(iter_repo_files())
+    files_by_suffix = Counter(path.suffix for path in scanned)
+    pages_checked = 0
+    released = released_docs_tree()
+
+    for path in scanned:
+        rel = path.relative_to(REPO_ROOT)
+        content = read_text(path)
+        if content is None:
+            failures.append(f"{rel}: not valid UTF-8, so it cannot be scanned for docs URLs")
+            continue
         for match in DOCS_URL_RE.finditer(content):
             rest = match.group("rest")
-            if rest is None or not rest.strip("/"):
+            if rest is None:
                 continue  # bare project URL, e.g. the OpenRouter HTTP-Referer header
-            checked_count += 1
+            rest = rest.rstrip(".,;:!?")  # a URL ending a prose sentence
+            if not rest.strip("/"):
+                continue
+            url = match.group(0)
             url_path, _, fragment = rest.partition("#")
             segments = url_path.strip("/").split("/")
-            version, page_segments = segments[0], segments[1:]
-            rel = path.relative_to(REPO_ROOT)
-            if version != ALLOWED_VERSION:
-                failures.append(f"{rel}: pins '{version}', expected '{ALLOWED_VERSION}' -> {match.group(0)}")
-                continue
-            page_path = "/".join(page_segments)
+            version, page_path = segments[0], "/".join(segments[1:])
             if page_path in GENERATED_PAGES:
                 continue
-            target = docs_file_for(page_path)
-            if target is None:
-                failures.append(f"{rel}: no docs page for {match.group(0)}")
+
+            if version == TREE_VERSION:
+                page = tree_page_for(page_path)
+                unresolved = f"{rel}: no docs page for {url}"
+            elif version == RELEASED_VERSION:
+                if released is None:
+                    failures.append(f"{rel}: cannot verify {url} — no git tags available to resolve the alias")
+                    continue
+                tag, tree = released
+                page = released_page_for(page_path, tag, tree)
+                unresolved = f"{rel}: {url} does not exist at {tag}, which is what '{RELEASED_VERSION}' serves"
+            else:
+                failures.append(f"{rel}: pins '{version}', expected '{TREE_VERSION}' or '{RELEASED_VERSION}' -> {url}")
                 continue
-            if fragment and fragment not in anchors_of(target):
-                failures.append(f"{rel}: anchor '#{fragment}' missing from {target.relative_to(REPO_ROOT)}")
-    assert checked_count > 20, (
-        f"Only {checked_count} docs URLs evaluated — DOCS_URL_RE or SKIPPED_DIR_NAMES may have drifted "
-        f"(base URL changed, or skip logic now matches everything)"
-    )
+
+            if page is None:
+                failures.append(unresolved)
+                continue
+            pages_checked += 1
+            if not fragment:
+                continue
+            page_content = page.read()
+            if page_content is None:
+                failures.append(f"{rel}: could not read {page.label} to verify '#{fragment}'")
+            elif fragment not in anchors_in(page_content):
+                failures.append(f"{rel}: anchor '#{fragment}' missing from {page.label}")
+
+    # Real breakage is reported before the floors, which would otherwise mask it.
     assert not failures, "Broken documentation URLs:\n" + "\n".join(failures)
+    # Floors guard the scanner, not the prose: they must not move when links are added or removed.
+    assert len(scanned) > 500, f"only {len(scanned)} files scanned — SCANNED_SUFFIXES or the skip lists drifted"
+    for suffix, floor in ((".py", 300), (".html", 50), (".md", 20)):
+        assert files_by_suffix[suffix] > floor, (
+            f"only {files_by_suffix[suffix]} '{suffix}' files scanned (expected > {floor}) — "
+            f"a whole file class dropped out: {dict(files_by_suffix)}"
+        )
+    assert pages_checked > 10, f"only {pages_checked} docs URLs resolved — DOCS_URL_RE may no longer match"
 
 
-def test_no_orphan_docs_pages():
-    """Every docs page needs at least one inbound link.
+def test_all_docs_pages_reachable():
+    """Every docs page is reachable from the site root by following links.
 
-    Only the site root is exempt. Section index pages such as
-    integrations/rt/index.md are not — they are exactly the kind of page
-    that goes orphaned.
+    Nav membership deliberately does not count: a page reachable only through the
+    sidebar is invisible to llms.txt consumers and search-landing readers, which is
+    the case this guards. Pages that link only to each other are unreachable even
+    though each has an inbound link.
     """
     pages = [p for p in DOCS_DIR.rglob("*.md") if not is_skipped(p)]
-    linked: set[Path] = set()
+    failures: list[str] = []
+    outbound: dict[Path, set[Path]] = {}
+
     for page in pages:
-        for match in MD_LINK_RE.finditer(page.read_text(encoding="utf-8")):
+        content = read_text(page)
+        if content is None:
+            failures.append(f"{page.relative_to(REPO_ROOT)}: not valid UTF-8, so its links cannot be read")
+            outbound[page.resolve()] = set()
+            continue
+        targets = set()
+        for match in (*MD_LINK_RE.finditer(content), *HTML_LINK_RE.finditer(content)):
             target = match.group("target").split("#")[0]
-            if not target or target.startswith(("http://", "https://", "mailto:")):
+            if not target or target.startswith(("http://", "https://", "mailto:", "/")):
                 continue
             if not target.endswith(".md"):
                 continue
-            resolved = (page.parent / target).resolve()
-            if resolved != page.resolve():
-                linked.add(resolved)
+            targets.add((page.parent / target).resolve())
+        outbound[page.resolve()] = targets
 
-    root_index = (DOCS_DIR / "index.md").resolve()
-    orphans = sorted(
-        str(p.relative_to(REPO_ROOT)) for p in pages if p.resolve() != root_index and p.resolve() not in linked
-    )
+    root = (DOCS_DIR / "index.md").resolve()
+    reached = {root}
+    queue = deque([root])
+    while queue:
+        for target in outbound.get(queue.popleft(), ()):
+            if target not in reached:
+                reached.add(target)
+                queue.append(target)
+
+    unreachable = sorted(str(p.relative_to(REPO_ROOT)) for p in pages if p.resolve() not in reached)
     assert len(pages) > 20, (
-        f"Only {len(pages)} docs pages collected — DOCS_DIR or SKIPPED_DIR_NAMES may have drifted "
+        f"Only {len(pages)} docs pages collected — DOCS_DIR or the skip lists may have drifted "
         f"(docs directory moved, or skip logic now matches everything)"
     )
-    assert not orphans, "Docs pages with no inbound link:\n" + "\n".join(orphans)
+    assert not failures, "Unreadable docs pages:\n" + "\n".join(failures)
+    assert not unreachable, "Docs pages not reachable from docs/index.md by following links:\n" + "\n".join(unreachable)


### PR DESCRIPTION
## What

Makes the README, CONTRIBUTING, docs site, and in-app strings refer to each other
correctly instead of duplicating content, and adds a guard that keeps them correct.

## Why

`setup_webhooks.py` was telling GitHub users to visit
`/dev/getting-started/configuration/` — a page renamed to `platform-setup` months
ago. It returned a 404. Nothing caught it, because the docs workflow is
path-filtered to `docs/**` and would never fire on a change to a `.py` file.

The README was a linkless clone of `docs/index.md`, and had already drifted: it
still described Chat and Activity as separate features after they became Sessions.
Deleting the duplicated prose removes the drift surface entirely.

## Changes

**A regression guard** (`tests/unit_tests/test_docs_links.py`) — a pure-filesystem
test that resolves every absolute docs URL in the repository to a real page and
anchor, and a second that fails on any docs page with no inbound link. It lives in
the unfiltered `ci.yml` suite precisely so it fires on non-docs changes like the
one that shipped the 404. Both tests assert a floor on what they scanned, so they
cannot silently pass while checking nothing.

**The shipped 404** — corrected to `/latest/getting-started/platform-setup/`.

**Three orphan pages adopted** — `site-configuration`, `agent-architecture` and
`community` had zero inbound links, reachable only through the sidebar nav and so
invisible to `llms.txt` consumers and search-landing readers.

**Five dead ends given onward links** — `pull-request-assistant`,
`issue-addressing`, `subagents`, `merge-metrics` and `mcp-tools`, applying the
`Related pages` / `Next steps` convention the other eight pages already used. The
MCP Tools ↔ MCP Endpoint cross-link fixes a real reader trap: near-identical names
for inverse concepts, with neither page previously mentioning the other.

**README rebuilt as a shop window** — every feature now links to its docs page;
local development setup handed to `CONTRIBUTING.md`, which previously pointed back
at the README.

**One stale instruction removed** — `docker compose --profile mcp up` was
documented but the profile was deleted in #1256. It fails silently, bringing up
the core stack and no MCP. The `github` profile (the smee webhook forwarder), which
was undocumented, is now documented in its place.

## Verification

- `make test` — 4000/4000
- `uv run --only-group=docs mkdocs build --strict` — exit 0
- `make lint` — clean
- Guard proven load-bearing: reinstating the old `/dev/` URL produces exactly one
  failure naming `setup_webhooks.py`
- All 26 docs pages traversed: zero broken relative targets, zero orphans

## Follow-ups (not in this PR)

- `daiv/public/llms.txt` and the accounts homepage still advertise a feature set
  that omits Sessions, Notifications, Merge Metrics and Sandbox Environments. Prose
  drift, which no guard can catch.
- `docker-compose.yml` hardcodes a shared smee.io channel for the `github` profile.
  Pre-existing, but this PR documents that profile, so it will now see more use.
