### PR TITLE
docs: align llms.txt and the homepage with the current feature set

### DIFF
--- a/daiv/accounts/templates/accounts/homepage.html
+++ b/daiv/accounts/templates/accounts/homepage.html
@@ -214,8 +214,8 @@
 
         <div class="mt-12 grid gap-4 sm:grid-cols-2">
             <!-- Slash Commands -->
-            <div class="animate-fade-up group rounded-2xl border border-white/[0.06] bg-white/[0.02] p-6 transition-all duration-200 hover:border-white/[0.1] hover:bg-white/[0.04]" style="animation-delay: 80ms">
-                <div class="mb-3 flex h-10 w-10 items-center justify-center rounded-xl border border-white/[0.08] bg-white/[0.03]">
+            <div class="animate-fade-up group landing-card" style="animation-delay: 80ms">
+                <div class="landing-card__icon">
                     {% icon "command-line" "h-5 w-5 text-gray-400 transition-colors group-hover:text-white" %}
                 </div>
                 <h3 class="text-[15px] font-semibold text-white">Slash Commands & Skills</h3>
@@ -223,8 +223,8 @@
             </div>
 
             <!-- Sandbox -->
-            <div class="animate-fade-up group rounded-2xl border border-white/[0.06] bg-white/[0.02] p-6 transition-all duration-200 hover:border-white/[0.1] hover:bg-white/[0.04]" style="animation-delay: 120ms">
-                <div class="mb-3 flex h-10 w-10 items-center justify-center rounded-xl border border-white/[0.08] bg-white/[0.03]">
+            <div class="animate-fade-up group landing-card" style="animation-delay: 120ms">
+                <div class="landing-card__icon">
                     {% icon "cube" "h-5 w-5 text-gray-400 transition-colors group-hover:text-white" %}
                 </div>
                 <h3 class="text-[15px] font-semibold text-white">Secure Sandbox</h3>
@@ -232,8 +232,8 @@
             </div>
 
             <!-- MCP -->
-            <div class="animate-fade-up group rounded-2xl border border-white/[0.06] bg-white/[0.02] p-6 transition-all duration-200 hover:border-white/[0.1] hover:bg-white/[0.04]" style="animation-delay: 160ms">
-                <div class="mb-3 flex h-10 w-10 items-center justify-center rounded-xl border border-white/[0.08] bg-white/[0.03]">
+            <div class="animate-fade-up group landing-card" style="animation-delay: 160ms">
+                <div class="landing-card__icon">
                     {% icon "puzzle-piece" "h-5 w-5 text-gray-400 transition-colors group-hover:text-white" %}
                 </div>
                 <h3 class="text-[15px] font-semibold text-white">MCP Tool Integrations</h3>
@@ -241,8 +241,8 @@
             </div>
 
             <!-- Subagents -->
-            <div class="animate-fade-up group rounded-2xl border border-white/[0.06] bg-white/[0.02] p-6 transition-all duration-200 hover:border-white/[0.1] hover:bg-white/[0.04]" style="animation-delay: 200ms">
-                <div class="mb-3 flex h-10 w-10 items-center justify-center rounded-xl border border-white/[0.08] bg-white/[0.03]">
+            <div class="animate-fade-up group landing-card" style="animation-delay: 200ms">
+                <div class="landing-card__icon">
                     {% icon "squares-2x2" "h-5 w-5 text-gray-400 transition-colors group-hover:text-white" %}
                 </div>
                 <h3 class="text-[15px] font-semibold text-white">Subagents</h3>
@@ -250,8 +250,8 @@
             </div>
 
             <!-- Multi-provider -->
-            <div class="animate-fade-up group rounded-2xl border border-white/[0.06] bg-white/[0.02] p-6 transition-all duration-200 hover:border-white/[0.1] hover:bg-white/[0.04]" style="animation-delay: 240ms">
-                <div class="mb-3 flex h-10 w-10 items-center justify-center rounded-xl border border-white/[0.08] bg-white/[0.03]">
+            <div class="animate-fade-up group landing-card" style="animation-delay: 240ms">
+                <div class="landing-card__icon">
                     {% icon "cpu-chip" "h-5 w-5 text-gray-400 transition-colors group-hover:text-white" %}
                 </div>
                 <h3 class="text-[15px] font-semibold text-white">Multi-provider LLMs</h3>
@@ -259,21 +259,81 @@
             </div>
 
             <!-- Jobs API -->
-            <div class="animate-fade-up group rounded-2xl border border-white/[0.06] bg-white/[0.02] p-6 transition-all duration-200 hover:border-white/[0.1] hover:bg-white/[0.04]" style="animation-delay: 280ms">
-                <div class="mb-3 flex h-10 w-10 items-center justify-center rounded-xl border border-white/[0.08] bg-white/[0.03]">
+            <div class="animate-fade-up group landing-card" style="animation-delay: 280ms">
+                <div class="landing-card__icon">
                     {% icon "bolt" "h-5 w-5 text-gray-400 transition-colors group-hover:text-white" %}
                 </div>
                 <h3 class="text-[15px] font-semibold text-white">Jobs API</h3>
                 <p class="mt-1 text-[14px] text-gray-400">Trigger agents programmatically via REST. Chain tasks from CI/CD, or integrate with Slack bots.</p>
             </div>
 
+            <!-- MCP Endpoint -->
+            <div class="animate-fade-up group landing-card" style="animation-delay: 320ms">
+                <div class="landing-card__icon">
+                    {% icon "link" "h-5 w-5 text-gray-400 transition-colors group-hover:text-white" %}
+                </div>
+                <h3 class="text-[15px] font-semibold text-white">MCP Endpoint</h3>
+                <p class="mt-1 text-[14px] text-gray-400">The inverse direction: DAIV itself is an MCP server. Delegate tasks to it from Claude Code, Cursor, or Codex CLI without leaving your editor.</p>
+            </div>
+
             <!-- Scheduled Jobs -->
-            <div class="animate-fade-up group rounded-2xl border border-white/[0.06] bg-white/[0.02] p-6 transition-all duration-200 hover:border-white/[0.1] hover:bg-white/[0.04]" style="animation-delay: 320ms">
-                <div class="mb-3 flex h-10 w-10 items-center justify-center rounded-xl border border-white/[0.08] bg-white/[0.03]">
+            <div class="animate-fade-up group landing-card" style="animation-delay: 360ms">
+                <div class="landing-card__icon">
                     {% icon "clock" "h-5 w-5 text-gray-400 transition-colors group-hover:text-white" %}
                 </div>
                 <h3 class="text-[15px] font-semibold text-white">Scheduled Jobs</h3>
                 <p class="mt-1 text-[14px] text-gray-400">Run agents on a recurring basis — hourly, daily, weekly, or custom cron. Automate dependency audits, code scans, and maintenance tasks.</p>
+            </div>
+        </div>
+    </div>
+</section>
+
+<!-- Dashboard -->
+<section class="border-t border-white/[0.06] py-24">
+    <div class="mx-auto max-w-5xl px-6">
+        <div class="animate-fade-up">
+            <p class="text-[12px] font-medium uppercase tracking-[0.2em] text-gray-400">Dashboard</p>
+            <h2 class="mt-3 text-3xl font-bold tracking-tight sm:text-4xl">A self-hosted control plane</h2>
+            <p class="mt-4 max-w-2xl text-[16px] font-light text-gray-400">
+                Every run lands in one place — whether it started from a webhook, the API, your editor, a schedule, or by hand. Pick the model and thinking effort per run.
+            </p>
+        </div>
+
+        <div class="mt-12 grid gap-4 sm:grid-cols-2">
+            <!-- Sessions -->
+            <div class="animate-fade-up group landing-card" style="animation-delay: 80ms">
+                <div class="landing-card__icon">
+                    {% icon "chat-bubble" "h-5 w-5 text-gray-400 transition-colors group-hover:text-white" %}
+                </div>
+                <h3 class="text-[15px] font-semibold text-white">Sessions</h3>
+                <p class="mt-1 text-[14px] text-gray-400">Chat with the agent live, start background runs, and browse the full history in one list — with retries when something needs another pass.</p>
+            </div>
+
+            <!-- Sandbox Environments -->
+            <div class="animate-fade-up group landing-card" style="animation-delay: 120ms">
+                <div class="landing-card__icon">
+                    {% icon "sandbox" "h-5 w-5 text-gray-400 transition-colors group-hover:text-white" %}
+                </div>
+                <h3 class="text-[15px] font-semibold text-white">Sandbox Environments</h3>
+                <p class="mt-1 text-[14px] text-gray-400">Define a runtime once and reuse it: base image, CPU and memory, network egress policy, and encrypted secrets — scoped to the repositories you choose.</p>
+            </div>
+
+            <!-- Notifications -->
+            <div class="animate-fade-up group landing-card" style="animation-delay: 160ms">
+                <div class="landing-card__icon">
+                    {% icon "bell" "h-5 w-5 text-gray-400 transition-colors group-hover:text-white" %}
+                </div>
+                <h3 class="text-[15px] font-semibold text-white">Notifications</h3>
+                <p class="mt-1 text-[14px] text-gray-400">Know the moment work finishes, via the in-app bell, email, or Rocket Chat.</p>
+            </div>
+
+            <!-- Merge Metrics -->
+            <div class="animate-fade-up group landing-card" style="animation-delay: 200ms">
+                <div class="landing-card__icon">
+                    {% icon "chart-bar" "h-5 w-5 text-gray-400 transition-colors group-hover:text-white" %}
+                </div>
+                <h3 class="text-[15px] font-semibold text-white">Merge Metrics</h3>
+                <p class="mt-1 text-[14px] text-gray-400">Track code velocity with commit-level attribution — what DAIV wrote versus what your team wrote.</p>
             </div>
         </div>
     </div>

--- a/daiv/public/llms.txt
+++ b/daiv/public/llms.txt
@@ -12,12 +12,19 @@ DAIV turns issues into working code. You create an issue, DAIV analyzes your cod
 ## Capabilities
 
 - Issue-to-merge-request automation with human-in-the-loop approval
+- Merge/pull request assistant that answers review comments and repairs failing CI/CD pipelines
 - Slash commands and custom skills invoked from issues and merge requests
+- MCP endpoint exposing DAIV to editors and CLIs such as Claude Code, Cursor, and Codex CLI
+- Jobs API for programmatic agent triggering and CI/CD integration
+- Sessions dashboard for live chat, background runs, and unified run history with retries
+- Scheduled jobs on cron for dependency audits, code-quality scans, and recurring maintenance
+- Sandbox environments with configurable base image, resources, network egress policy, and encrypted secrets
+- Notifications on run completion via in-app bell, email, or Rocket Chat
+- Merge metrics with commit-level DAIV-vs-human attribution
 - Secure sandboxed code execution in isolated Docker containers
 - MCP (Model Context Protocol) tool integrations for external services
 - Specialized subagents for exploration and execution
 - Multi-provider LLM support (OpenRouter, Anthropic, OpenAI, Google Gemini)
-- Jobs API for programmatic agent triggering and CI/CD integration
 - Per-repository configuration and custom skill authoring
 
 ## How It Works

--- a/daiv/static_src/css/input.css
+++ b/daiv/static_src/css/input.css
@@ -2114,3 +2114,19 @@ main:has(.chat-shell) {
     @apply pointer-events-none opacity-50 transition-opacity duration-150;
   }
 }
+
+/* -- Public landing page feature cards -----------------------------------
+   Templates must also carry `animate-fade-up group`: the first is a plain
+   class (not a utility) and the second is a variant marker, so neither can
+   be @applied. */
+
+@layer components {
+  .landing-card {
+    @apply rounded-2xl border border-white/[0.06] bg-white/[0.02]
+      p-6 transition-all duration-200 hover:border-white/[0.1] hover:bg-white/[0.04];
+  }
+  .landing-card__icon {
+    @apply mb-3 flex h-10 w-10 items-center justify-center rounded-xl
+      border border-white/[0.08] bg-white/[0.03];
+  }
+}


### PR DESCRIPTION
> **Stacked on #1462.** This PR targets `claude/happy-swanson-921ba1`, not
> `main`, so the diff below is scoped to this work alone: one commit, three
> files. It needs #1462 first — the branch carries the link guard this change is
> verified against. GitHub retargets this PR to `main` automatically when #1462
> merges and its branch is deleted.

## What

Brings the two hand-maintained feature lists outside the docs up to date with
`docs/index.md`.

## Why

Both surfaces advertised a feature set that predated **Sessions**,
**Notifications**, **Merge Metrics** and **Sandbox Environments**; the homepage
also omitted the **MCP Endpoint**. #1462 aligned `README.md` with
`docs/index.md`; these were left out of scope and tracked as follow-up.

This is prose drift, so no guard can catch it — the link checker added in #1462
passes on both files already, because every *URL* on them is valid. Only the
described feature set was stale.

## `daiv/public/llms.txt`

Keeps its terse one-line-per-capability format. The list now flattens the docs'
three groups plus Under the hood, in that order, rather than mixing user-facing
features with internals arbitrarily.

## `homepage.html`

The Capabilities grid turned out **not** to be a feature-list mirror — it is a
curated mix of user-facing features and internals (Subagents, Multi-provider
LLMs), and the page had **no dashboard section at all**. A visitor learned
nothing about the self-hosted control plane, which is the larger gap.

- Adds a **Dashboard** section: Sessions, Sandbox Environments, Notifications,
  Merge Metrics. Per-run model and effort selection is mentioned in the section
  intro rather than given a card, matching `docs/index.md`, where it is the one
  bullet with no page of its own.
- Adds an **MCP Endpoint** card beside Jobs API. Its copy names the
  inverse-direction relationship to *MCP Tool Integrations* outright — the two
  are near-identical names for opposite concepts, the same reader trap #1462
  fixed in the docs.

## CSS

Extracts `.landing-card` / `.landing-card__icon` instead of repeating a
20-class Tailwind chain twelve times. `animate-fade-up` and `group` stay inline
in the template: the first is a plain CSS class (`input.css:37`), the second a
variant marker, and Tailwind v4 `@apply` rejects both — my first attempt at
this would have failed the stylesheet build.

## Verification

- `make test` — 4000/4000
- `make lint-fix` — clean, `djade` included
- `tests/unit_tests/test_docs_links.py` — 2/2
- Template renders to 31,212 chars: all new strings present, no unrendered
  tags, and all 16 icon references resolve to real files in
  `daiv/core/static/core/img/icons/` (the `{% icon %}` tag validates the slug
  format but not that the file exists, so this was checked separately)

**Not verified locally:** the Tailwind compile. There is no host `tailwindcss`
and the build needs `docker compose exec app`. Every utility in the two new
classes either appears in an existing `@apply` in `input.css` or is an obvious
scale variant of one (`p-6`↔`p-5`, `hover:border-white/[0.1]`↔`[0.12]`), and the
one construct with no precedent was dropped. Worth a `make tailwind-build`
before merge — see below.

## Worth deciding separately

`docker.yml` is the only workflow that compiles Tailwind, and its
`pull_request` trigger is path-filtered to `docker/production/app/**`,
`uv.lock`, and itself. `daiv/static_src/css/input.css` is not in that filter,
so a bad `@apply` would first surface as a build failure on `main` and block
deploys. Structurally the same blind spot as the `docs.yml` filter that let the
shipped 404 in #1462 go unnoticed. Adding the CSS path to that filter, or a
lightweight CSS-compile step in `ci.yml`, would close it.
