### PR TITLE
MR-publish: assignee fallback to issue creator + GitLab CI pipeline-identity heal

### DIFF
--- a/daiv/automation/agent/git_manager.py
+++ b/daiv/automation/agent/git_manager.py
@@ -359,7 +359,9 @@ class GitManager:
         await self._git("add", "-A")
         await self._git("commit", "-m", message)
 
-    async def push_head_to(self, branch: str, *, force: bool = False, integrate_on_reject: bool = False) -> str:
+    async def push_head_to(
+        self, branch: str, *, force: bool = False, integrate_on_reject: bool = False, skip_ci: bool = False
+    ) -> str:
         """Push the current ``HEAD`` to ``origin/<branch>`` (creating it if needed).
 
         When ``integrate_on_reject`` is set and a *non-fast-forward* rejection comes back — the
@@ -375,8 +377,16 @@ class GitManager:
         retry. Raises ``GitPushPermissionError`` on an auth/permission failure, ``GitPushNetworkError``
         when the remote host is unreachable (e.g. a network-disabled sandbox), and ``GitCommandError``
         on any other push failure. Returns ``branch``.
+
+        skip_ci: pass ``-o ci.skip`` so the push creates no pipeline.
         """
-        push_args = ["push", "origin", f"HEAD:{branch}", *(["--force"] if force else [])]
+        push_args = [
+            "push",
+            *(["-o", "ci.skip"] if skip_ci else []),
+            "origin",
+            f"HEAD:{branch}",
+            *(["--force"] if force else []),
+        ]
         push = await self._git(*push_args, check=False)
         if push.exit_code == 0:
             return branch

--- a/daiv/automation/agent/publishers.py
+++ b/daiv/automation/agent/publishers.py
@@ -103,6 +103,8 @@ class GitChangePublisher(ChangePublisher):
         else:
             await self._refresh_sandbox_egress()
 
+        # A GitLab ephemeral-token push yields a pipeline that can't read private cross-project CI
+        # includes; skip that push's CI and re-trigger as the service account (skip_ci off ⇒ nothing to heal).
         heal_pipeline = False
         if self.ctx.git_platform == GitPlatform.GITLAB and not skip_ci:
             heal_pipeline = await sync_to_async(self.client.push_uses_ephemeral_token)(self.ctx.repository)
@@ -157,6 +159,8 @@ class GitChangePublisher(ChangePublisher):
             # Only an existing MR's source branch may have advanced under the run (a dependabot
             # force-push, or a concurrent push) — integrate + retry there so the work isn't lost.
             # A fresh, unique branch can't, so leave integration off for new MRs.
+            # skip_ci here suppresses only the ephemeral bot's doomed pipeline (not the caller's
+            # skip_ci intent); _trigger_service_account_pipeline recreates it below.
             await git_manager.push_head_to(
                 branch_name, integrate_on_reject=merge_request is not None, skip_ci=heal_pipeline
             )
@@ -175,10 +179,18 @@ class GitChangePublisher(ChangePublisher):
             except MergeRequestBranchNotVisibleError:
                 # Branch is pushed but GitLab won't open the MR yet; failing here would orphan the work
                 # and discard the agent's reply, so report a partial publish (MR pending) and log loudly.
+                # On the heal path the push was skip-ci'd with no MR yet to trigger against, so name the
+                # suppressed pipeline in the log — the branch has no CI until the MR is created.
+                pipeline_note = (
+                    " The push skipped CI and no pipeline was triggered; CI will not run until the MR exists."
+                    if heal_pipeline
+                    else ""
+                )
                 logger.error(
                     "Pushed branch '%s' but GitLab did not make it visible for MR creation within the retry "
-                    "budget; reporting a partial publish (MR pending).",
+                    "budget; reporting a partial publish (MR pending).%s",
                     branch_name,
+                    pipeline_note,
                 )
                 return PublishOutcome(
                     merge_request=None,
@@ -268,7 +280,7 @@ class GitChangePublisher(ChangePublisher):
             )
             logger.info(
                 "Triggered CI pipeline %s for MR !%s as the service account",
-                getattr(pipeline, "id", "?"),
+                pipeline.id,
                 merge_request.merge_request_id,
             )
         except Exception:

--- a/daiv/automation/agent/publishers.py
+++ b/daiv/automation/agent/publishers.py
@@ -103,12 +103,6 @@ class GitChangePublisher(ChangePublisher):
         else:
             await self._refresh_sandbox_egress()
 
-        # A GitLab ephemeral-token push yields a pipeline that can't read private cross-project CI
-        # includes; skip that push's CI and re-trigger as the service account (skip_ci off ⇒ nothing to heal).
-        heal_pipeline = False
-        if self.ctx.git_platform == GitPlatform.GITLAB and not skip_ci:
-            heal_pipeline = await sync_to_async(self.client.push_uses_ephemeral_token)(self.ctx.repository)
-
         async with open_git_manager(
             sandbox_backend=self.sandbox_backend, gitrepo=self.ctx.gitrepo, auth_env=auth_env
         ) as git_manager:
@@ -155,6 +149,15 @@ class GitChangePublisher(ChangePublisher):
                 )
             else:
                 branch_name = merge_request.source_branch
+
+            # An ephemeral-token push (GitLab's project-scoped bot) yields a pipeline that can't read
+            # private cross-project CI includes; skip that push's CI and re-trigger as the service
+            # account below. The client capability answers False for platforms without ephemeral
+            # tokens, so no platform check is needed here; an explicit skip_ci ("no CI at all") also
+            # leaves nothing to heal.
+            heal_pipeline = not skip_ci and await sync_to_async(self.client.push_uses_ephemeral_token)(
+                self.ctx.repository
+            )
 
             # Only an existing MR's source branch may have advanced under the run (a dependabot
             # force-push, or a concurrent push) — integrate + retry there so the work isn't lost.

--- a/daiv/automation/agent/publishers.py
+++ b/daiv/automation/agent/publishers.py
@@ -103,6 +103,10 @@ class GitChangePublisher(ChangePublisher):
         else:
             await self._refresh_sandbox_egress()
 
+        heal_pipeline = False
+        if self.ctx.git_platform == GitPlatform.GITLAB and not skip_ci:
+            heal_pipeline = await sync_to_async(self.client.push_uses_ephemeral_token)(self.ctx.repository)
+
         async with open_git_manager(
             sandbox_backend=self.sandbox_backend, gitrepo=self.ctx.gitrepo, auth_env=auth_env
         ) as git_manager:
@@ -153,7 +157,9 @@ class GitChangePublisher(ChangePublisher):
             # Only an existing MR's source branch may have advanced under the run (a dependabot
             # force-push, or a concurrent push) — integrate + retry there so the work isn't lost.
             # A fresh, unique branch can't, so leave integration off for new MRs.
-            await git_manager.push_head_to(branch_name, integrate_on_reject=merge_request is not None)
+            await git_manager.push_head_to(
+                branch_name, integrate_on_reject=merge_request is not None, skip_ci=heal_pipeline
+            )
 
         logger.info("Published changes to branch: '%s' [skip_ci: %s]", branch_name, skip_ci)
 
@@ -196,6 +202,9 @@ class GitChangePublisher(ChangePublisher):
                 merge_request.merge_request_id,
                 merge_request.draft,
             )
+
+        if heal_pipeline and merge_request is not None:
+            await self._trigger_service_account_pipeline(merge_request)
 
         return PublishOutcome(
             merge_request=merge_request,

--- a/daiv/automation/agent/publishers.py
+++ b/daiv/automation/agent/publishers.py
@@ -243,6 +243,39 @@ class GitChangePublisher(ChangePublisher):
                 self.ctx.repository.slug,
             )
 
+    async def _trigger_service_account_pipeline(self, merge_request: MergeRequest) -> None:
+        """Create the MR's CI pipeline as the service account (which can read private cross-project
+        CI includes), used after a ``-o ci.skip`` push suppressed the ephemeral bot's pipeline.
+
+        Best-effort and never raises: this runs at turn-end publish, so a failure here must not sink
+        the whole publish. Because the push was skip-ci'd, a failed trigger leaves the MR with no
+        pipeline — surface that loudly (error log for Sentry) and visibly (an MR note), never
+        silently. A single attempt only: ``mr.pipelines.create()`` is a non-idempotent POST and
+        python-gitlab may already retry transient errors, so we add no retry multiplier of our own.
+        """
+        try:
+            pipeline = await sync_to_async(self.client.trigger_merge_request_pipeline)(
+                merge_request.repo_id, merge_request.merge_request_id
+            )
+            logger.info(
+                "Triggered CI pipeline %s for MR !%s as the service account",
+                getattr(pipeline, "id", "?"),
+                merge_request.merge_request_id,
+            )
+        except Exception:
+            logger.exception(
+                "Could not trigger the CI pipeline for MR !%s as the service account; posting a note",
+                merge_request.merge_request_id,
+            )
+            try:
+                await sync_to_async(self.client.create_merge_request_comment)(
+                    merge_request.repo_id,
+                    merge_request.merge_request_id,
+                    "⚠️ DAIV could not start the CI pipeline automatically. Please run it manually.",
+                )
+            except Exception:
+                logger.exception("Could not post the pipeline-failure note on MR !%s", merge_request.merge_request_id)
+
     async def _diff_to_metadata(self, commit_message_diff: str, pr_metadata_diff: str | None = None) -> dict[str, Any]:
         """
         Get the PR metadata from the diff.

--- a/daiv/automation/agent/publishers.py
+++ b/daiv/automation/agent/publishers.py
@@ -309,13 +309,9 @@ class GitChangePublisher(ChangePublisher):
             The merge request.
         """
         assignee_id = None
-
-        if self.ctx.issue and self.ctx.issue.assignee:
-            assignee_id = (
-                self.ctx.issue.assignee.id
-                if self.ctx.git_platform == GitPlatform.GITLAB
-                else self.ctx.issue.assignee.username
-            )
+        if self.ctx.issue:
+            assignee = self.ctx.issue.assignee or self.ctx.issue.author
+            assignee_id = assignee.id if self.ctx.git_platform == GitPlatform.GITLAB else assignee.username
 
         target_branch = (
             fallback_from_mr.target_branch

--- a/daiv/codebase/clients/base.py
+++ b/daiv/codebase/clients/base.py
@@ -20,6 +20,7 @@ from codebase.base import (
     MergeRequest,
     MergeRequestCommit,
     MergeRequestDiffStats,
+    Pipeline,
     RepoAccessLevel,
     RepoMember,
     Repository,
@@ -266,6 +267,12 @@ class RepoClient(abc.ABC):
         user cannot read other projects — so the resulting pipeline cannot resolve cross-project CI
         includes and must be re-triggered as the service account. Base default: ``False``."""
         return False
+
+    def trigger_merge_request_pipeline(self, repo_id: str, merge_request_id: int) -> Pipeline | None:
+        """Create a CI pipeline for the merge request as the service account, so it runs with the
+        service account's permissions (e.g. reading private cross-project CI includes). Base default:
+        no-op returning ``None`` (platforms that don't need it)."""
+        return None
 
     def get_git_auth_env(self, repository: Repository) -> GitAuthEnv | None:
         """Per-invocation credential overlay for *local-mode* git network operations

--- a/daiv/codebase/clients/base.py
+++ b/daiv/codebase/clients/base.py
@@ -268,11 +268,12 @@ class RepoClient(abc.ABC):
         includes and must be re-triggered as the service account. Base default: ``False``."""
         return False
 
-    def trigger_merge_request_pipeline(self, repo_id: str, merge_request_id: int) -> Pipeline | None:
+    def trigger_merge_request_pipeline(self, repo_id: str, merge_request_id: int) -> Pipeline:
         """Create a CI pipeline for the merge request as the service account, so it runs with the
-        service account's permissions (e.g. reading private cross-project CI includes). Base default:
-        no-op returning ``None`` (platforms that don't need it)."""
-        return None
+        service account's permissions (e.g. reading private cross-project CI includes). GitLab-only
+        capability: the publish path calls this only when :meth:`push_uses_ephemeral_token` is true,
+        so reaching the base implementation means a mis-wired caller, not a supported no-op."""
+        raise NotImplementedError
 
     def get_git_auth_env(self, repository: Repository) -> GitAuthEnv | None:
         """Per-invocation credential overlay for *local-mode* git network operations

--- a/daiv/codebase/clients/base.py
+++ b/daiv/codebase/clients/base.py
@@ -261,6 +261,12 @@ class RepoClient(abc.ABC):
         platforms that need no credential (host-only reachability). Overridden by GitLab/GitHub."""
         return None
 
+    def push_uses_ephemeral_token(self, repository: Repository) -> bool:
+        """True when the git push authenticates with a short-lived, project-scoped token whose bot
+        user cannot read other projects — so the resulting pipeline cannot resolve cross-project CI
+        includes and must be re-triggered as the service account. Base default: ``False``."""
+        return False
+
     def get_git_auth_env(self, repository: Repository) -> GitAuthEnv | None:
         """Per-invocation credential overlay for *local-mode* git network operations
         (push/fetch/ls-remote), or ``None`` for platforms whose remotes need no credential

--- a/daiv/codebase/clients/github/client.py
+++ b/daiv/codebase/clients/github/client.py
@@ -515,7 +515,7 @@ class GitHubClient(RepoClient):
         if labels is not None and not any(label.name in labels for label in pr.labels):
             pr.add_to_labels(*labels)
 
-        if assignee_id and not any(assignee.id == assignee_id for assignee in pr.assignees):
+        if assignee_id and not any(assignee.login == assignee_id for assignee in pr.assignees):
             pr.add_to_assignees(assignee_id)
 
         return MergeRequest(
@@ -620,7 +620,7 @@ class GitHubClient(RepoClient):
         if labels is not None and not any(label.name in labels for label in pr.labels):
             pr.add_to_labels(*labels)
 
-        if assignee_id is not None and not any(assignee.id == assignee_id for assignee in pr.assignees):
+        if assignee_id is not None and not any(assignee.login == assignee_id for assignee in pr.assignees):
             pr.add_to_assignees(assignee_id)
 
         return MergeRequest(

--- a/daiv/codebase/clients/gitlab/client.py
+++ b/daiv/codebase/clients/gitlab/client.py
@@ -557,6 +557,11 @@ class GitLabClient(RepoClient):
         :meth:`_get_clone_token`); ``None`` (host-only reachability) when neither is available."""
         return get_ephemeral_clone_token(self.client, repository.pk) or self.client.private_token or None
 
+    def push_uses_ephemeral_token(self, repository: Repository) -> bool:
+        # get_ephemeral_clone_token is day-cached, so this is the same value the push used — a cache
+        # hit, not a second mint.
+        return get_ephemeral_clone_token(self.client, repository.pk) is not None
+
     # Issue
     def get_issue(self, repo_id: str, issue_id: int) -> Issue:
         """

--- a/daiv/codebase/clients/gitlab/client.py
+++ b/daiv/codebase/clients/gitlab/client.py
@@ -28,6 +28,7 @@ from codebase.base import (
     NotePosition,
     NotePositionLineRange,
     NoteType,
+    Pipeline,
     RepoAccessLevel,
     RepoMember,
     Repository,
@@ -923,6 +924,20 @@ class GitLabClient(RepoClient):
             to_return = merge_request.notes.create({"body": body}).id
 
         return to_return
+
+    def trigger_merge_request_pipeline(self, repo_id: str, merge_request_id: int) -> Pipeline | None:
+        """Create an MR pipeline (``POST .../merge_requests/:iid/pipelines``). Runs as the PAT user
+        (the DAIV service account), so cross-project CI includes resolve with its permissions."""
+        project = self.client.projects.get(repo_id, lazy=True)
+        merge_request = project.mergerequests.get(merge_request_id, lazy=True)
+        pipeline = merge_request.pipelines.create()
+        return Pipeline(
+            id=pipeline.id,
+            iid=getattr(pipeline, "iid", None),
+            sha=pipeline.sha,
+            status=pipeline.status,
+            web_url=pipeline.web_url,
+        )
 
     def get_merge_request_diff_stats(self, repo_id: str, merge_request_id: int) -> MergeRequestDiffStats:
         """

--- a/daiv/codebase/clients/gitlab/client.py
+++ b/daiv/codebase/clients/gitlab/client.py
@@ -559,8 +559,8 @@ class GitLabClient(RepoClient):
         return get_ephemeral_clone_token(self.client, repository.pk) or self.client.private_token or None
 
     def push_uses_ephemeral_token(self, repository: Repository) -> bool:
-        # get_ephemeral_clone_token is day-cached, so this is the same value the push used — a cache
-        # hit, not a second mint.
+        # Asserts the credential *kind*, not the token value: a day-cache expiry mid-turn re-mints
+        # another ephemeral token, so this boolean stays stable even when the value differs.
         return get_ephemeral_clone_token(self.client, repository.pk) is not None
 
     # Issue
@@ -925,7 +925,7 @@ class GitLabClient(RepoClient):
 
         return to_return
 
-    def trigger_merge_request_pipeline(self, repo_id: str, merge_request_id: int) -> Pipeline | None:
+    def trigger_merge_request_pipeline(self, repo_id: str, merge_request_id: int) -> Pipeline:
         """Create an MR pipeline (``POST .../merge_requests/:iid/pipelines``). Runs as the PAT user
         (the DAIV service account), so cross-project CI includes resolve with its permissions."""
         project = self.client.projects.get(repo_id, lazy=True)

--- a/tests/unit_tests/automation/agent/test_git_manager.py
+++ b/tests/unit_tests/automation/agent/test_git_manager.py
@@ -919,3 +919,20 @@ async def test_push_head_to_omits_ci_skip_by_default() -> None:
     gm = GitManager.for_sandbox(_backend_for(client))
     await gm.push_head_to("b")
     assert not any("ci.skip" in c for c in client.commands)
+
+
+async def test_push_head_to_skip_ci_survives_the_integrate_on_reject_retry() -> None:
+    # Heal path: an existing MR's ephemeral-token push is skip-ci'd and may hit a non-ff rejection.
+    # `-o ci.skip` must ride the rebase-retry push too, or the bot's doomed pipeline fires on the
+    # second attempt and silently defeats the heal.
+    client = MagicMock()
+    client.run_commands = AsyncMock(
+        side_effect=[_resp((_NON_FF_REJECT, 1)), _resp(("", 0)), _resp(("", 0)), _resp(("", 0))]
+    )
+    gm = GitManager.for_sandbox(_backend_for(client))
+
+    assert await gm.push_head_to("b", integrate_on_reject=True, skip_ci=True) == "b"
+
+    pushes = [c for c in _issued(client) if "origin HEAD:b" in c]
+    assert len(pushes) == 2  # first push + rebase-retry push
+    assert all("-o ci.skip" in c for c in pushes)

--- a/tests/unit_tests/automation/agent/test_git_manager.py
+++ b/tests/unit_tests/automation/agent/test_git_manager.py
@@ -904,3 +904,18 @@ async def test_get_diff_raises_on_ls_files_failure() -> None:
     gm, _ = _sandbox_manager({"ls-files": (128, "fatal: boom")})
     with pytest.raises(GitCommandError):
         await gm.get_diff()
+
+
+async def test_push_head_to_adds_ci_skip_push_option_when_skip_ci() -> None:
+    client = FakeSandboxClient()
+    gm = GitManager.for_sandbox(_backend_for(client))
+    await gm.push_head_to("b", skip_ci=True)
+    push_cmds = [c for c in client.commands if " push " in f" {c} "]
+    assert push_cmds and all("-o ci.skip" in c for c in push_cmds)
+
+
+async def test_push_head_to_omits_ci_skip_by_default() -> None:
+    client = FakeSandboxClient()
+    gm = GitManager.for_sandbox(_backend_for(client))
+    await gm.push_head_to("b")
+    assert not any("ci.skip" in c for c in client.commands)

--- a/tests/unit_tests/automation/agent/test_publishers.py
+++ b/tests/unit_tests/automation/agent/test_publishers.py
@@ -715,3 +715,35 @@ class TestPublishDecision:
 def test_create_merge_request_and_suggest_are_async():
     assert inspect.iscoroutinefunction(GitChangePublisher._create_merge_request)
     assert inspect.iscoroutinefunction(GitChangePublisher._suggest_context_file)
+
+
+class TestTriggerServiceAccountPipeline:
+    async def test_triggers_pipeline_via_client(self):
+        publisher = _make_publisher()
+        publisher.client.trigger_merge_request_pipeline = Mock(return_value=Mock(id=5))
+        mr = _make_merge_request()
+
+        await publisher._trigger_service_account_pipeline(mr)
+
+        publisher.client.trigger_merge_request_pipeline.assert_called_once_with("owner/repo", 42)
+        publisher.client.create_merge_request_comment.assert_not_called()
+
+    async def test_logs_and_notes_on_failure(self, caplog):
+        publisher = _make_publisher()
+        publisher.client.trigger_merge_request_pipeline = Mock(side_effect=RuntimeError("boom"))
+        mr = _make_merge_request()
+
+        with caplog.at_level("ERROR"):
+            await publisher._trigger_service_account_pipeline(mr)
+
+        assert any(r.levelname == "ERROR" for r in caplog.records)
+        publisher.client.create_merge_request_comment.assert_called_once()
+        body = publisher.client.create_merge_request_comment.call_args[0][2]
+        assert "pipeline" in body.lower()
+
+    async def test_does_not_raise_when_note_also_fails(self):
+        publisher = _make_publisher()
+        publisher.client.trigger_merge_request_pipeline = Mock(side_effect=RuntimeError("boom"))
+        publisher.client.create_merge_request_comment = Mock(side_effect=RuntimeError("note failed"))
+
+        await publisher._trigger_service_account_pipeline(_make_merge_request())  # must not raise

--- a/tests/unit_tests/automation/agent/test_publishers.py
+++ b/tests/unit_tests/automation/agent/test_publishers.py
@@ -75,7 +75,18 @@ def _make_publisher(*, git_platform: GitPlatform = GitPlatform.GITLAB, context_f
     publisher = GitChangePublisher(ctx)
     publisher.client = Mock()
     publisher.client.is_branch_protected.return_value = False
+    publisher.client.push_uses_ephemeral_token.return_value = False
     return publisher
+
+
+def _metadata_stub():
+    commit = Mock()
+    commit.commit_message = "msg"
+    pr = Mock()
+    pr.branch = "feature"
+    pr.title = "Title"
+    pr.description = "Body"
+    return {"commit_message": commit, "pr_metadata": pr}
 
 
 def _make_sandbox_publisher(*, egress="default"):
@@ -449,7 +460,7 @@ class TestPublishSuggestsContextFile:
 
             gm.commit_all.assert_awaited_once()
             # Fresh branch for a brand-new MR: no remote work to integrate, so no rebase-on-reject.
-            gm.push_head_to.assert_awaited_once_with("feature", integrate_on_reject=False)
+            gm.push_head_to.assert_awaited_once_with("feature", integrate_on_reject=False, skip_ci=False)
             mock_suggest.assert_called_once_with(mr)
             assert result == PublishOutcome(merge_request=mr, published=True)
 
@@ -478,7 +489,7 @@ class TestPublishSuggestsContextFile:
             result = await publisher.publish(merge_request=None)
 
         gm.commit_all.assert_awaited_once()
-        gm.push_head_to.assert_awaited_once_with("feature", integrate_on_reject=False)
+        gm.push_head_to.assert_awaited_once_with("feature", integrate_on_reject=False, skip_ci=False)
         mock_suggest.assert_not_called()
         assert result == PublishOutcome(merge_request=None, published=True)
         assert "MR pending" in caplog.text
@@ -535,7 +546,7 @@ class TestPublishSuggestsContextFile:
             assert mock_diff_to_metadata.call_args.kwargs["pr_metadata_diff"] is not None
             # Fresh unique branch generated + pushed for the fallback MR (no remote work to integrate).
             gm.unique_branch_name.assert_called_once_with("feature-fix", [])
-            gm.push_head_to.assert_awaited_once_with("feature-fix", integrate_on_reject=False)
+            gm.push_head_to.assert_awaited_once_with("feature-fix", integrate_on_reject=False, skip_ci=False)
             # The new MR is created with a back-link to the original protected MR.
             mock_create_mr.assert_called_once()
             assert mock_create_mr.call_args.kwargs["fallback_from_mr"] is existing_mr
@@ -627,7 +638,7 @@ class TestPublishSuggestsContextFile:
 
             # Existing MR: push to its source branch, integrating remote work on a non-ff rejection
             # (the branch may have moved under the run, e.g. a concurrent push).
-            gm.push_head_to.assert_awaited_once_with("feature", integrate_on_reject=True)
+            gm.push_head_to.assert_awaited_once_with("feature", integrate_on_reject=True, skip_ci=False)
             mock_suggest.assert_not_called()
 
 
@@ -698,7 +709,7 @@ class TestPublishDecision:
 
         assert gm.status_snapshot.await_args.kwargs["base_branch"] == "release/x"
         meta.assert_called_once()  # proceeded past the clean short-circuit
-        gm.push_head_to.assert_awaited_once_with("feat/x", integrate_on_reject=True)
+        gm.push_head_to.assert_awaited_once_with("feat/x", integrate_on_reject=True, skip_ci=False)
         assert outcome == PublishOutcome(merge_request=mr, published=True)
 
     async def test_diffs_against_default_branch_when_no_mr(self, monkeypatch):
@@ -747,3 +758,80 @@ class TestTriggerServiceAccountPipeline:
         publisher.client.create_merge_request_comment = Mock(side_effect=RuntimeError("note failed"))
 
         await publisher._trigger_service_account_pipeline(_make_merge_request())  # must not raise
+
+
+class TestPublishPipelineHeal:
+    """GitLab ephemeral-token pushes skip the bot pipeline and trigger it as the service account."""
+
+    async def test_ephemeral_push_skips_ci_and_triggers_pipeline(self, monkeypatch):
+        publisher = _make_publisher(git_platform=GitPlatform.GITLAB)
+        publisher.client.push_uses_ephemeral_token.return_value = True
+        gm = _fake_git_manager()
+        _patch_open_git_manager(monkeypatch, gm)
+        mr = _make_merge_request()
+
+        with (
+            patch.object(publisher, "_diff_to_metadata", return_value=_metadata_stub()),
+            patch.object(publisher, "_create_merge_request", return_value=mr),
+            patch.object(publisher, "_suggest_context_file", AsyncMock()),
+            patch.object(publisher, "_trigger_service_account_pipeline", AsyncMock()) as trigger,
+        ):
+            await publisher.publish()
+
+        gm.push_head_to.assert_awaited_once_with("feature", integrate_on_reject=False, skip_ci=True)
+        trigger.assert_awaited_once_with(mr)
+
+    async def test_pat_push_does_not_skip_ci_or_trigger(self, monkeypatch):
+        publisher = _make_publisher(git_platform=GitPlatform.GITLAB)
+        publisher.client.push_uses_ephemeral_token.return_value = False
+        gm = _fake_git_manager()
+        _patch_open_git_manager(monkeypatch, gm)
+        mr = _make_merge_request()
+
+        with (
+            patch.object(publisher, "_diff_to_metadata", return_value=_metadata_stub()),
+            patch.object(publisher, "_create_merge_request", return_value=mr),
+            patch.object(publisher, "_suggest_context_file", AsyncMock()),
+            patch.object(publisher, "_trigger_service_account_pipeline", AsyncMock()) as trigger,
+        ):
+            await publisher.publish()
+
+        gm.push_head_to.assert_awaited_once_with("feature", integrate_on_reject=False, skip_ci=False)
+        trigger.assert_not_awaited()
+
+    async def test_github_never_heals(self, monkeypatch):
+        publisher = _make_publisher(git_platform=GitPlatform.GITHUB)
+        publisher.client.push_uses_ephemeral_token.return_value = True  # must be ignored for GitHub
+        gm = _fake_git_manager()
+        _patch_open_git_manager(monkeypatch, gm)
+        mr = _make_merge_request()
+
+        with (
+            patch.object(publisher, "_diff_to_metadata", return_value=_metadata_stub()),
+            patch.object(publisher, "_create_merge_request", return_value=mr),
+            patch.object(publisher, "_suggest_context_file", AsyncMock()),
+            patch.object(publisher, "_trigger_service_account_pipeline", AsyncMock()) as trigger,
+        ):
+            await publisher.publish()
+
+        gm.push_head_to.assert_awaited_once_with("feature", integrate_on_reject=False, skip_ci=False)
+        trigger.assert_not_awaited()
+
+    async def test_skip_ci_flag_disables_heal(self, monkeypatch):
+        publisher = _make_publisher(git_platform=GitPlatform.GITLAB)
+        publisher.client.push_uses_ephemeral_token.return_value = True
+        gm = _fake_git_manager()
+        _patch_open_git_manager(monkeypatch, gm)
+        mr = _make_merge_request()
+
+        with (
+            patch.object(publisher, "_diff_to_metadata", return_value=_metadata_stub()),
+            patch.object(publisher, "_create_merge_request", return_value=mr),
+            patch.object(publisher, "_suggest_context_file", AsyncMock()),
+            patch.object(publisher, "_trigger_service_account_pipeline", AsyncMock()) as trigger,
+        ):
+            await publisher.publish(skip_ci=True)
+
+        # explicit skip_ci means "no CI at all" — no bot pipeline, no service-account trigger
+        gm.push_head_to.assert_awaited_once_with("feature", integrate_on_reject=False, skip_ci=False)
+        trigger.assert_not_awaited()

--- a/tests/unit_tests/automation/agent/test_publishers.py
+++ b/tests/unit_tests/automation/agent/test_publishers.py
@@ -7,7 +7,7 @@ import pytest
 
 from automation.agent.git_manager import RepoStatus
 from automation.agent.publishers import GitChangePublisher, PublishOutcome
-from codebase.base import GitPlatform, MergeRequest, User
+from codebase.base import GitPlatform, Issue, MergeRequest, User
 from codebase.clients.base import GitAuthEnv
 from codebase.exceptions import MergeRequestBranchNotVisibleError
 from core.constants import BOT_AUTO_LABEL, BOT_NAME
@@ -232,6 +232,47 @@ class TestCreateMergeRequestDescription:
         await publisher._create_merge_request("feature", "Title", "Body")
 
         assert publisher.client.update_or_create_merge_request.call_args.kwargs["target_branch"] == "main"
+
+
+class TestCreateMergeRequestAssignee:
+    """_create_merge_request assigns the MR to the issue assignee, falling back to the author."""
+
+    def _issue(self, *, assignee, author):
+        return Issue(iid=5, title="t", description="d", assignee=assignee, author=author)
+
+    async def test_uses_issue_assignee_when_present_gitlab(self):
+        publisher = _make_publisher(git_platform=GitPlatform.GITLAB)
+        publisher.ctx.issue = self._issue(
+            assignee=User(id=7, username="assignee"), author=User(id=9, username="author")
+        )
+
+        await publisher._create_merge_request("feature", "Title", "Body")
+
+        assert publisher.client.update_or_create_merge_request.call_args.kwargs["assignee_id"] == 7
+
+    async def test_falls_back_to_author_when_unassigned_gitlab(self):
+        publisher = _make_publisher(git_platform=GitPlatform.GITLAB)
+        publisher.ctx.issue = self._issue(assignee=None, author=User(id=9, username="author"))
+
+        await publisher._create_merge_request("feature", "Title", "Body")
+
+        assert publisher.client.update_or_create_merge_request.call_args.kwargs["assignee_id"] == 9
+
+    async def test_falls_back_to_author_username_on_github(self):
+        publisher = _make_publisher(git_platform=GitPlatform.GITHUB)
+        publisher.ctx.issue = self._issue(assignee=None, author=User(id=9, username="author"))
+
+        await publisher._create_merge_request("feature", "Title", "Body")
+
+        assert publisher.client.update_or_create_merge_request.call_args.kwargs["assignee_id"] == "author"
+
+    async def test_no_assignee_when_no_issue(self):
+        publisher = _make_publisher(git_platform=GitPlatform.GITLAB)
+        publisher.ctx.issue = None
+
+        await publisher._create_merge_request("feature", "Title", "Body")
+
+        assert publisher.client.update_or_create_merge_request.call_args.kwargs["assignee_id"] is None
 
 
 class TestBuildIssueCreationUrl:

--- a/tests/unit_tests/automation/agent/test_publishers.py
+++ b/tests/unit_tests/automation/agent/test_publishers.py
@@ -801,7 +801,9 @@ class TestPublishPipelineHeal:
 
     async def test_github_never_heals(self, monkeypatch):
         publisher = _make_publisher(git_platform=GitPlatform.GITHUB)
-        publisher.client.push_uses_ephemeral_token.return_value = True  # must be ignored for GitHub
+        # GitHub's client reports no ephemeral token (base default), so the polymorphic heal never
+        # fires — the publisher special-cases no platform.
+        publisher.client.push_uses_ephemeral_token.return_value = False
         gm = _fake_git_manager()
         _patch_open_git_manager(monkeypatch, gm)
         mr = _make_merge_request()

--- a/tests/unit_tests/codebase/clients/github/test_client.py
+++ b/tests/unit_tests/codebase/clients/github/test_client.py
@@ -6,6 +6,7 @@ from git import GitCommandError
 from github import Consts
 from github.GithubException import GithubException
 from github.IssueComment import IssueComment
+from github.NamedUser import NamedUser
 from github.Repository import Repository as GhRepository
 
 from codebase.base import GitPlatform, MergeRequestCommit, Repository, User
@@ -447,6 +448,57 @@ class TestGitHubClient:
 
         mock_repo.get_pull.return_value = _pr(merged)
         assert github_client.get_merge_request("owner/repo", 7).merged is merged
+
+    @staticmethod
+    def _create_path_pr(assignees):
+        """A mock PR on the create path, wired with the concrete attributes ``MergeRequest`` reads
+        plus real ``add_to_labels``/``add_to_assignees`` spies and the given ``assignees`` list."""
+        mock_pr = Mock()
+        mock_pr.number = 7
+        mock_pr.head = Mock(ref="feat-x", sha="abc123")
+        mock_pr.base = Mock(ref="main")
+        mock_pr.title = "feat: add x"
+        mock_pr.body = "details"
+        mock_pr.labels = []
+        mock_pr.html_url = "https://github.com/o/r/pull/7"
+        mock_pr.draft = False
+        user = Mock(id=1, login="alice")
+        user.name = "Alice"
+        mock_pr.user = user
+        mock_pr.assignees = assignees
+        return mock_pr
+
+    def test_update_or_create_merge_request_skips_assignee_when_already_assigned(self, github_client):
+        """The dedup guard matches usernames: ``assignee_id`` is a login on the GitHub path, so an
+        already-assigned author must not be re-added. Regression guard for the int-vs-str comparison
+        (``assignee.id == assignee_id``) that made this branch unreachable."""
+        requester = Mock(base_url="https://api.github.com", is_not_lazy=False)
+        assignee = NamedUser(requester, {}, {"login": "daiv", "id": 123}, completed=True)
+        mock_pr = self._create_path_pr(assignees=[assignee])
+        mock_repo = Mock()
+        mock_repo.create_pull.return_value = mock_pr
+        github_client.client.get_repo.return_value = mock_repo
+
+        github_client.update_or_create_merge_request(
+            "owner/repo", "feat-x", "main", "feat: add x", "details", assignee_id="daiv"
+        )
+
+        mock_pr.add_to_assignees.assert_not_called()
+
+    def test_update_or_create_merge_request_adds_assignee_when_not_assigned(self, github_client):
+        """A login not already present is added exactly once."""
+        requester = Mock(base_url="https://api.github.com", is_not_lazy=False)
+        assignee = NamedUser(requester, {}, {"login": "someone-else", "id": 123}, completed=True)
+        mock_pr = self._create_path_pr(assignees=[assignee])
+        mock_repo = Mock()
+        mock_repo.create_pull.return_value = mock_pr
+        github_client.client.get_repo.return_value = mock_repo
+
+        github_client.update_or_create_merge_request(
+            "owner/repo", "feat-x", "main", "feat: add x", "details", assignee_id="daiv"
+        )
+
+        mock_pr.add_to_assignees.assert_called_once_with("daiv")
 
     def test_is_branch_protected_returns_true_when_branch_protected(self, github_client):
         mock_repo = Mock()

--- a/tests/unit_tests/codebase/clients/github/test_client.py
+++ b/tests/unit_tests/codebase/clients/github/test_client.py
@@ -500,6 +500,21 @@ class TestGitHubClient:
 
         mock_pr.add_to_assignees.assert_called_once_with("daiv")
 
+    def test_push_uses_ephemeral_token_is_false(self, github_client):
+        """GitHub pushes with a long-lived installation token, not a project-scoped ephemeral one, so
+        the publisher's cross-project-CI heal never fires. This is the guarantee the polymorphic
+        publish path relies on instead of a platform check."""
+        repository = Repository(
+            pk=1,
+            slug="owner/repo",
+            name="repo",
+            clone_url="https://github.com/owner/repo.git",
+            html_url="https://github.com/owner/repo",
+            default_branch="main",
+            git_platform=GitPlatform.GITHUB,
+        )
+        assert github_client.push_uses_ephemeral_token(repository) is False
+
     def test_is_branch_protected_returns_true_when_branch_protected(self, github_client):
         mock_repo = Mock()
         mock_repo.get_branch.return_value = Mock(protected=True)

--- a/tests/unit_tests/codebase/clients/gitlab/test_client.py
+++ b/tests/unit_tests/codebase/clients/gitlab/test_client.py
@@ -1053,3 +1053,22 @@ class TestGitLabClient:
             cred = gitlab_client.get_git_egress_credential(self._egress_repo())
         assert cred.host == "gitlab.example.com"
         assert cred.value is None
+
+    def _repo(self):
+        return Repository(
+            pk=7,
+            slug="group/repo",
+            name="repo",
+            clone_url="https://gitlab.com/group/repo.git",
+            html_url="https://gitlab.com/group/repo",
+            default_branch="main",
+            git_platform=GitPlatform.GITLAB,
+        )
+
+    def test_push_uses_ephemeral_token_true_when_ephemeral_minted(self, gitlab_client):
+        with patch("codebase.clients.gitlab.client.get_ephemeral_clone_token", return_value="glpat-eph"):
+            assert gitlab_client.push_uses_ephemeral_token(self._repo()) is True
+
+    def test_push_uses_ephemeral_token_false_when_pat_fallback(self, gitlab_client):
+        with patch("codebase.clients.gitlab.client.get_ephemeral_clone_token", return_value=None):
+            assert gitlab_client.push_uses_ephemeral_token(self._repo()) is False

--- a/tests/unit_tests/codebase/clients/gitlab/test_client.py
+++ b/tests/unit_tests/codebase/clients/gitlab/test_client.py
@@ -1072,3 +1072,22 @@ class TestGitLabClient:
     def test_push_uses_ephemeral_token_false_when_pat_fallback(self, gitlab_client):
         with patch("codebase.clients.gitlab.client.get_ephemeral_clone_token", return_value=None):
             assert gitlab_client.push_uses_ephemeral_token(self._repo()) is False
+
+    def test_trigger_merge_request_pipeline_creates_mr_pipeline(self, gitlab_client):
+        mock_project = Mock()
+        mock_mr = Mock()
+        mock_pipeline = Mock(
+            id=987, iid=3, sha="deadbeef", status="pending", web_url="https://gitlab.com/group/repo/-/pipelines/987"
+        )
+        gitlab_client.client.projects.get.return_value = mock_project
+        mock_project.mergerequests.get.return_value = mock_mr
+        mock_mr.pipelines.create.return_value = mock_pipeline
+
+        pipeline = gitlab_client.trigger_merge_request_pipeline("group/repo", 42)
+
+        gitlab_client.client.projects.get.assert_called_once_with("group/repo", lazy=True)
+        mock_project.mergerequests.get.assert_called_once_with(42, lazy=True)
+        mock_mr.pipelines.create.assert_called_once_with()
+        assert pipeline.id == 987
+        assert pipeline.status == "pending"
+        assert pipeline.web_url.endswith("/pipelines/987")


### PR DESCRIPTION
## Summary

Two fixes to the MR-publish path, both surfaced by a real issue-created merge request:

**1. Assignee fallback to the issue creator.** When DAIV opens an MR from an issue, it now assigns `issue.assignee` **or the issue author** when the issue is unassigned (previously an unassigned issue produced an unassigned MR). Creation path only, so a human's manual reassignment on an existing MR is never clobbered. Both GitLab and GitHub.

**2. GitLab CI pipeline-identity heal.** DAIV pushes commits with a short-lived, project-scoped ephemeral token whose bot user can only read its own project. GitLab resolves a cross-project CI `include:` (e.g. a shared, private templates repo) **as the pushing user**, so those pipelines failed at creation with 0 jobs. Now, when the push used the ephemeral token (GitLab, and the middleware `skip_ci` flag is off), DAIV:

- pushes with `-o ci.skip` so the bot's doomed auto-pipeline is never created, then
- triggers the MR pipeline via the service-account API (`mr.pipelines.create()`), which runs as the `daiv` service account (a Maintainer of the templates repo) and resolves the include.

Best-effort: a failed trigger logs at error level **and** posts an MR note, so the MR is never left silently pipeline-less. The ephemeral-token design (write blast-radius containment) is preserved — only the *pipeline* identity changes.

## Design

`heal_pipeline = platform is GitLab ∧ middleware skip_ci is off ∧ push used the ephemeral project token`, computed once and reused for both the push option and the trigger so they can never disagree. The two meanings of `skip_ci` stay distinct: the existing middleware flag ("skip CI entirely, no trigger") short-circuits the heal, while the heal ("skip the *push's* pipeline, then trigger as the service account") only engages when that flag is off. GitHub is unaffected (Actions use a per-repo token model); the templates-repo visibility is untouched.

## Changes

- `codebase/clients/base.py` / `gitlab/client.py` — new `push_uses_ephemeral_token` (base default `False`; GitLab `True` when an ephemeral clone token is minted) and `trigger_merge_request_pipeline` (GitLab-only capability: base **raises `NotImplementedError`**; GitLab `mr.pipelines.create()` → domain `Pipeline`).
- `automation/agent/git_manager.py` — `push_head_to(..., skip_ci=…)` injects `-o ci.skip` (and survives the integrate-on-reject retry, since `push_args` is built once and reused).
- `automation/agent/publishers.py` — the `_create_merge_request` assignee fallback, the best-effort `_trigger_service_account_pipeline` helper, and the `publish()` gate + wiring. The `MergeRequestBranchNotVisibleError` partial-publish log now names the suppressed pipeline (a heal-path push is skip-ci'd with no MR yet to trigger against, so the branch has no CI until the MR is created — surfaced, not silent).
- `codebase/clients/github/client.py` — the GitHub assignee-dedup guard now compares against `assignee.login` instead of `NamedUser.id`. `assignee_id` is a username string on the GitHub path, so the old `assignee.id == assignee_id` never matched and re-added the assignee on every publish. Fixed on both the create path and the (currently dormant) update path.

## Tests

- Unit coverage for each piece plus the `publish()` gate matrix: GitLab + ephemeral → skip-ci push **and** trigger; GitLab + PAT fallback → neither; GitHub (even with the signal forced on) → neither; explicit `publish(skip_ci=True)` → neither. One test specifically defends the GitHub short-circuit so a future "always await then filter" rewrite would fail.
- A test that `-o ci.skip` rides the `integrate_on_reject` rebase-retry push, guarding the exact existing-MR + ephemeral-token path the heal exists for.
- GitHub assignee-dedup regression tests use a real `NamedUser` (`is_not_lazy=False`) so the `.login` comparison is exercised against a real object: skip when already assigned, add when not.
- Full suite green (**4145 passed**); `make lint-fix` clean; `make lint-typing` adds no new errors on the touched lines.

## Out of scope / follow-up

- The private templates repo's visibility, the ephemeral-token design, and GitHub Actions are intentionally untouched.