### PR TITLE
fix: disable pinch-to-zoom on mobile

### DIFF
--- a/daiv/accounts/templates/base.html
+++ b/daiv/accounts/templates/base.html
@@ -2,7 +2,7 @@
 <html lang="en" class="h-full">
 <head>
     <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
     <title>{% block title %}DAIV{% endblock %}</title>
     {% block meta_description %}<meta name="description" content="DAIV is an open-source async SWE agent that integrates natively with GitLab and GitHub. Create an issue, get a merge request.">{% endblock %}
     {% block meta_robots %}{% endblock %}


### PR DESCRIPTION
The viewport meta tag only pinned initial-scale, leaving pinch-to-zoom
enabled on mobile. Add maximum-scale=1 and user-scalable=no so the app
UI cannot be zoomed.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015HsavnZNYppo87pjquFMYy