### PR TITLE
feat(deferred-tools): freeze the bound tools array for allowlisted models to preserve prompt cache

### DIFF
--- a/daiv/automation/agent/deferred/conf.py
+++ b/daiv/automation/agent/deferred/conf.py
@@ -15,6 +15,20 @@ class DeferredToolsSettings(BaseSettings):
     )
     TOP_K_DEFAULT: int = Field(default=3, description="Default number of search results returned by tool_search.")
     TOP_K_MAX: int = Field(default=10, description="Maximum number of search results tool_search will return per call.")
+    FROZEN_TOOLS_MODELS: list[str] = Field(
+        default=["claude-", "anthropic/claude-", "qwen/qwen3.8-max"],
+        description=(
+            "Prefix-matched model names that get a frozen tools array; schemas reach them only via "
+            "tool_search results. Empty list disables freezing."
+        ),
+    )
+    EMBED_SCHEMAS_IN_RESULTS: bool = Field(
+        default=True,
+        description=(
+            "Emergency valve: if False, tool_search results carry summaries only (pre-change "
+            "behaviour). Only meaningful with freezing also disabled."
+        ),
+    )
 
 
 settings = DeferredToolsSettings()

--- a/daiv/automation/agent/deferred/conf.py
+++ b/daiv/automation/agent/deferred/conf.py
@@ -25,8 +25,9 @@ class DeferredToolsSettings(BaseSettings):
     EMBED_SCHEMAS_IN_RESULTS: bool = Field(
         default=True,
         description=(
-            "Emergency valve: if False, tool_search results carry summaries only (pre-change "
-            "behaviour). Only meaningful with freezing also disabled."
+            "Emergency valve: if False, tool_search results carry summaries only and freezing is "
+            "forced off (a frozen model has no other way to receive schemas), so every model falls "
+            "back to the array-append + summary pre-change behaviour."
         ),
     )
 

--- a/daiv/automation/agent/deferred/prompt.py
+++ b/daiv/automation/agent/deferred/prompt.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
 _INSTRUCTIONS = """\
 ## `tool_search` (deferred tools)
 
-Some tools are deferred — only their names and summaries are loaded into your context. Their full schemas are not loaded until you call `tool_search` to load them. Once loaded, the tool stays available for the rest of the session and appears in your loaded tools.
+Some tools are deferred — only their names and summaries are loaded into your context. Their full schemas are not loaded until you call `tool_search` to load them. Once loaded, the tool is callable for the rest of the session. If you can no longer see a loaded tool's schema, call `tool_search` again.
 
 How to use:
 - Prefer `select` (a JSON array of exact tool names from `<available-deferred-tools>` below) — fastest and most precise.
@@ -17,7 +17,7 @@ How to use:
 - `select` must be an array, not a string. `["gitlab"]` is correct; `"[\"gitlab\"]"` or `"gitlab"` is not.
 
 Notes:
-- The list below is exhaustive and stable across the conversation. Use your loaded-tools view (not this list) to tell what is currently available.
+- The list below is exhaustive and stable across the conversation. It shows what *can* be loaded, not what you have already loaded this session.
 - When the user asks what tools or capabilities you have, include the deferred tools alongside your loaded tools, marked as deferred.
 
 <example>
@@ -29,10 +29,10 @@ Notes:
 def build_deferred_tools_block(index: DeferredToolsIndex) -> str:
     """Render the deferred-tools advertisement appended to the system prompt.
 
-    The output is intentionally independent of which tools have already been loaded:
-    any per-call variation in the system prompt invalidates Anthropic's prompt cache
-    from byte 0 (system message is hashed before tools/messages), which in observed
-    traces cost ~22k tokens of fresh cache creation per deferred-tool load.
+    The output is intentionally independent of which tools have already been loaded.
+    Anthropic hashes the cached prefix in tools → system → messages order, so a per-call
+    change to the system block invalidates the cache from the system block onward — in
+    observed traces ~22k tokens of fresh cache creation per deferred-tool load.
     """
     lines = [f"{entry.name}: {entry.summary}" for entry in index.deferred_entries()]
     if not lines:

--- a/daiv/automation/agent/deferred/search_tool.py
+++ b/daiv/automation/agent/deferred/search_tool.py
@@ -9,6 +9,7 @@ from langchain_core.messages import ToolMessage
 from langchain_core.utils.function_calling import convert_to_openai_tool
 from langgraph.types import Command
 from pydantic import BeforeValidator
+from pydantic.errors import PydanticInvalidForJsonSchema
 
 from automation.agent.deferred.conf import settings as deferred_settings
 from automation.agent.deferred.state import DeferredToolsState  # noqa: TC001
@@ -74,8 +75,12 @@ def _render_loaded(entries: list[ToolEntry]) -> str:
     With schema embedding on (default), each loaded tool's full OpenAI-format schema rides in a
     ``<functions>`` block so an allowlisted model can call it directly without the tool being in
     its bound array. Re-selecting an already-loaded name re-sends its schema, so a
-    summarization-evicted schema stays recoverable. With the valve off, falls back to name/summary
-    lines only (pre-change behaviour).
+    summarization-evicted schema stays recoverable. A tool whose args can't emit a JSON schema
+    (non-serializable arg types, e.g. ``git.Repo``) degrades to a summary-only
+    ``<function-summary>`` entry — on a frozen model that tool is then uncallable, hence the
+    warning-level log. Any other conversion fault degrades the same way but logs at error level
+    (it is unexpected, unlike the known git.Repo case) and never aborts the rest of the batch.
+    With the valve off, falls back to name/summary lines only (pre-change behaviour).
     """
     if not deferred_settings.EMBED_SCHEMAS_IN_RESULTS:
         body = "\n".join(f"- {entry.name}: {entry.summary}" for entry in entries)
@@ -85,8 +90,15 @@ def _render_loaded(entries: list[ToolEntry]) -> str:
     for entry in entries:
         try:
             schema = convert_to_openai_tool(entry.tool)
+        except PydanticInvalidForJsonSchema:
+            logger.warning("tool_search: no JSON schema for %s; embedding summary only", entry.name)
+            functions.append(f"<function-summary>{entry.name}: {entry.summary}</function-summary>")
+            continue
         except Exception:
-            logger.debug("tool_search: no JSON schema for %s; embedding summary only", entry.name)
+            # Contain an unexpected conversion fault to this one tool — a raise would abort the whole
+            # tool_search batch and drop every other selected tool. Log at error (Sentry) since,
+            # unlike the git.Repo case above, this is not a known-benign degradation.
+            logger.exception("tool_search: unexpected schema-conversion failure for %s; summary only", entry.name)
             functions.append(f"<function-summary>{entry.name}: {entry.summary}</function-summary>")
             continue
         functions.append(f"<function>{json.dumps(schema, separators=(',', ':'))}</function>")

--- a/daiv/automation/agent/deferred/search_tool.py
+++ b/daiv/automation/agent/deferred/search_tool.py
@@ -6,9 +6,11 @@ from typing import TYPE_CHECKING, Annotated
 
 from langchain.tools import ToolRuntime, tool
 from langchain_core.messages import ToolMessage
+from langchain_core.utils.function_calling import convert_to_openai_tool
 from langgraph.types import Command
 from pydantic import BeforeValidator
 
+from automation.agent.deferred.conf import settings as deferred_settings
 from automation.agent.deferred.state import DeferredToolsState  # noqa: TC001
 
 if TYPE_CHECKING:
@@ -16,7 +18,7 @@ if TYPE_CHECKING:
 
     from langchain_core.tools import BaseTool
 
-    from automation.agent.deferred.index import DeferredToolsIndex
+    from automation.agent.deferred.index import DeferredToolsIndex, ToolEntry
 
 logger = logging.getLogger("daiv.tools")
 
@@ -66,6 +68,33 @@ Examples (parameter values shown in JSON form):
   - query: "open pull request"                                # only when browsing by capability"""
 
 
+def _render_loaded(entries: list[ToolEntry]) -> str:
+    """Render the tool_search result body.
+
+    With schema embedding on (default), each loaded tool's full OpenAI-format schema rides in a
+    ``<functions>`` block so an allowlisted model can call it directly without the tool being in
+    its bound array. Re-selecting an already-loaded name re-sends its schema, so a
+    summarization-evicted schema stays recoverable. With the valve off, falls back to name/summary
+    lines only (pre-change behaviour).
+    """
+    if not deferred_settings.EMBED_SCHEMAS_IN_RESULTS:
+        body = "\n".join(f"- {entry.name}: {entry.summary}" for entry in entries)
+        return f"Loaded {len(entries)} tool(s):\n{body}"
+
+    functions: list[str] = []
+    for entry in entries:
+        try:
+            schema = convert_to_openai_tool(entry.tool)
+        except Exception:
+            logger.debug("tool_search: no JSON schema for %s; embedding summary only", entry.name)
+            functions.append(f"<function-summary>{entry.name}: {entry.summary}</function-summary>")
+            continue
+        functions.append(f"<function>{json.dumps(schema, separators=(',', ':'))}</function>")
+    body = "\n".join(functions)
+    header = f"Loaded {len(entries)} tool(s). Their full schemas follow — call them directly by name."
+    return f"{header}\n\n<functions>\n{body}\n</functions>"
+
+
 def make_tool_search(get_index: Callable[[], DeferredToolsIndex], *, top_k_default: int, top_k_max: int) -> BaseTool:
     async def tool_search(
         runtime: ToolRuntime[object, DeferredToolsState],
@@ -104,8 +133,7 @@ def make_tool_search(get_index: Callable[[], DeferredToolsIndex], *, top_k_defau
         existing = runtime.state.get("loaded_tool_names") or set()
         new_loaded = existing | {entry.name for entry in entries}
 
-        summary = "\n".join(f"- {entry.name}: {entry.summary}" for entry in entries)
-        content = f"Loaded {len(entries)} tool(s):\n{summary}"
+        content = _render_loaded(entries)
         if missing:
             content += f"\n\nIgnored unknown names: {', '.join(missing)}"
         return Command(

--- a/daiv/automation/agent/middlewares/deferred_tools.py
+++ b/daiv/automation/agent/middlewares/deferred_tools.py
@@ -26,14 +26,31 @@ def _model_name(model: object) -> str:
 
     ChatAnthropic exposes it on ``.model``; ChatOpenAI/ChatOpenRouter on ``.model_name``. A non-str
     (e.g. a test MagicMock attribute) yields "" so the caller treats it as non-frozen instead of
-    crashing on ``.startswith``.
+    crashing on ``.startswith``. A real (non-None) model reaching that fallback is a
+    misconfiguration or an upstream shape change that silently forfeits the cache benefit, so it is
+    logged rather than swallowed.
     """
     name = getattr(model, "model_name", None) or getattr(model, "model", None)
-    return name if isinstance(name, str) else ""
+    if isinstance(name, str):
+        return name
+    if model is not None:
+        logger.warning(
+            "deferred-tools: model %s exposes no str name attribute; treating as non-frozen (cache not preserved)",
+            type(model).__name__,
+        )
+    return ""
 
 
 def _is_frozen(model: object) -> bool:
-    """Whether this model gets a frozen tools array (schemas reach it via tool_search results only)."""
+    """Whether this model gets a frozen tools array (schemas reach it via tool_search results only).
+
+    Freezing is off whenever ``EMBED_SCHEMAS_IN_RESULTS`` is off: a frozen model gets its schemas
+    only from tool_search results, so with embedding disabled it would get neither bound tools nor
+    embedded schemas and could call nothing. Forcing freezing off there degrades that config to the
+    array-append + summary (pre-change) behaviour for every model instead of breaking frozen ones.
+    """
+    if not deferred_settings.EMBED_SCHEMAS_IN_RESULTS:
+        return False
     prefixes = tuple(deferred_settings.FROZEN_TOOLS_MODELS)
     return bool(prefixes) and _model_name(model).startswith(prefixes)
 
@@ -99,12 +116,6 @@ class DeferredToolsMiddleware(AgentMiddleware):
             self._index = self._build_index(request.tools)
 
         loaded_names: set[str] = request.state.get("loaded_tool_names") or set()
-        # Iterate the index in its (insertion-ordered) registration order, not the `loaded_names`
-        # set. Set iteration is not contractually stable across CPython versions, and any
-        # reordering of the tools array invalidates Anthropic's cached prefix.
-        loaded_tools: list[BaseTool] = [
-            entry.tool for entry in self._index.deferred_entries() if entry.name in loaded_names
-        ]
         if loaded_names:
             stale = sorted(loaded_names - set(self._index.names()))
             if stale:
@@ -129,9 +140,16 @@ class DeferredToolsMiddleware(AgentMiddleware):
                 allowed.append(tool)
                 seen_names.add(tool.name)
 
-        # Allowlisted models get a frozen array (schemas arrive via tool_search results, Task 1);
+        # Allowlisted models get a frozen array (schemas arrive via tool_search results);
         # everyone else keeps the append. Evaluated per call, so a mid-run fallback model is gated right.
-        new_tools = allowed if _is_frozen(request.model) else [*allowed, *loaded_tools]
+        if _is_frozen(request.model):
+            new_tools = allowed
+        else:
+            # Iterate the index in its (insertion-ordered) registration order, not the `loaded_names`
+            # set. Set iteration is not contractually stable across CPython versions, and any
+            # reordering of the tools array invalidates Anthropic's cached prefix.
+            loaded_tools = [entry.tool for entry in self._index.deferred_entries() if entry.name in loaded_names]
+            new_tools = [*allowed, *loaded_tools]
 
         response = await handler(request.override(tools=new_tools, system_prompt=new_system_prompt))
         self._inject_corrective_messages(response, loaded_names)

--- a/daiv/automation/agent/middlewares/deferred_tools.py
+++ b/daiv/automation/agent/middlewares/deferred_tools.py
@@ -21,12 +21,31 @@ if TYPE_CHECKING:
 logger = logging.getLogger("daiv.tools")
 
 
+def _model_name(model: object) -> str:
+    """Best-effort model-name string from a BaseChatModel instance.
+
+    ChatAnthropic stores it on ``.model`` (alias ``model_name``); ChatOpenAI/ChatOpenRouter on
+    ``.model_name``. A non-str (e.g. a test MagicMock attribute) yields "" so the caller treats it
+    as non-frozen instead of crashing on ``.startswith``.
+    """
+    name = getattr(model, "model_name", None) or getattr(model, "model", None)
+    return name if isinstance(name, str) else ""
+
+
+def _is_frozen(model: object) -> bool:
+    """Whether this model gets a frozen tools array (schemas reach it via tool_search results only)."""
+    prefixes = tuple(deferred_settings.FROZEN_TOOLS_MODELS)
+    return bool(prefixes) and _model_name(model).startswith(prefixes)
+
+
 class DeferredToolsMiddleware(AgentMiddleware):
     """Defers every tool not in ``always_loaded`` behind a ``tool_search`` capability.
 
     On the first model call, the middleware snapshots the union of ``request.tools`` and
-    ``extra_tools``, sends only the always-loaded tools (plus already-loaded deferred ones)
-    to the model, and indexes the rest for ``tool_search``. Subsequent calls reuse the index.
+    ``extra_tools``, sends the always-loaded tools to the model, and indexes the rest for
+    ``tool_search``. On allowlisted models (``FROZEN_TOOLS_MODELS``) the bound array stays frozen
+    and loaded schemas arrive via ``tool_search`` results; off the allowlist, already-loaded
+    deferred tools are appended to the array as before. Subsequent calls reuse the index.
     """
 
     state_schema = DeferredToolsState
@@ -103,13 +122,16 @@ class DeferredToolsMiddleware(AgentMiddleware):
             if tool.name in self._always_loaded and tool.name not in seen_names:
                 allowed.append(tool)
                 seen_names.add(tool.name)
-        # Surface any always-loaded extra_tools the request doesn't already carry.
-        for tool in self._extra_tools:
+        # Surface any always-loaded tools the request doesn't already carry (self.tools includes
+        # tool_search itself and all extra_tools).
+        for tool in self.tools:
             if tool.name in self._always_loaded and tool.name not in seen_names:
                 allowed.append(tool)
                 seen_names.add(tool.name)
 
-        new_tools = [*allowed, *loaded_tools]
+        # Allowlisted models get a frozen array (schemas arrive via tool_search results, Task 1);
+        # everyone else keeps the append. Evaluated per call, so a mid-run fallback model is gated right.
+        new_tools = allowed if _is_frozen(request.model) else [*allowed, *loaded_tools]
 
         response = await handler(request.override(tools=new_tools, system_prompt=new_system_prompt))
         self._inject_corrective_messages(response, loaded_names)
@@ -169,7 +191,9 @@ def deferred_tools_middleware(always_loaded: Iterable[str], mcp_tools: list[Base
     Installed whenever deferral is enabled — both the main agent and the general-purpose/custom
     subagents keep only the file/bash/todo core eagerly bound, so they always have non-always-loaded
     tools (web search/fetch, git-platform, and any MCP tools) to defer. A loaded deferred tool stays
-    loaded for the rest of the session, so the cost is at most one ``tool_search`` per session.
+    loaded for the rest of the session; the agent discovers tool needs incrementally, so expect
+    several ``tool_search`` calls per session — on allowlisted models each merely extends the cached
+    prefix instead of rewriting it.
     """
     if not deferred_settings.ENABLED:
         return []

--- a/daiv/automation/agent/middlewares/deferred_tools.py
+++ b/daiv/automation/agent/middlewares/deferred_tools.py
@@ -24,9 +24,9 @@ logger = logging.getLogger("daiv.tools")
 def _model_name(model: object) -> str:
     """Best-effort model-name string from a BaseChatModel instance.
 
-    ChatAnthropic stores it on ``.model`` (alias ``model_name``); ChatOpenAI/ChatOpenRouter on
-    ``.model_name``. A non-str (e.g. a test MagicMock attribute) yields "" so the caller treats it
-    as non-frozen instead of crashing on ``.startswith``.
+    ChatAnthropic exposes it on ``.model``; ChatOpenAI/ChatOpenRouter on ``.model_name``. A non-str
+    (e.g. a test MagicMock attribute) yields "" so the caller treats it as non-frozen instead of
+    crashing on ``.startswith``.
     """
     name = getattr(model, "model_name", None) or getattr(model, "model", None)
     return name if isinstance(name, str) else ""

--- a/daiv/automation/agent/subagents.py
+++ b/daiv/automation/agent/subagents.py
@@ -77,12 +77,11 @@ def _general_purpose_system_prompt(working_directory: str) -> str:
 """  # noqa: E501
 
 
-# Tools kept eagerly bound on a subagent's model; web search/fetch, git-platform, and the MCP toolset
-# are all deferred behind tool_search — the same policy as the main agent. This mirrors
-# ALWAYS_LOADED_TOOLS (graph.py) minus `skill`/`task` (subagents spawn neither). A deferred tool stays
-# loaded for the rest of the subagent's session once loaded, so a delegate that needs web/git pays at
-# most one tool_search. DAIV-owned tool names reference their canonical constant; deepagents-provided
-# names (filesystem, write_todos) stay as literals.
+# ALWAYS_LOADED_TOOLS (graph.py) minus `skill`/`task` (subagents spawn neither). A deferred tool
+# stays loaded for the rest of the subagent's session once loaded; a delegate discovers needs
+# incrementally, so expect several tool_search calls across a session. DAIV-owned tool names
+# reference their canonical constant; deepagents-provided names (filesystem, write_todos) stay as
+# literals.
 SUBAGENT_ALWAYS_LOADED_TOOLS = frozenset({
     "ls",
     "read_file",

--- a/docs/reference/env-variables.md
+++ b/docs/reference/env-variables.md
@@ -319,6 +319,8 @@ When enabled, tools outside the always-loaded set are deferred behind a `tool_se
 | `DEFERRED_TOOLS_ENABLED`        | Defer non-essential tools behind `tool_search` instead of binding them eagerly | `true` | `false` |
 | `DEFERRED_TOOLS_TOP_K_DEFAULT`  | Default number of results returned by a `tool_search` call     | `3`            | `5` |
 | `DEFERRED_TOOLS_TOP_K_MAX`      | Maximum number of results `tool_search` will return per call   | `10`           | `20` |
+| `DEFERRED_TOOLS_FROZEN_TOOLS_MODELS` | Prefix-matched model names whose bound tools array is kept frozen (loaded schemas reach them via `tool_search` results only), preserving the provider prompt cache. Empty list disables freezing. | `claude-,anthropic/claude-,qwen/qwen3.8-max` | `claude-` |
+| `DEFERRED_TOOLS_EMBED_SCHEMAS_IN_RESULTS` | Embed each loaded tool's full schema in the `tool_search` result. Emergency valve: when `false`, results carry summaries only **and freezing is forced off** (a frozen model has no other way to receive schemas), so every model falls back to the array-append + summary pre-change behaviour. | `true` | `false` |
 
 ---
 

--- a/tests/integration_tests/test_deferred_tools_frozen.py
+++ b/tests/integration_tests/test_deferred_tools_frozen.py
@@ -1,0 +1,132 @@
+"""Live gate for adding a model to DEFERRED_TOOLS_FROZEN_TOOLS_MODELS.
+
+Excluded from ``make test`` (lives under tests/integration_tests). Requires real provider keys;
+each parametrization is skipped when its key is absent. Three modes per model:
+
+  * Mode 1 (fallback): schema in the tool_search result AND the tool bound. Must PASS for every
+    model — this is the non-allowlisted production shape.
+  * Mode 2 (frozen): schema in the result, tool NOT bound. Must PASS to allowlist the model.
+  * Mode 3 (control): summary only, no schema, tool not bound. Must NOT yield correct typed args —
+    proves a mode-1/2 pass really measures schema-reading.
+
+``max_notes``/``include_resolved`` are unguessable from the tool name, so correct args prove the
+schema was read rather than the name pattern-matched.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
+from langchain_core.tools import StructuredTool
+from langchain_core.utils.function_calling import convert_to_openai_tool
+from pydantic import BaseModel, Field
+
+from automation.agent import BaseAgent
+from automation.agent.deferred.index import DeferredToolsIndex
+from automation.agent.deferred.prompt import build_deferred_tools_block
+from automation.agent.deferred.search_tool import TOOL_SEARCH_NAME, make_tool_search
+
+from .utils import require_provider_for_model
+
+TOOL_NAME = "rt_fetch_ticket_digest"
+
+
+def _digest_tool() -> StructuredTool:
+    class _Args(BaseModel):
+        ticket: str = Field(description="Ticket identifier to summarize.")
+        max_notes: int = Field(default=5, description="Maximum number of correspondence notes to include.")
+        include_resolved: bool = Field(default=False, description="Whether to include resolved child tickets.")
+
+    def _run(ticket: str, max_notes: int = 5, include_resolved: bool = False) -> str:
+        return "digest"
+
+    return StructuredTool.from_function(
+        func=_run, name=TOOL_NAME, description="Fetch a condensed digest of an RT ticket.", args_schema=_Args
+    )
+
+
+def _conversation(*, embed_schema: bool) -> list:
+    tool = _digest_tool()
+    index = DeferredToolsIndex([tool])
+    if embed_schema:
+        schema = convert_to_openai_tool(tool)
+        result = (
+            "Loaded 1 tool(s). Their full schemas follow — call them directly by name.\n\n"
+            f"<functions>\n<function>{json.dumps(schema, separators=(',', ':'))}</function>\n</functions>"
+        )
+    else:
+        result = f"Loaded 1 tool(s):\n- {TOOL_NAME}: Fetch a condensed digest of an RT ticket."
+
+    return [
+        SystemMessage(content=build_deferred_tools_block(index)),
+        HumanMessage(content="Fetch a digest of ticket ABC-123, at most 3 notes, and skip resolved children."),
+        AIMessage(
+            content="",
+            tool_calls=[
+                {"name": TOOL_SEARCH_NAME, "id": "call_ts", "args": {"select": [TOOL_NAME]}, "type": "tool_call"}
+            ],
+        ),
+        ToolMessage(content=result, tool_call_id="call_ts"),
+    ]
+
+
+def _bound_model(model_spec: str, *, bind_digest: bool):
+    model = BaseAgent.get_model(model=model_spec)
+    tools = [make_tool_search(lambda: DeferredToolsIndex([_digest_tool()]), top_k_default=5, top_k_max=10)]
+    if bind_digest:
+        tools.append(_digest_tool())
+    return model.bind_tools(tools)
+
+
+def _called_digest_with_typed_args(response: AIMessage) -> bool:
+    for call in response.tool_calls or []:
+        if call.get("name") != TOOL_NAME:
+            continue
+        args = call.get("args") or {}
+        # A real schema read yields the unguessable param names; string coercions ("3"/"true") count.
+        return "max_notes" in args or "include_resolved" in args
+    return False
+
+
+# (model_spec, is_allowlist_candidate). Candidates must also pass Mode 2; non-candidates need only
+# Mode 1. See the spec's verification matrix.
+_MODELS = [
+    pytest.param("openrouter:anthropic/claude-sonnet-4.6", True, id="openrouter-claude-sonnet"),
+    pytest.param("openrouter:z-ai/glm-5.1", False, id="openrouter-glm"),
+    pytest.param("openrouter:openai/gpt-5.3-codex", False, id="openrouter-gpt-codex"),
+]
+
+
+@pytest.mark.deferred_frozen
+@pytest.mark.parametrize("model_spec,is_candidate", _MODELS)
+async def test_mode1_fallback_reaches_tool(model_spec, is_candidate):
+    require_provider_for_model(model_spec)
+    model = _bound_model(model_spec, bind_digest=True)
+    response = await model.ainvoke(_conversation(embed_schema=True))
+    assert _called_digest_with_typed_args(response), f"Mode 1 must pass for every model; {model_spec} did not"
+
+
+@pytest.mark.deferred_frozen
+@pytest.mark.parametrize("model_spec,is_candidate", _MODELS)
+async def test_mode2_frozen_reaches_tool(model_spec, is_candidate):
+    require_provider_for_model(model_spec)
+    model = _bound_model(model_spec, bind_digest=False)
+    response = await model.ainvoke(_conversation(embed_schema=True))
+    passed = _called_digest_with_typed_args(response)
+    if is_candidate:
+        assert passed, f"Allowlist candidate {model_spec} failed Mode 2 (frozen array) — do not allowlist it"
+    elif not passed:
+        pytest.xfail(f"{model_spec} is a known Mode-2 non-passer (livelocks on the frozen array)")
+
+
+@pytest.mark.deferred_frozen
+@pytest.mark.parametrize("model_spec,is_candidate", _MODELS)
+async def test_mode3_control_does_not_reach_tool(model_spec, is_candidate):
+    require_provider_for_model(model_spec)
+    model = _bound_model(model_spec, bind_digest=False)
+    response = await model.ainvoke(_conversation(embed_schema=False))
+    assert not _called_digest_with_typed_args(response), (
+        f"Control violated: {model_spec} produced correct args with no schema present"
+    )

--- a/tests/unit_tests/automation/agent/deferred/test_prompt.py
+++ b/tests/unit_tests/automation/agent/deferred/test_prompt.py
@@ -49,3 +49,18 @@ class TestBuildDeferredToolsBlock:
         index = DeferredToolsIndex(tools)
         block = build_deferred_tools_block(index)
         assert "tool_search" in block
+
+    def test_advertisement_is_mechanism_neutral(self):
+        index = DeferredToolsIndex([_make_tool("github_create_issue", "Create issue")])
+        block = build_deferred_tools_block(index)
+
+        # Mechanism-neutral: no array-membership phrasing that would mislead the frozen-array path.
+        assert "appears in your loaded tools" not in block
+        assert "loaded-tools view" not in block
+        assert "callable for the rest of the session" in block
+
+    def test_advertisement_has_self_heal_line(self):
+        index = DeferredToolsIndex([_make_tool("github_create_issue", "Create issue")])
+        block = build_deferred_tools_block(index)
+
+        assert "call `tool_search` again" in block

--- a/tests/unit_tests/automation/agent/deferred/test_search_tool.py
+++ b/tests/unit_tests/automation/agent/deferred/test_search_tool.py
@@ -142,3 +142,58 @@ class TestToolSearch:
         assert isinstance(result, Command)
         assert "loaded_tool_names" not in result.update
         assert "42" in result.update["messages"][0].content
+
+
+class TestToolSearchSchemaDelivery:
+    def _index_with_typed_tool(self):
+        from pydantic import BaseModel, Field
+
+        class _Args(BaseModel):
+            ticket: str = Field(description="Ticket identifier.")
+            max_notes: int = Field(default=5, description="Max correspondence notes.")
+
+        def _run(ticket: str, max_notes: int = 5) -> str:
+            return "ok"
+
+        tool = StructuredTool.from_function(
+            func=_run, name="rt_fetch_ticket_digest", description="Fetch a ticket digest.", args_schema=_Args
+        )
+        return DeferredToolsIndex([tool])
+
+    async def test_result_embeds_full_schema_in_functions_block(self):
+        tool_search = make_tool_search(lambda: self._index_with_typed_tool(), top_k_default=5, top_k_max=10)
+
+        result = await tool_search.ainvoke({"query": "", "select": ["rt_fetch_ticket_digest"], "runtime": _runtime()})
+
+        content = result.update["messages"][0].content
+        assert "<functions>" in content and "</functions>" in content
+        assert "rt_fetch_ticket_digest" in content
+        # The schema's real parameter names ride in the result — this is what a frozen-array model reads.
+        assert "max_notes" in content
+        assert "ticket" in content
+
+    async def test_reselecting_loaded_name_resends_schema(self):
+        # Idempotent re-delivery: a summarization-evicted (or migration-inherited) schema is
+        # recoverable by re-searching. No short-circuit on already-loaded names.
+        tool_search = make_tool_search(lambda: self._index_with_typed_tool(), top_k_default=5, top_k_max=10)
+        runtime = _runtime({"loaded_tool_names": {"rt_fetch_ticket_digest"}})
+
+        result = await tool_search.ainvoke({"query": "", "select": ["rt_fetch_ticket_digest"], "runtime": runtime})
+
+        content = result.update["messages"][0].content
+        assert "<functions>" in content
+        assert "max_notes" in content
+        assert result.update["loaded_tool_names"] == {"rt_fetch_ticket_digest"}
+
+    async def test_valve_off_returns_summaries_only(self, monkeypatch):
+        from automation.agent.deferred import search_tool as search_tool_module
+
+        monkeypatch.setattr(search_tool_module.deferred_settings, "EMBED_SCHEMAS_IN_RESULTS", False)
+        tool_search = make_tool_search(lambda: self._index_with_typed_tool(), top_k_default=5, top_k_max=10)
+
+        result = await tool_search.ainvoke({"query": "", "select": ["rt_fetch_ticket_digest"], "runtime": _runtime()})
+
+        content = result.update["messages"][0].content
+        assert "<functions>" not in content
+        assert "rt_fetch_ticket_digest" in content
+        assert "Fetch a ticket digest." in content

--- a/tests/unit_tests/automation/agent/deferred/test_search_tool.py
+++ b/tests/unit_tests/automation/agent/deferred/test_search_tool.py
@@ -197,3 +197,76 @@ class TestToolSearchSchemaDelivery:
         assert "<functions>" not in content
         assert "rt_fetch_ticket_digest" in content
         assert "Fetch a ticket digest." in content
+
+    def _index_with_unconvertible_tool(self):
+        from pydantic import BaseModel, ConfigDict, Field
+
+        class _Unserializable:
+            pass
+
+        class _Args(BaseModel):
+            model_config = ConfigDict(arbitrary_types_allowed=True)
+            repo: _Unserializable = Field(description="Non-serializable handle.")
+
+        def _run(repo) -> str:
+            return "ok"
+
+        tool = StructuredTool.from_function(
+            func=_run, name="bad_tool", description="Tool with a non-serializable arg.", args_schema=_Args
+        )
+        return DeferredToolsIndex([tool])
+
+    async def test_unconvertible_tool_degrades_to_summary_and_warns(self, caplog):
+        # A tool whose args reference a non-serializable type (mirrors index.py's git.Repo case)
+        # can't emit a JSON schema: the result degrades to a <function-summary> rather than aborting,
+        # and warns (not debug) because on a frozen model that tool is then uncallable.
+        import logging
+
+        tool_search = make_tool_search(lambda: self._index_with_unconvertible_tool(), top_k_default=5, top_k_max=10)
+
+        with caplog.at_level(logging.WARNING, logger="daiv.tools"):
+            result = await tool_search.ainvoke({"query": "", "select": ["bad_tool"], "runtime": _runtime()})
+
+        content = result.update["messages"][0].content
+        assert "<function-summary>" in content
+        assert "bad_tool" in content
+        assert "<function>" not in content
+        assert result.update["loaded_tool_names"] == {"bad_tool"}
+        assert any(r.levelname == "WARNING" and "bad_tool" in r.getMessage() for r in caplog.records)
+
+    async def test_unexpected_conversion_error_is_contained_per_tool(self, monkeypatch, caplog):
+        # A non-Pydantic conversion fault (ValueError/TypeError from convert_to_openai_tool) must not
+        # abort the whole batch: the offending tool degrades to a summary, siblings still load, and it
+        # logs at error level (unlike the known git.Repo case, which warns).
+        import logging
+
+        from automation.agent.deferred import search_tool as search_tool_module
+
+        good = StructuredTool.from_function(func=lambda ticket: "ok", name="good_tool", description="Converts fine.")
+        bad = StructuredTool.from_function(
+            func=lambda ticket: "ok", name="explodes", description="Trips an unexpected fault."
+        )
+        index = DeferredToolsIndex([good, bad])
+
+        real = search_tool_module.convert_to_openai_tool
+
+        def _flaky(tool):
+            if tool.name == "explodes":
+                raise ValueError("simulated non-pydantic conversion fault")
+            return real(tool)
+
+        monkeypatch.setattr(search_tool_module, "convert_to_openai_tool", _flaky)
+        tool_search = make_tool_search(lambda: index, top_k_default=5, top_k_max=10)
+
+        with caplog.at_level(logging.ERROR, logger="daiv.tools"):
+            result = await tool_search.ainvoke({
+                "query": "",
+                "select": ["good_tool", "explodes"],
+                "runtime": _runtime(),
+            })
+
+        content = result.update["messages"][0].content
+        assert "<function>" in content  # the good tool still loaded despite the sibling's failure
+        assert "<function-summary>explodes:" in content
+        assert result.update["loaded_tool_names"] == {"good_tool", "explodes"}
+        assert any(r.levelname == "ERROR" and "explodes" in r.getMessage() for r in caplog.records)

--- a/tests/unit_tests/automation/agent/middlewares/test_deferred_tools.py
+++ b/tests/unit_tests/automation/agent/middlewares/test_deferred_tools.py
@@ -1,3 +1,4 @@
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 from langchain_core.tools import StructuredTool
@@ -9,17 +10,21 @@ def _make_tool(name: str, description: str) -> StructuredTool:
     return StructuredTool.from_function(func=lambda **kwargs: "ok", name=name, description=description)
 
 
-def _request(*, system_prompt: str = "", tools: list | None = None, state: dict | None = None) -> MagicMock:
+def _request(
+    *, system_prompt: str = "", tools: list | None = None, state: dict | None = None, model: object | None = None
+) -> MagicMock:
     request = MagicMock()
     request.system_prompt = system_prompt
     request.tools = list(tools or [])
     request.state = state or {}
+    request.model = model  # None → _model_name() == "" → non-frozen (today's behaviour)
 
     def _override(**kwargs) -> MagicMock:
         new = MagicMock()
         new.system_prompt = kwargs.get("system_prompt", request.system_prompt)
         new.tools = kwargs.get("tools", request.tools)
         new.state = request.state
+        new.model = request.model
         new.override = _override
         return new
 
@@ -355,3 +360,110 @@ class TestDeferredToolsMiddlewareCorrectiveMessages:
 
         assert "removed_tool" in caplog.text
         assert "github_create_issue" not in [t.name for t in captured["tools"]]
+
+
+class TestDeferredToolsMiddlewareFrozenBinding:
+    @staticmethod
+    def _frozen_model():
+        # ChatAnthropic exposes the name on ``.model`` — native Anthropic name matches the
+        # "claude-" prefix in the default allowlist.
+        return SimpleNamespace(model="claude-sonnet-5")
+
+    @staticmethod
+    def _non_frozen_model():
+        # ChatOpenAI/ChatOpenRouter expose the name on ``.model_name``; GLM is not allowlisted.
+        return SimpleNamespace(model_name="z-ai/glm-5.2")
+
+    async def test_frozen_array_identical_regardless_of_loaded_state(self, monkeypatch):
+        # THE core invariant: for an allowlisted model the bound tools array is a pure function of
+        # always_loaded + extra_tools — byte-identical whether loaded_tool_names is empty or full.
+        from automation.agent.middlewares import deferred_tools as mw_module
+
+        monkeypatch.setattr(mw_module.deferred_settings, "FROZEN_TOOLS_MODELS", ["claude-"])
+        a = _make_tool("a_tool", "A")
+        b = _make_tool("b_tool", "B")
+        middleware = DeferredToolsMiddleware(always_loaded=set(), extra_tools=[a, b])
+
+        captured: list[list[str]] = []
+
+        async def handler(req):
+            captured.append([t.name for t in req.tools])
+            return MagicMock()
+
+        model = self._frozen_model()
+        await middleware.awrap_model_call(_request(state={}, model=model), handler)
+        await middleware.awrap_model_call(
+            _request(state={"loaded_tool_names": {"a_tool", "b_tool"}}, model=model), handler
+        )
+
+        assert captured[0] == captured[1]
+        assert captured[0] == ["tool_search"]  # loaded tools are delivered via content, never bound
+
+    async def test_non_allowlisted_model_retains_array_append(self, monkeypatch):
+        from automation.agent.middlewares import deferred_tools as mw_module
+
+        monkeypatch.setattr(mw_module.deferred_settings, "FROZEN_TOOLS_MODELS", ["claude-"])
+        a = _make_tool("a_tool", "A")
+        b = _make_tool("b_tool", "B")
+        middleware = DeferredToolsMiddleware(always_loaded=set(), extra_tools=[a, b])
+
+        captured: list[list[str]] = []
+
+        async def handler(req):
+            captured.append([t.name for t in req.tools])
+            return MagicMock()
+
+        model = self._non_frozen_model()
+        await middleware.awrap_model_call(_request(state={"loaded_tool_names": {"b_tool"}}, model=model), handler)
+        await middleware.awrap_model_call(
+            _request(state={"loaded_tool_names": {"a_tool", "b_tool"}}, model=model), handler
+        )
+
+        deferred_only = [[n for n in step if n != "tool_search"] for step in captured]
+        assert deferred_only == [["b_tool"], ["a_tool", "b_tool"]]  # index order, appended as today
+
+    async def test_frozen_post_eviction_array_stays_frozen(self, monkeypatch):
+        # Migration / post-summarization shape: loaded_tool_names is populated but no schema is in
+        # the (mocked-away) message history. The frozen array must NOT re-bind the tool — recovery
+        # is the model re-calling tool_search (idempotent re-delivery, Task 1), not array membership.
+        from automation.agent.middlewares import deferred_tools as mw_module
+
+        monkeypatch.setattr(mw_module.deferred_settings, "FROZEN_TOOLS_MODELS", ["claude-"])
+        github = _make_tool("github_create_issue", "Create issue")
+        middleware = DeferredToolsMiddleware(always_loaded=set(), extra_tools=[github])
+
+        captured: dict = {}
+
+        async def handler(req):
+            captured["tools"] = [t.name for t in req.tools]
+            return MagicMock()
+
+        await middleware.awrap_model_call(
+            _request(state={"loaded_tool_names": {"github_create_issue"}}, model=self._frozen_model()), handler
+        )
+
+        assert "github_create_issue" not in captured["tools"]
+        assert captured["tools"] == ["tool_search"]
+
+    async def test_frozen_model_still_gets_corrective_for_unloaded_tool(self, monkeypatch):
+        from langchain.agents.middleware.types import ModelResponse
+        from langchain_core.messages import AIMessage, ToolMessage
+
+        from automation.agent.middlewares import deferred_tools as mw_module
+
+        monkeypatch.setattr(mw_module.deferred_settings, "FROZEN_TOOLS_MODELS", ["claude-"])
+        github = _make_tool("github_create_issue", "Create issue")
+        middleware = DeferredToolsMiddleware(always_loaded=set(), extra_tools=[github])
+
+        ai_message = AIMessage(
+            content="", tool_calls=[{"name": "github_create_issue", "id": "call_z", "args": {}, "type": "tool_call"}]
+        )
+
+        async def handler(req):
+            return ModelResponse(result=[ai_message])
+
+        result = await middleware.awrap_model_call(_request(state={}, model=self._frozen_model()), handler)
+
+        tool_messages = [m for m in result.result if isinstance(m, ToolMessage)]
+        assert len(tool_messages) == 1
+        assert "tool_search" in tool_messages[0].content

--- a/tests/unit_tests/automation/agent/middlewares/test_deferred_tools.py
+++ b/tests/unit_tests/automation/agent/middlewares/test_deferred_tools.py
@@ -374,6 +374,32 @@ class TestDeferredToolsMiddlewareFrozenBinding:
         # ChatOpenAI/ChatOpenRouter expose the name on ``.model_name``; GLM is not allowlisted.
         return SimpleNamespace(model_name="z-ai/glm-5.2")
 
+    async def test_stale_loaded_name_still_warns_on_frozen_path(self, monkeypatch, caplog):
+        # The stale-name diagnostic sits before the frozen/non-frozen split, so it must fire even for
+        # a frozen model (whose loaded_tools list is never built). Pins it to that position: moving it
+        # into the else branch would silence the warning for exactly the allowlisted (Claude) models.
+        import logging
+
+        from automation.agent.middlewares import deferred_tools as mw_module
+
+        monkeypatch.setattr(mw_module.deferred_settings, "FROZEN_TOOLS_MODELS", ["claude-"])
+        github = _make_tool("github_create_issue", "Create issue")
+        middleware = DeferredToolsMiddleware(always_loaded=set(), extra_tools=[github])
+
+        captured: dict = {}
+
+        async def handler(req):
+            captured["tools"] = [t.name for t in req.tools]
+            return MagicMock()
+
+        with caplog.at_level(logging.WARNING, logger="daiv.tools"):
+            await middleware.awrap_model_call(
+                _request(state={"loaded_tool_names": {"removed_tool"}}, model=self._frozen_model()), handler
+            )
+
+        assert "removed_tool" in caplog.text
+        assert captured["tools"] == ["tool_search"]  # frozen array: stale name warned, never bound
+
     async def test_frozen_array_identical_regardless_of_loaded_state(self, monkeypatch):
         # THE core invariant: for an allowlisted model the bound tools array is a pure function of
         # always_loaded + extra_tools — byte-identical whether loaded_tool_names is empty or full.
@@ -467,3 +493,83 @@ class TestDeferredToolsMiddlewareFrozenBinding:
         tool_messages = [m for m in result.result if isinstance(m, ToolMessage)]
         assert len(tool_messages) == 1
         assert "tool_search" in tool_messages[0].content
+
+    async def test_empty_allowlist_disables_freezing(self, monkeypatch):
+        # The documented kill-switch / rollback lever: an empty FROZEN_TOOLS_MODELS turns freezing
+        # off even for a claude- model, so the array reverts to the append shape.
+        from automation.agent.middlewares import deferred_tools as mw_module
+
+        monkeypatch.setattr(mw_module.deferred_settings, "FROZEN_TOOLS_MODELS", [])
+        a = _make_tool("a_tool", "A")
+        middleware = DeferredToolsMiddleware(always_loaded=set(), extra_tools=[a])
+
+        captured: dict = {}
+
+        async def handler(req):
+            captured["tools"] = [t.name for t in req.tools]
+            return MagicMock()
+
+        await middleware.awrap_model_call(
+            _request(state={"loaded_tool_names": {"a_tool"}}, model=self._frozen_model()), handler
+        )
+
+        assert "a_tool" in captured["tools"]  # appended despite the claude- model, because the allowlist is empty
+
+    async def test_embed_off_gracefully_degrades_frozen_model_to_append(self, monkeypatch):
+        # The footgun guard: EMBED_SCHEMAS_IN_RESULTS=False can't deliver schemas to a frozen model,
+        # so freezing is forced off and even an allowlisted claude- model gets the tool bound in the
+        # array (pre-change behaviour) instead of an empty, uncallable array.
+        from automation.agent.middlewares import deferred_tools as mw_module
+
+        monkeypatch.setattr(mw_module.deferred_settings, "FROZEN_TOOLS_MODELS", ["claude-"])
+        monkeypatch.setattr(mw_module.deferred_settings, "EMBED_SCHEMAS_IN_RESULTS", False)
+        a = _make_tool("a_tool", "A")
+        middleware = DeferredToolsMiddleware(always_loaded=set(), extra_tools=[a])
+
+        captured: dict = {}
+
+        async def handler(req):
+            captured["tools"] = [t.name for t in req.tools]
+            return MagicMock()
+
+        await middleware.awrap_model_call(
+            _request(state={"loaded_tool_names": {"a_tool"}}, model=self._frozen_model()), handler
+        )
+
+        assert "a_tool" in captured["tools"]  # bound despite the claude- model, because embedding is off
+
+
+class TestModelNameGating:
+    def test_model_name_prefers_model_name_then_model(self):
+        from automation.agent.middlewares import deferred_tools as mw_module
+
+        assert mw_module._model_name(SimpleNamespace(model_name="gpt-x")) == "gpt-x"
+        assert mw_module._model_name(SimpleNamespace(model="claude-x")) == "claude-x"
+        assert mw_module._model_name(None) == ""
+
+    def test_empty_allowlist_is_never_frozen(self, monkeypatch):
+        from automation.agent.middlewares import deferred_tools as mw_module
+
+        monkeypatch.setattr(mw_module.deferred_settings, "FROZEN_TOOLS_MODELS", [])
+        assert mw_module._is_frozen(SimpleNamespace(model="claude-sonnet-5")) is False
+
+    def test_embed_off_forces_non_frozen_even_for_allowlisted_model(self, monkeypatch):
+        # A frozen model receives schemas only via tool_search results, so freezing must be off
+        # when embedding is off — otherwise it would get neither bound tools nor embedded schemas.
+        from automation.agent.middlewares import deferred_tools as mw_module
+
+        monkeypatch.setattr(mw_module.deferred_settings, "FROZEN_TOOLS_MODELS", ["claude-"])
+        monkeypatch.setattr(mw_module.deferred_settings, "EMBED_SCHEMAS_IN_RESULTS", False)
+        assert mw_module._is_frozen(SimpleNamespace(model="claude-sonnet-5")) is False
+
+    def test_non_str_model_name_degrades_to_non_frozen_and_warns(self, monkeypatch, caplog):
+        # The isinstance guard: a model whose name attribute isn't a str (unexpected shape) must
+        # degrade to non-frozen instead of crashing on .startswith — and warn so it's visible.
+        import logging
+
+        from automation.agent.middlewares import deferred_tools as mw_module
+
+        monkeypatch.setattr(mw_module.deferred_settings, "FROZEN_TOOLS_MODELS", ["claude-"])
+        with caplog.at_level(logging.WARNING, logger="daiv.tools"):
+            assert mw_module._is_frozen(MagicMock()) is False
+        assert "no str name attribute" in caplog.text


### PR DESCRIPTION
## Summary

Stops `DeferredToolsMiddleware` from mutating the bound tools array mid-conversation on allowlisted models, so `tool_search` no longer invalidates the provider prompt cache. Loaded tool schemas are delivered as `tool_search` **result content** instead of being appended to the bound tools array.

Two independent axes:

- **Delivery (all models):** every `tool_search` result embeds each selected tool's full OpenAI-format JSON schema in a `<functions>` block, and re-selecting an already-loaded name re-sends its schema — idempotent, so a summarization-evicted or migration-inherited schema is recoverable by re-searching. Gated by the `EMBED_SCHEMAS_IN_RESULTS` emergency valve (default on).
- **Binding (gated per model):** for prefix-allowlisted models (`FROZEN_TOOLS_MODELS`) the bound tools array is a pure function of `always_loaded + extra_tools` — byte-identical on every call. Non-allowlisted models keep today's array-append behaviour. The gate is evaluated per call from `request.model`, so a mid-run fallback model is gated correctly.

The load-bearing invariant holds because `extra_tools` are registered on the runtime `ToolNode` at build time — freezing only removes them from the model's *bound view*, not from the executable set — so an allowlisted model can read a schema from a `tool_search` result and call that tool directly.

## Why

`tool_search` mutating the tools array invalidated Anthropic's cached prefix (hashed tools → system → messages), costing fresh cache creation on every deferred-tool load. Acceptance criterion (verify in LangSmith on the traces that surfaced this): after any `tool_search` call, the next LLM call reports `cache_read > 0` — today 0/16, target 16/16.

## Changes

- `deferred/conf.py` — new `FROZEN_TOOLS_MODELS` (allowlist, seeded `claude-`, `anthropic/claude-`, `qwen/qwen3.8-max`) and `EMBED_SCHEMAS_IN_RESULTS` (valve) settings.
- `deferred/search_tool.py` — `tool_search` result embeds each loaded tool's schema in a `<functions>` block, idempotently; valve falls back to summaries-only.
- `middlewares/deferred_tools.py` — per-model `_model_name`/`_is_frozen` helpers; bound array is `allowed if frozen else [*allowed, *loaded_tools]`. Corrects false "at most one `tool_search` per session" docstrings.
- `deferred/prompt.py` — advertisement reworded mechanism-neutral, self-heal line added, backwards cache-hash-order docstring fixed.
- `subagents.py` — echoed comment corrected (doc-only).
- `tests/integration_tests/test_deferred_tools_frozen.py` — **new** live network gate (3 modes: fallback / frozen / control) constructed through `BaseAgent.get_model`, gating any addition to the allowlist. Excluded from `make test`.

## Rollout & rollback

Ships with the allowlist seeded to verified entries. All rollback levers are env-only, no deploy: remove one prefix from `DEFERRED_TOOLS_FROZEN_TOOLS_MODELS` → empty the list (schemas still embedded, harmless) → `DEFERRED_TOOLS_EMBED_SCHEMAS_IN_RESULTS=false` → `DEFERRED_TOOLS_ENABLED=false`.

## Testing

- `make test` — full unit suite green (4132 passed); new unit coverage for schema embedding, idempotent re-delivery, valve-off, the frozen-array byte-identical invariant, non-allowlisted append, post-eviction, and the frozen corrective nudge.
- New integration gate collects cleanly (9 items) and is excluded from `make test`; it runs only with real provider keys.
