### PR TITLE
feat: accept API-key auth on the MCP endpoint

### DIFF
--- a/daiv/mcp_server/auth.py
+++ b/daiv/mcp_server/auth.py
@@ -6,27 +6,24 @@ from mcp.server.auth.middleware.auth_context import get_access_token
 from mcp.server.auth.provider import AccessToken as MCPAccessToken
 from oauth2_provider.models import AccessToken as OAuthAccessToken
 
+from accounts.models import APIKey
+
 if TYPE_CHECKING:
     from accounts.models import User
 
 logger = logging.getLogger("daiv.mcp_server")
 
+# client_id prefix used for MCP access tokens minted from an API key, so the SDK's
+# AuthenticatedUser carries a stable, non-OAuth identity distinguishable in logs.
+API_KEY_CLIENT_ID_PREFIX = "api-key:"
 
-async def get_current_user() -> User | None:
-    """Get the Django user associated with the current MCP request.
 
-    Derives the user from the SDK-managed access token contextvar,
-    so it is only available during MCP tool/resource execution after successful authentication.
-    """
-    access_token = get_access_token()
-    if access_token is None:
-        return None
-
-    token_checksum = hashlib.sha256(access_token.token.encode("utf-8")).hexdigest()
+async def _user_from_oauth_token(token: str) -> User | None:
+    """Resolve the active user for an OAuth access token, or None if it can't be resolved."""
+    token_checksum = hashlib.sha256(token.encode("utf-8")).hexdigest()
     try:
         oauth_token = await OAuthAccessToken.objects.select_related("user").aget(token_checksum=token_checksum)
     except OAuthAccessToken.DoesNotExist:
-        logger.warning("OAuth token not found during user resolution (token may have been revoked)")
         return None
 
     if not oauth_token.user.is_active:
@@ -35,10 +32,52 @@ async def get_current_user() -> User | None:
     return oauth_token.user
 
 
+async def _user_from_api_key(token: str) -> User | None:
+    """Resolve the active user for an API key, or None if the key is unusable/inactive."""
+    try:
+        api_key = await APIKey.objects.get_from_key(token)
+    except APIKey.DoesNotExist:
+        return None
+
+    if not api_key.user.is_active:
+        logger.warning("API key used by an inactive user during user resolution")
+        return None
+    return api_key.user
+
+
+async def get_current_user() -> User | None:
+    """Get the Django user associated with the current MCP request.
+
+    Derives the user from the SDK-managed access token contextvar, so it is only available
+    during MCP tool/resource execution after successful authentication. Handles both OAuth2
+    access tokens and ``accounts.APIKey`` keys; the re-lookup (rather than trusting the
+    verifier's result) re-validates revocation/expiry at execution time for both.
+    """
+    access_token = get_access_token()
+    if access_token is None:
+        return None
+
+    user = await _user_from_oauth_token(access_token.token)
+    if user is None:
+        user = await _user_from_api_key(access_token.token)
+    if user is None:
+        logger.warning("Token not found during user resolution (may have been revoked)")
+    return user
+
+
 class DjangoOAuthTokenVerifier:
-    """MCP TokenVerifier backed by django-oauth-toolkit's AccessToken model."""
+    """MCP TokenVerifier backed by django-oauth-toolkit's AccessToken and ``accounts.APIKey``.
+
+    Bearer tokens are verified first as OAuth2 access tokens, then as API keys. Both grant the
+    ``mcp`` scope so the SDK's ``required_scopes`` gate passes; API keys are per-user and carry
+    no scopes of their own, so any usable key authenticates against MCP (same blanket access it
+    already has on the REST Jobs/Chat endpoints).
+    """
 
     async def verify_token(self, token: str) -> MCPAccessToken | None:
+        return await self._verify_oauth_token(token) or await self._verify_api_key(token)
+
+    async def _verify_oauth_token(self, token: str) -> MCPAccessToken | None:
         token_checksum = hashlib.sha256(token.encode("utf-8")).hexdigest()
         try:
             access_token = await OAuthAccessToken.objects.select_related("application", "user").aget(
@@ -71,4 +110,24 @@ class DjangoOAuthTokenVerifier:
             client_id=access_token.application.client_id,
             scopes=access_token.scope.split() if access_token.scope else [],
             expires_at=int(access_token.expires.timestamp()) if access_token.expires else None,
+        )
+
+    async def _verify_api_key(self, token: str) -> MCPAccessToken | None:
+        try:
+            api_key = await APIKey.objects.get_from_key(token)
+        except APIKey.DoesNotExist:
+            return None
+        except Exception:
+            logger.exception("Failed to validate API key against database")
+            raise
+
+        if not api_key.user.is_active:
+            logger.warning("API key used for MCP access belongs to an inactive user")
+            return None
+
+        return MCPAccessToken(
+            token=token,
+            client_id=f"{API_KEY_CLIENT_ID_PREFIX}{api_key.prefix}",
+            scopes=["mcp"],
+            expires_at=int(api_key.expires_at.timestamp()) if api_key.expires_at else None,
         )

--- a/daiv/mcp_server/auth.py
+++ b/daiv/mcp_server/auth.py
@@ -62,12 +62,16 @@ async def get_current_user() -> User | None:
 
     Accepts OAuth2 access tokens and ``accounts.APIKey`` keys, re-resolving the user on every
     call so a token revoked — or a user deactivated — between verification and execution is
-    rejected.
+    rejected. Dispatches on the verified token's ``client_id`` (set by the verifier) so an
+    API-key request doesn't pay a guaranteed-miss OAuth lookup; OAuth client ids never contain
+    ``:``, so they can't collide with the ``api-key:`` prefix.
     """
     access_token = get_access_token()
     if access_token is None:
         return None
-    return await _user_from_oauth_token(access_token.token) or await _user_from_api_key(access_token.token)
+    if access_token.client_id.startswith(API_KEY_CLIENT_ID_PREFIX):
+        return await _user_from_api_key(access_token.token)
+    return await _user_from_oauth_token(access_token.token)
 
 
 class DjangoTokenVerifier:

--- a/daiv/mcp_server/auth.py
+++ b/daiv/mcp_server/auth.py
@@ -13,8 +13,6 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger("daiv.mcp_server")
 
-# client_id prefix used for MCP access tokens minted from an API key, so the SDK's
-# AuthenticatedUser carries a stable, non-OAuth identity distinguishable in logs.
 API_KEY_CLIENT_ID_PREFIX = "api-key:"
 
 
@@ -35,32 +33,36 @@ async def _user_from_oauth_token(token: str) -> User | None:
     return oauth_token.user
 
 
-async def _user_from_api_key(token: str) -> User | None:
-    """Resolve the active user for an API key, or None if the key is unusable/inactive."""
+async def _active_api_key(token: str) -> APIKey | None:
+    """Resolve a usable API key whose user is active, or None. Shared by the verifier and
+    execution-time resolution so the lookup + active-user gate lives in one place."""
     try:
         api_key = await APIKey.objects.get_from_key(token)
     except APIKey.DoesNotExist:
         return None
     except Exception:
-        logger.exception("Failed to resolve user from API key")
+        logger.exception("Failed to resolve API key")
         raise
 
     if not api_key.user.is_active:
-        logger.warning("API key used by an inactive user during user resolution")
+        logger.warning("API key used by an inactive user")
         return None
-    return api_key.user
+    return api_key
+
+
+async def _user_from_api_key(token: str) -> User | None:
+    """Resolve the active user for an API key, or None if the key is unusable/inactive."""
+    api_key = await _active_api_key(token)
+    return api_key.user if api_key else None
 
 
 async def get_current_user() -> User | None:
-    """Get the Django user associated with the current MCP request.
+    """Get the Django user for the current MCP request from the SDK-managed access-token
+    contextvar (only populated during tool/resource execution, after authentication).
 
-    Derives the user from the SDK-managed access token contextvar, so it is only available
-    during MCP tool/resource execution after successful authentication. Accepts both OAuth2
-    access tokens and ``accounts.APIKey`` keys, re-resolving the user on each call so a token
-    deleted/revoked — or a user deactivated — between verification and execution is rejected.
-    (The API-key branch additionally drops expired keys via ``get_usable_keys``; the OAuth
-    branch re-checks existence and active status, not expiry.) Each branch logs the actionable
-    rejection reason; a benign not-found race resolves to None without a log.
+    Accepts OAuth2 access tokens and ``accounts.APIKey`` keys, re-resolving the user on every
+    call so a token revoked — or a user deactivated — between verification and execution is
+    rejected.
     """
     access_token = get_access_token()
     if access_token is None:
@@ -68,7 +70,7 @@ async def get_current_user() -> User | None:
     return await _user_from_oauth_token(access_token.token) or await _user_from_api_key(access_token.token)
 
 
-class DjangoOAuthTokenVerifier:
+class DjangoTokenVerifier:
     """MCP TokenVerifier backed by django-oauth-toolkit's AccessToken and ``accounts.APIKey``.
 
     Bearer tokens are verified first as OAuth2 access tokens, then as API keys. Both grant the
@@ -116,18 +118,9 @@ class DjangoOAuthTokenVerifier:
         )
 
     async def _verify_api_key(self, token: str) -> MCPAccessToken | None:
-        try:
-            api_key = await APIKey.objects.get_from_key(token)
-        except APIKey.DoesNotExist:
+        api_key = await _active_api_key(token)
+        if api_key is None:
             return None
-        except Exception:
-            logger.exception("Failed to validate API key against database")
-            raise
-
-        if not api_key.user.is_active:
-            logger.warning("API key used for MCP access belongs to an inactive user")
-            return None
-
         return MCPAccessToken(
             token=token,
             client_id=f"{API_KEY_CLIENT_ID_PREFIX}{api_key.prefix}",

--- a/daiv/mcp_server/auth.py
+++ b/daiv/mcp_server/auth.py
@@ -25,6 +25,9 @@ async def _user_from_oauth_token(token: str) -> User | None:
         oauth_token = await OAuthAccessToken.objects.select_related("user").aget(token_checksum=token_checksum)
     except OAuthAccessToken.DoesNotExist:
         return None
+    except Exception:
+        logger.exception("Failed to resolve user from OAuth token")
+        raise
 
     if not oauth_token.user.is_active:
         logger.warning("OAuth token used by an inactive user during user resolution")
@@ -38,6 +41,9 @@ async def _user_from_api_key(token: str) -> User | None:
         api_key = await APIKey.objects.get_from_key(token)
     except APIKey.DoesNotExist:
         return None
+    except Exception:
+        logger.exception("Failed to resolve user from API key")
+        raise
 
     if not api_key.user.is_active:
         logger.warning("API key used by an inactive user during user resolution")
@@ -49,20 +55,17 @@ async def get_current_user() -> User | None:
     """Get the Django user associated with the current MCP request.
 
     Derives the user from the SDK-managed access token contextvar, so it is only available
-    during MCP tool/resource execution after successful authentication. Handles both OAuth2
-    access tokens and ``accounts.APIKey`` keys; the re-lookup (rather than trusting the
-    verifier's result) re-validates revocation/expiry at execution time for both.
+    during MCP tool/resource execution after successful authentication. Accepts both OAuth2
+    access tokens and ``accounts.APIKey`` keys, re-resolving the user on each call so a token
+    deleted/revoked — or a user deactivated — between verification and execution is rejected.
+    (The API-key branch additionally drops expired keys via ``get_usable_keys``; the OAuth
+    branch re-checks existence and active status, not expiry.) Each branch logs the actionable
+    rejection reason; a benign not-found race resolves to None without a log.
     """
     access_token = get_access_token()
     if access_token is None:
         return None
-
-    user = await _user_from_oauth_token(access_token.token)
-    if user is None:
-        user = await _user_from_api_key(access_token.token)
-    if user is None:
-        logger.warning("Token not found during user resolution (may have been revoked)")
-    return user
+    return await _user_from_oauth_token(access_token.token) or await _user_from_api_key(access_token.token)
 
 
 class DjangoOAuthTokenVerifier:

--- a/daiv/mcp_server/server.py
+++ b/daiv/mcp_server/server.py
@@ -31,7 +31,7 @@ from codebase.authorization import (
 )
 from core.conf import settings as core_settings
 from core.models import ThinkingLevelChoices  # noqa: TC001 - runtime literal for FastMCP
-from mcp_server.auth import DjangoOAuthTokenVerifier, get_current_user
+from mcp_server.auth import DjangoTokenVerifier, get_current_user
 from schedules.models import Frequency, Intent, ScheduledJob  # noqa: TC001 - runtime literal for FastMCP
 from schedules.services import acreate_scheduled_job, alist_scheduled_jobs
 
@@ -75,7 +75,7 @@ continue polling with `get_job_status` if the result is not yet available.\
     stateless_http=True,
     transport_security=TransportSecuritySettings(enable_dns_rebinding_protection=False),
     auth=AuthSettings(issuer_url=_external_url, resource_server_url=f"{_external_url}/mcp", required_scopes=["mcp"]),
-    token_verifier=DjangoOAuthTokenVerifier(),
+    token_verifier=DjangoTokenVerifier(),
 )
 
 _THREAD_NOT_FOUND = "thread_id not found"

--- a/docs/features/mcp-endpoint.md
+++ b/docs/features/mcp-endpoint.md
@@ -4,10 +4,38 @@ DAIV exposes a [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) 
 
 The DAIV agent can read and modify code, run commands in a sandbox, create commits and branches, open merge requests or pull requests, and debug CI/CD pipelines. Through the MCP endpoint, your local assistant can offload these tasks to DAIV and get the results back.
 
-Authentication is handled via OAuth 2.0 — on first use a browser window opens for you to log in with your existing DAIV account. Your client manages tokens and refreshes them automatically.
+## Authentication
 
-!!! tip
-    Prefer the HTTP [Jobs API](jobs-api.md) instead? It uses API key authentication, and you can create a key self-service in the dashboard at `/accounts/api-keys/` (see [Creating an API key](jobs-api.md#creating-an-api-key)).
+The endpoint accepts two authentication methods:
+
+- **OAuth 2.0** (default for interactive clients) — on first use a browser window opens for you to log in with your existing DAIV account. Your client manages tokens and refreshes them automatically. This is what the editor integrations below use out of the box.
+- **API key** — pass an `Authorization: Bearer <api-key>` header. This is aimed at headless or non-interactive clients (CI jobs, scripts) that can't complete the browser flow. Create a key self-service in the dashboard at `/accounts/api-keys/` (see [Creating an API key](jobs-api.md#creating-an-api-key)); the same key also works against the HTTP [Jobs API](jobs-api.md).
+
+!!! note
+    API keys are scoped to your user, not to a specific surface — a key that authenticates against the MCP endpoint has the same access as it does on the REST Jobs/Chat API. Revoke a key from the dashboard to cut off both at once.
+
+### Authenticating with an API key
+
+Any MCP client that lets you set request headers can pass the key. For example, with Claude Code:
+
+```bash
+claude mcp add daiv --transport http https://daiv.example.com/mcp/ \
+  --header "Authorization: Bearer <prefix.secret>"
+```
+
+Or in Cursor's `mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "daiv": {
+      "type": "streamable-http",
+      "url": "https://daiv.example.com/mcp/",
+      "headers": { "Authorization": "Bearer <prefix.secret>" }
+    }
+  }
+}
+```
 
 ## Getting started
 

--- a/tests/unit_tests/mcp_server/test_auth.py
+++ b/tests/unit_tests/mcp_server/test_auth.py
@@ -279,6 +279,22 @@ async def test_get_current_user_returns_user_for_api_key(api_key, user):
 
 
 @pytest.mark.django_db(transaction=True)
+async def test_get_current_user_api_key_client_id_skips_oauth_probe(api_key, user):
+    """An ``api-key:`` client_id dispatches straight to the key resolver, no OAuth lookup."""
+    mcp_token = MCPAccessToken(token=api_key, client_id=f"{API_KEY_CLIENT_ID_PREFIX}x", scopes=["mcp"])
+
+    with (
+        patch("mcp_server.auth.get_access_token", return_value=mcp_token),
+        patch("mcp_server.auth._user_from_oauth_token") as oauth_resolver,
+    ):
+        result = await get_current_user()
+
+    oauth_resolver.assert_not_called()
+    assert result is not None
+    assert result.pk == user.pk
+
+
+@pytest.mark.django_db(transaction=True)
 async def test_get_current_user_returns_none_when_api_key_revoked(api_key, user):
     """Key was valid at auth time but revoked before get_current_user runs (TOCTOU)."""
     mcp_token = MCPAccessToken(token=api_key, client_id="api-key:x", scopes=["mcp"])

--- a/tests/unit_tests/mcp_server/test_auth.py
+++ b/tests/unit_tests/mcp_server/test_auth.py
@@ -176,6 +176,24 @@ async def test_get_current_user_returns_none_without_token():
 
 
 @pytest.mark.django_db(transaction=True)
+async def test_get_current_user_db_error_propagates():
+    """An unexpected DB error during execution-time resolution propagates (and is logged)."""
+    from django.db import OperationalError
+
+    mcp_token = MCPAccessToken(token="any-token", client_id="test", scopes=["mcp"])  # noqa: S106
+    mock_qs = AsyncMock()
+    mock_qs.aget.side_effect = OperationalError("connection refused")
+
+    with (
+        patch("mcp_server.auth.get_access_token", return_value=mcp_token),
+        patch("mcp_server.auth.OAuthAccessToken.objects") as mock_objects,
+        pytest.raises(OperationalError),
+    ):
+        mock_objects.select_related.return_value = mock_qs
+        await get_current_user()
+
+
+@pytest.mark.django_db(transaction=True)
 async def test_get_current_user_returns_none_when_token_deleted(access_token):
     """Token was valid at auth time but deleted before get_current_user runs (TOCTOU)."""
     mcp_token = MCPAccessToken(token="test-valid-token", client_id="test", scopes=["mcp"])  # noqa: S106

--- a/tests/unit_tests/mcp_server/test_auth.py
+++ b/tests/unit_tests/mcp_server/test_auth.py
@@ -5,9 +5,9 @@ from django.utils import timezone
 
 import pytest
 from mcp.server.auth.provider import AccessToken as MCPAccessToken
-from mcp_server.auth import DjangoOAuthTokenVerifier, get_current_user
+from mcp_server.auth import API_KEY_CLIENT_ID_PREFIX, DjangoOAuthTokenVerifier, get_current_user
 
-from accounts.models import User
+from accounts.models import APIKey, User
 
 
 @pytest.fixture
@@ -77,6 +77,28 @@ def no_app_token(user):
         expires=timezone.now() + timedelta(hours=1),
         scope="mcp",
     )
+
+
+@pytest.fixture
+async def api_key(user):
+    _, raw_key = await APIKey.objects.create_key(user, name="test-key")
+    return raw_key
+
+
+@pytest.fixture
+async def expired_api_key(user):
+    _, raw_key = await APIKey.objects.create_key(
+        user, name="expired-key", expires_at=timezone.now() - timedelta(hours=1)
+    )
+    return raw_key
+
+
+@pytest.fixture
+async def revoked_api_key(user):
+    obj, raw_key = await APIKey.objects.create_key(user, name="revoked-key")
+    obj.revoked = True
+    await obj.asave(update_fields=["revoked"])
+    return raw_key
 
 
 @pytest.fixture
@@ -180,6 +202,79 @@ async def test_get_current_user_inactive_user_rejected(access_token, user):
     user.is_active = False
     await user.asave(update_fields=["is_active"])
     mcp_token = MCPAccessToken(token="test-valid-token", client_id="test", scopes=["mcp"])  # noqa: S106
+
+    with patch("mcp_server.auth.get_access_token", return_value=mcp_token):
+        assert await get_current_user() is None
+
+
+# --- API key authentication -------------------------------------------------
+
+
+@pytest.mark.django_db(transaction=True)
+async def test_verify_api_key_returns_access_token(verifier, api_key):
+    result = await verifier.verify_token(api_key)
+
+    assert result is not None
+    assert result.token == api_key
+    assert result.scopes == ["mcp"]
+    assert result.client_id.startswith(API_KEY_CLIENT_ID_PREFIX)
+    assert result.expires_at is None
+
+
+@pytest.mark.django_db(transaction=True)
+async def test_verify_api_key_with_expiry_sets_expires_at(verifier, user):
+    _, raw_key = await APIKey.objects.create_key(user, name="dated-key", expires_at=timezone.now() + timedelta(hours=1))
+
+    result = await verifier.verify_token(raw_key)
+
+    assert result is not None
+    assert result.expires_at is not None
+
+
+@pytest.mark.django_db(transaction=True)
+async def test_verify_expired_api_key_returns_none(verifier, expired_api_key):
+    assert await verifier.verify_token(expired_api_key) is None
+
+
+@pytest.mark.django_db(transaction=True)
+async def test_verify_revoked_api_key_returns_none(verifier, revoked_api_key):
+    assert await verifier.verify_token(revoked_api_key) is None
+
+
+@pytest.mark.django_db(transaction=True)
+async def test_verify_api_key_inactive_user_rejected(verifier, api_key, user):
+    user.is_active = False
+    await user.asave(update_fields=["is_active"])
+
+    assert await verifier.verify_token(api_key) is None
+
+
+@pytest.mark.django_db(transaction=True)
+async def test_get_current_user_returns_user_for_api_key(api_key, user):
+    mcp_token = MCPAccessToken(token=api_key, client_id="api-key:x", scopes=["mcp"])
+
+    with patch("mcp_server.auth.get_access_token", return_value=mcp_token):
+        result = await get_current_user()
+
+    assert result is not None
+    assert result.pk == user.pk
+
+
+@pytest.mark.django_db(transaction=True)
+async def test_get_current_user_returns_none_when_api_key_revoked(api_key, user):
+    """Key was valid at auth time but revoked before get_current_user runs (TOCTOU)."""
+    mcp_token = MCPAccessToken(token=api_key, client_id="api-key:x", scopes=["mcp"])
+    await APIKey.objects.filter(user=user).aupdate(revoked=True)
+
+    with patch("mcp_server.auth.get_access_token", return_value=mcp_token):
+        assert await get_current_user() is None
+
+
+@pytest.mark.django_db(transaction=True)
+async def test_get_current_user_inactive_user_rejected_for_api_key(api_key, user):
+    user.is_active = False
+    await user.asave(update_fields=["is_active"])
+    mcp_token = MCPAccessToken(token=api_key, client_id="api-key:x", scopes=["mcp"])
 
     with patch("mcp_server.auth.get_access_token", return_value=mcp_token):
         assert await get_current_user() is None

--- a/tests/unit_tests/mcp_server/test_auth.py
+++ b/tests/unit_tests/mcp_server/test_auth.py
@@ -5,7 +5,7 @@ from django.utils import timezone
 
 import pytest
 from mcp.server.auth.provider import AccessToken as MCPAccessToken
-from mcp_server.auth import API_KEY_CLIENT_ID_PREFIX, DjangoOAuthTokenVerifier, get_current_user
+from mcp_server.auth import API_KEY_CLIENT_ID_PREFIX, DjangoTokenVerifier, get_current_user
 
 from accounts.models import APIKey, User
 
@@ -103,7 +103,7 @@ async def revoked_api_key(user):
 
 @pytest.fixture
 def verifier():
-    return DjangoOAuthTokenVerifier()
+    return DjangoTokenVerifier()
 
 
 @pytest.mark.django_db(transaction=True)


### PR DESCRIPTION
The MCP endpoint previously required OAuth 2.0, forcing headless clients
(CI, scripts) through an interactive browser flow. Extend the token
verifier to also accept `accounts.APIKey` bearer tokens: `verify_token`
tries OAuth first, then API keys, minting an MCP access token with the
`mcp` scope so the SDK's required-scopes gate passes. `get_current_user`
resolves the user for either token type, re-validating revocation/expiry
at execution time.

API keys are per-user with no scopes, so any usable key authenticates
against MCP with the same blanket access it already has on the REST
Jobs/Chat API.
