### PR TITLE
fix(sessions): repair session list mobile overflow

### DIFF
--- a/daiv/sessions/templates/sessions/_session_row.html
+++ b/daiv/sessions/templates/sessions/_session_row.html
@@ -15,17 +15,17 @@
         {% icon session.origin|origin_icon "h-4 w-4" %}
     </span>
 
-    <div class="flex min-w-0 flex-1 items-center gap-2.5">
+    <div class="flex min-w-0 flex-1 items-center gap-2.5 overflow-hidden">
         <span class="truncate text-[14px] font-medium text-white">
             {% if session.title %}{{ session.title }}{% else %}<em class="text-gray-500">{% translate "generating title…" %}</em>{% endif %}
         </span>
         {% if session.repo_id %}
-        <span class="session-repo shrink-0" title="{{ session.repo_id }}">
-            {% icon "repo" "h-3 w-3 shrink-0" %}<span class="max-w-[220px] truncate">{{ session.repo_id }}</span>
+        <span class="session-repo min-w-0 shrink-0" title="{{ session.repo_id }}">
+            {% icon "repo" "h-3 w-3 shrink-0" %}<span class="max-w-[120px] truncate sm:max-w-[220px]">{{ session.repo_id }}</span>
         </span>
         {% endif %}
         {% if session.ref %}
-        <span class="session-branch shrink-0">{% icon "branch" "h-3 w-3" %}{{ session.ref }}</span>
+        <span class="session-branch min-w-0" title="{{ session.ref }}">{% icon "branch" "h-3 w-3 shrink-0" %}<span class="truncate">{{ session.ref }}</span></span>
         {% endif %}
         {% if session.merge_request_iid %}
             {% if latest.merge_request_web_url %}

--- a/daiv/static_src/css/input.css
+++ b/daiv/static_src/css/input.css
@@ -2064,9 +2064,14 @@ main:has(.chat-shell) {
     @apply h-9 w-full rounded-xl border border-white/[0.06] bg-[#0b1018]
       pl-9 pr-3 text-sm text-gray-300 placeholder:text-gray-500;
   }
-  .filter-seg { @apply inline-flex items-center gap-0.5 rounded-xl border border-white/[0.06] bg-white/[0.02] p-1; }
+  .filter-seg {
+    @apply inline-flex max-w-full items-center gap-0.5 overflow-x-auto rounded-xl
+      border border-white/[0.06] bg-white/[0.02] p-1;
+    scrollbar-width: none;
+  }
+  .filter-seg::-webkit-scrollbar { display: none; }
   .filter-seg-item {
-    @apply inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-[13px] font-medium
+    @apply inline-flex shrink-0 items-center gap-1.5 rounded-lg px-2.5 py-1.5 text-[13px] font-medium
       text-gray-400 transition-colors hover:text-gray-200;
   }
   .filter-seg-item--active { @apply bg-white/[0.1] text-white; }


### PR DESCRIPTION
The Agent sessions page had two mobile layout defects:

- The status segmented control (All/Queued/…/Failed) was wider than the
  viewport and, since `<main>` clips overflow-x, the trailing chips were
  unreachable rather than scrollable. Make `.filter-seg` an
  overflow-x-auto scroller (hidden scrollbar) with non-shrinking items so
  every status stays reachable on narrow screens.

- Long branch names in a row were `shrink-0` with no truncation, so they
  spilled over and overlapped the relative-time column. Let the branch
  shrink and truncate with an ellipsis, cap the repo width on small
  screens, and clip the row's middle section as a safety net.