### PR TITLE
feat(chat): show elapsed time in the working loader

### DIFF
--- a/daiv/chat/static/chat/js/chat-stream.js
+++ b/daiv/chat/static/chat/js/chat-stream.js
@@ -102,6 +102,15 @@
     "Running tools…",
   ];
 
+  // Tiers mirror the ``duration`` template filter (sessions/templatetags/session_tags.py)
+  // so a run reads the same live as it does once it lands in the sessions list.
+  const formatElapsed = (sec) => {
+    if (sec < 60) return `${sec}s`;
+    const min = Math.floor(sec / 60);
+    if (min < 60) return `${min}m ${sec % 60}s`;
+    return `${Math.floor(min / 60)}h ${min % 60}m`;
+  };
+
   const pickPath = (argsStr) => {
     try {
       const args = JSON.parse(argsStr);
@@ -165,11 +174,9 @@
     _thinkingTimer: null,
     _scrollListener: null,
     _thinkingPhrase: THINKING_LABELS[0],
-    // Wall-clock origin of the run the loader is currently reporting on, and the
-    // seconds derived from it (see _startElapsed).
-    _runStartedAt: 0,
-    _elapsedTimer: null,
-    runElapsed: 0,
+    // Wall-clock origin of the run in progress, 0 when idle. Read by the loader's
+    // `elapsed` clock; set where a run actually starts, never inferred.
+    runStartedAt: 0,
     filesTouchedLimit: 20,
     // Reactive clock backing relative timestamps: a single interval bumps it
     // (init/destroy) so every `relativeTime()` label recomputes instead of freezing.
@@ -284,27 +291,19 @@
             i = (i + 1) % THINKING_LABELS.length;
             this._thinkingPhrase = THINKING_LABELS[i];
           }, 1800);
-          this._startElapsed();
         } else {
-          if (this._thinkingTimer) {
-            clearInterval(this._thinkingTimer);
-            this._thinkingTimer = null;
-          }
-          this._stopElapsed();
+          clearInterval(this._thinkingTimer);
+          this._thinkingTimer = null;
+          this.runStartedAt = 0;
         }
       });
-
-      // The loader is already on screen while resuming, before `streaming` flips
-      // and fires the watcher above — start its timer from the server-reported
-      // start so a rejoined run doesn't restart the count at 0.
-      if (this.resuming) {
-        this._startElapsed(Date.parse(config.activeRunStartedAt || ""));
-      }
 
       if (this.resuming && this.thread && config.activeRunId) {
         // Page loaded while a run is executing server-side: rejoin its event
         // stream with a full replay, deduping anything already rendered from
-        // the checkpoint hydration.
+        // the checkpoint hydration. The clock counts from the server-reported
+        // start so a rejoined run doesn't restart at 0.
+        this.runStartedAt = Date.parse(config.activeRunStartedAt || "") || Date.now();
         this._resumeRun(config.activeRunId);
       } else {
         this.resuming = false;
@@ -323,29 +322,8 @@
         this._scrollEl.removeEventListener("scroll", this._scrollListener);
       }
       if (this._thinkingTimer) clearInterval(this._thinkingTimer);
-      if (this._elapsedTimer) clearInterval(this._elapsedTimer);
       if (this._nowTimer) clearInterval(this._nowTimer);
       if (this._source) this._source.close();
-    },
-
-    // Idempotent: the resume path seeds the origin before `streaming` flips, and the
-    // watcher must not reset it to now. Each tick re-derives from the origin instead
-    // of incrementing, so a throttled background tab still reads the true elapsed time.
-    _startElapsed(startedAtMs) {
-      if (this._elapsedTimer) return;
-      this._runStartedAt = Number.isFinite(startedAtMs) ? startedAtMs : Date.now();
-      const tick = () => {
-        this.runElapsed = Math.max(0, Math.floor((Date.now() - this._runStartedAt) / 1000));
-      };
-      tick();
-      this._elapsedTimer = setInterval(tick, 1000);
-    },
-
-    _stopElapsed() {
-      if (this._elapsedTimer) clearInterval(this._elapsedTimer);
-      this._elapsedTimer = null;
-      this._runStartedAt = 0;
-      this.runElapsed = 0;
     },
 
     // ---------- Run stream (EventSource against the relay) -------------
@@ -480,16 +458,6 @@
       );
       if (activeTool) return { tone: "running", label: `running ${activeTool.name}…` };
       return { tone: "thinking", label: this._thinkingPhrase };
-    },
-
-    // Seconds padded inside the minute/hour forms so the ticking label keeps a
-    // stable width. Untranslated, like the rest of the JS-rendered status text.
-    get runElapsedLabel() {
-      const sec = this.runElapsed;
-      if (sec < 60) return `${sec}s`;
-      const min = Math.floor(sec / 60);
-      if (min < 60) return `${min}m ${String(sec % 60).padStart(2, "0")}s`;
-      return `${Math.floor(min / 60)}h ${String(min % 60).padStart(2, "0")}m`;
     },
 
     get latestTodos() {
@@ -670,7 +638,7 @@
       if (seg.status === "running") return "Thinking…";
       if (!seg.startedAt || !seg.endedAt) return "Reasoning";
       const s = Math.max(1, Math.round((seg.endedAt - seg.startedAt) / 1000));
-      return s < 60 ? `Thought for ${s}s` : `Thought for ${Math.floor(s / 60)}m ${s % 60}s`;
+      return `Thought for ${formatElapsed(s)}`;
     },
 
     fileOpMark(op) {
@@ -780,6 +748,7 @@
       this.draftMessage = "";
       this.$nextTick(() => this.autosize());
       this.streaming = true;
+      this.runStartedAt = Date.now();
       this._activeRun = { threadId: this.thread.thread_id, runId: body.runId };
 
       // Forward the picker's selection so the API resolves the requested env per-request;
@@ -1153,8 +1122,46 @@
     },
   });
 
+  // Ticking "how long has this run been going" clock, shared by the working loader
+  // and the queued/running card. `track()` takes an ISO string or epoch ms and 0 to
+  // stop; each tick re-derives from the origin rather than incrementing, so interval
+  // clamping in a background tab costs accuracy nothing. Origin and handle stay
+  // closure-local: only `seconds` needs to be reactive.
+  const elapsed = (startedAt = 0) => {
+    let origin = 0;
+    let timer = null;
+    return {
+      seconds: 0,
+      init() {
+        this.track(startedAt);
+      },
+      get label() {
+        return formatElapsed(this.seconds);
+      },
+      track(next) {
+        const parsed = typeof next === "string" ? Date.parse(next) : next;
+        const at = Number.isFinite(parsed) ? parsed : 0;
+        if (at === origin) return;
+        origin = at;
+        clearInterval(timer);
+        timer = null;
+        this.seconds = 0;
+        if (!at) return;
+        const tick = () => {
+          this.seconds = Math.max(0, Math.floor((Date.now() - origin) / 1000));
+        };
+        tick();
+        timer = setInterval(tick, 1000);
+      },
+      destroy() {
+        clearInterval(timer);
+      },
+    };
+  };
+
   document.addEventListener("alpine:init", () => {
     window.Alpine.data("chat", chat);
     window.Alpine.data("userClamp", userClamp);
+    window.Alpine.data("elapsed", elapsed);
   });
 })();

--- a/daiv/chat/static/chat/js/chat-stream.js
+++ b/daiv/chat/static/chat/js/chat-stream.js
@@ -165,6 +165,11 @@
     _thinkingTimer: null,
     _scrollListener: null,
     _thinkingPhrase: THINKING_LABELS[0],
+    // Wall-clock origin of the run the loader is currently reporting on, and the
+    // seconds derived from it (see _startElapsed).
+    _runStartedAt: 0,
+    _elapsedTimer: null,
+    runElapsed: 0,
     filesTouchedLimit: 20,
     // Reactive clock backing relative timestamps: a single interval bumps it
     // (init/destroy) so every `relativeTime()` label recomputes instead of freezing.
@@ -279,11 +284,22 @@
             i = (i + 1) % THINKING_LABELS.length;
             this._thinkingPhrase = THINKING_LABELS[i];
           }, 1800);
-        } else if (this._thinkingTimer) {
-          clearInterval(this._thinkingTimer);
-          this._thinkingTimer = null;
+          this._startElapsed();
+        } else {
+          if (this._thinkingTimer) {
+            clearInterval(this._thinkingTimer);
+            this._thinkingTimer = null;
+          }
+          this._stopElapsed();
         }
       });
+
+      // The loader is already on screen while resuming, before `streaming` flips
+      // and fires the watcher above — start its timer from the server-reported
+      // start so a rejoined run doesn't restart the count at 0.
+      if (this.resuming) {
+        this._startElapsed(Date.parse(config.activeRunStartedAt || ""));
+      }
 
       if (this.resuming && this.thread && config.activeRunId) {
         // Page loaded while a run is executing server-side: rejoin its event
@@ -307,8 +323,29 @@
         this._scrollEl.removeEventListener("scroll", this._scrollListener);
       }
       if (this._thinkingTimer) clearInterval(this._thinkingTimer);
+      if (this._elapsedTimer) clearInterval(this._elapsedTimer);
       if (this._nowTimer) clearInterval(this._nowTimer);
       if (this._source) this._source.close();
+    },
+
+    // Idempotent: the resume path seeds the origin before `streaming` flips, and the
+    // watcher must not reset it to now. Each tick re-derives from the origin instead
+    // of incrementing, so a throttled background tab still reads the true elapsed time.
+    _startElapsed(startedAtMs) {
+      if (this._elapsedTimer) return;
+      this._runStartedAt = Number.isFinite(startedAtMs) ? startedAtMs : Date.now();
+      const tick = () => {
+        this.runElapsed = Math.max(0, Math.floor((Date.now() - this._runStartedAt) / 1000));
+      };
+      tick();
+      this._elapsedTimer = setInterval(tick, 1000);
+    },
+
+    _stopElapsed() {
+      if (this._elapsedTimer) clearInterval(this._elapsedTimer);
+      this._elapsedTimer = null;
+      this._runStartedAt = 0;
+      this.runElapsed = 0;
     },
 
     // ---------- Run stream (EventSource against the relay) -------------
@@ -443,6 +480,16 @@
       );
       if (activeTool) return { tone: "running", label: `running ${activeTool.name}…` };
       return { tone: "thinking", label: this._thinkingPhrase };
+    },
+
+    // Seconds padded inside the minute/hour forms so the ticking label keeps a
+    // stable width. Untranslated, like the rest of the JS-rendered status text.
+    get runElapsedLabel() {
+      const sec = this.runElapsed;
+      if (sec < 60) return `${sec}s`;
+      const min = Math.floor(sec / 60);
+      if (min < 60) return `${min}m ${String(sec % 60).padStart(2, "0")}s`;
+      return `${Math.floor(min / 60)}h ${String(min % 60).padStart(2, "0")}m`;
     },
 
     get latestTodos() {

--- a/daiv/sessions/templates/sessions/session_detail.html
+++ b/daiv/sessions/templates/sessions/session_detail.html
@@ -152,21 +152,8 @@
                   <p class="mt-1 text-sm text-gray-400">{% translate "This page refreshes automatically when the run finishes." %}</p>
                   {% if latest_run.started_at %}
                     <p class="mt-3 font-mono text-sm text-blue-300"
-                       x-data="{
-                           elapsed: 0,
-                           tickId: null,
-                           fmt(s) { const m = Math.floor(s/60); const r = s%60; return m ? `${m}m ${r}s` : `${r}s`; },
-                           init() {
-                               const startedMs = new Date('{{ latest_run.started_at|date:"c" }}').getTime();
-                               if (!Number.isFinite(startedMs)) return;
-                               this.elapsed = Math.max(0, Math.floor((Date.now() - startedMs) / 1000));
-                               this.tickId = setInterval(() => this.elapsed++, 1000);
-                           },
-                           destroy() {
-                               if (this.tickId) clearInterval(this.tickId);
-                           }
-                       }"
-                       x-text="'⏱ ' + fmt(elapsed) + ' elapsed'">⏱ elapsed</p>
+                       x-data="elapsed('{{ latest_run.started_at|date:"c" }}')"
+                       x-text="'⏱ ' + label + ' elapsed'">⏱ elapsed</p>
                   {% endif %}
                 </div>
               </div>
@@ -296,7 +283,11 @@
         <div class="chat-thinking" x-show="streaming || resuming" x-transition.opacity aria-live="polite">
           <span class="chat-thinking__dot"></span>
           {# aria-hidden: the region is live, and a per-second timer would make it announce nonstop. #}
-          <span class="chat-thinking__timer" x-text="runElapsedLabel" aria-hidden="true"></span>
+          <span class="chat-thinking__timer"
+                x-data="elapsed"
+                x-effect="track(runStartedAt)"
+                x-text="label"
+                aria-hidden="true"></span>
           <span x-text="runStatus.label"></span>
         </div>
       </div>

--- a/daiv/sessions/templates/sessions/session_detail.html
+++ b/daiv/sessions/templates/sessions/session_detail.html
@@ -57,6 +57,7 @@
          streamEndpoint: "{% url 'api:chat_run_stream' %}",
          cancelEndpoint: "{% url 'api:chat_run_cancel' %}",
          activeRunId: "{{ chat_active_run_id|default:''|escapejs }}",
+         activeRunStartedAt: "{{ chat_active_run_started_at|default:''|escapejs }}",
          {# Covers both live holders — a chat run this tab rejoins via the relay, and a #}
          {# background run the transcript poller follows — so the load-time scroll can #}
          {# tell "still working" from "finished" without duplicating that logic in JS. #}
@@ -295,6 +296,8 @@
         <div class="chat-thinking" x-show="streaming || resuming" x-transition.opacity aria-live="polite">
           <span class="chat-thinking__dot"></span>
           <span x-text="runStatus.label"></span>
+          {# aria-hidden: the region is live, and a per-second timer would make it announce nonstop. #}
+          <span class="chat-thinking__timer" x-text="runElapsedLabel" aria-hidden="true"></span>
         </div>
       </div>
 

--- a/daiv/sessions/templates/sessions/session_detail.html
+++ b/daiv/sessions/templates/sessions/session_detail.html
@@ -295,9 +295,9 @@
 
         <div class="chat-thinking" x-show="streaming || resuming" x-transition.opacity aria-live="polite">
           <span class="chat-thinking__dot"></span>
-          <span x-text="runStatus.label"></span>
           {# aria-hidden: the region is live, and a per-second timer would make it announce nonstop. #}
           <span class="chat-thinking__timer" x-text="runElapsedLabel" aria-hidden="true"></span>
+          <span x-text="runStatus.label"></span>
         </div>
       </div>
 

--- a/daiv/sessions/views.py
+++ b/daiv/sessions/views.py
@@ -272,6 +272,7 @@ class SessionDetailView(LoginRequiredMixin, BreadcrumbMixin, DetailView):
                 "expired": False,
                 "active_run_id": "",
                 "chat_active_run_id": "",
+                "chat_active_run_started_at": "",
                 "merge_request": None,
                 "runs": [],
                 "is_in_flight": False,
@@ -317,6 +318,11 @@ class SessionDetailView(LoginRequiredMixin, BreadcrumbMixin, DetailView):
             and all(r.trigger_type == SessionOrigin.CHAT for r in non_terminal)
             else ""
         )
+        # Seeds the working timer on resume so it counts from when the run actually
+        # started server-side, not from when this page loaded.
+        active_run = non_terminal[-1] if non_terminal else None
+        started_at = (active_run.started_at or active_run.created_at) if active_run else None
+        ctx["chat_active_run_started_at"] = started_at.isoformat() if ctx["chat_active_run_id"] and started_at else ""
         ctx["in_flight_ids"] = ",".join(str(r.id) for r in non_terminal) if is_in_flight else ""
 
         # Engage transcript polling when a background run holds the slot and there is

--- a/daiv/sessions/views.py
+++ b/daiv/sessions/views.py
@@ -319,10 +319,12 @@ class SessionDetailView(LoginRequiredMixin, BreadcrumbMixin, DetailView):
             else ""
         )
         # Seeds the working timer on resume so it counts from when the run actually
-        # started server-side, not from when this page loaded.
-        active_run = non_terminal[-1] if non_terminal else None
-        started_at = (active_run.started_at or active_run.created_at) if active_run else None
-        ctx["chat_active_run_started_at"] = started_at.isoformat() if ctx["chat_active_run_id"] and started_at else ""
+        # started server-side, not from when this page loaded. ``created_at`` covers a
+        # run still queued, which has no ``started_at`` yet.
+        active_run = non_terminal[-1] if ctx["chat_active_run_id"] else None
+        ctx["chat_active_run_started_at"] = (
+            (active_run.started_at or active_run.created_at).isoformat() if active_run else ""
+        )
         ctx["in_flight_ids"] = ",".join(str(r.id) for r in non_terminal) if is_in_flight else ""
 
         # Engage transcript polling when a background run holds the slot and there is

--- a/daiv/static_src/css/input.css
+++ b/daiv/static_src/css/input.css
@@ -1513,9 +1513,9 @@ main:has(.chat-shell) {
     font-variant-numeric: tabular-nums;
   }
 
-  .chat-thinking__timer::before {
+  .chat-thinking__timer::after {
     content: "·";
-    margin-right: 8px;
+    margin-left: 8px;
   }
 
   /* Per-turn reasoning disclosure */

--- a/daiv/static_src/css/input.css
+++ b/daiv/static_src/css/input.css
@@ -1508,6 +1508,16 @@ main:has(.chat-shell) {
     animation: pulse-dot 1.4s ease-in-out infinite;
   }
 
+  .chat-thinking__timer {
+    color: #64748b;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .chat-thinking__timer::before {
+    content: "·";
+    margin-right: 8px;
+  }
+
   /* Per-turn reasoning disclosure */
 
   .chat-thinking-seg {

--- a/tests/unit_tests/sessions/test_views_detail.py
+++ b/tests/unit_tests/sessions/test_views_detail.py
@@ -555,17 +555,6 @@ def test_chat_active_run_started_at_seeds_the_working_timer(member_client, membe
 
     assert resp.context["chat_active_run_started_at"] == ""
 
-    # All runs terminal — nothing in flight.
-    session_done = _create_session(user=member_user)
-    _create_run(session_done, trigger_type=SessionOrigin.CHAT, status=RunStatus.SUCCESSFUL, started_at=started)
-    session_done.active_run_id = "agui-run-3"
-    session_done.save(update_fields=["active_run_id"])
-
-    with patch("sessions.views.ahydrate_thread", _null_hydration()):
-        resp = member_client.get(reverse("session_detail", kwargs={"thread_id": session_done.thread_id}))
-
-    assert resp.context["chat_active_run_started_at"] == ""
-
 
 @pytest.mark.django_db
 def test_failed_middle_run_gets_marker_after_its_turn(member_client, member_user):

--- a/tests/unit_tests/sessions/test_views_detail.py
+++ b/tests/unit_tests/sessions/test_views_detail.py
@@ -517,6 +517,57 @@ def test_chat_active_run_id_only_for_chat_holders(member_client, member_user):
 
 
 @pytest.mark.django_db
+def test_chat_active_run_started_at_seeds_the_working_timer(member_client, member_user):
+    """The loader's elapsed timer counts from the run's server-side start, so the
+    resume path needs that timestamp; without a resumable chat holder there is
+    nothing to seed and the context value stays empty."""
+    started = timezone.now() - timedelta(minutes=3)
+
+    session_chat = _create_session(user=member_user)
+    _create_run(session_chat, trigger_type=SessionOrigin.CHAT, status=RunStatus.RUNNING, started_at=started)
+    session_chat.active_run_id = "agui-run-1"
+    session_chat.save(update_fields=["active_run_id"])
+
+    with patch("sessions.views.ahydrate_thread", _null_hydration()):
+        resp = member_client.get(reverse("session_detail", kwargs={"thread_id": session_chat.thread_id}))
+
+    assert resp.context["chat_active_run_started_at"] == started.isoformat()
+
+    # A queued run has no started_at yet — created_at keeps the timer anchored.
+    session_queued = _create_session(user=member_user)
+    queued_run = _create_run(session_queued, trigger_type=SessionOrigin.CHAT, status=RunStatus.QUEUED)
+    session_queued.active_run_id = "agui-run-2"
+    session_queued.save(update_fields=["active_run_id"])
+
+    with patch("sessions.views.ahydrate_thread", _null_hydration()):
+        resp = member_client.get(reverse("session_detail", kwargs={"thread_id": session_queued.thread_id}))
+
+    assert resp.context["chat_active_run_started_at"] == queued_run.created_at.isoformat()
+
+    # Background holder: no relay stream to rejoin, so no timer to seed either.
+    session_bg = _create_session(user=member_user)
+    bg_run = _create_run(session_bg, trigger_type=SessionOrigin.API_JOB, status=RunStatus.RUNNING, started_at=started)
+    session_bg.active_run_id = bg_run.id
+    session_bg.save(update_fields=["active_run_id"])
+
+    with patch("sessions.views.ahydrate_thread", _null_hydration()):
+        resp = member_client.get(reverse("session_detail", kwargs={"thread_id": session_bg.thread_id}))
+
+    assert resp.context["chat_active_run_started_at"] == ""
+
+    # All runs terminal — nothing in flight.
+    session_done = _create_session(user=member_user)
+    _create_run(session_done, trigger_type=SessionOrigin.CHAT, status=RunStatus.SUCCESSFUL, started_at=started)
+    session_done.active_run_id = "agui-run-3"
+    session_done.save(update_fields=["active_run_id"])
+
+    with patch("sessions.views.ahydrate_thread", _null_hydration()):
+        resp = member_client.get(reverse("session_detail", kwargs={"thread_id": session_done.thread_id}))
+
+    assert resp.context["chat_active_run_started_at"] == ""
+
+
+@pytest.mark.django_db
 def test_failed_middle_run_gets_marker_after_its_turn(member_client, member_user):
     """A CHAT run that FAILED mid-session: its run_status marker must sit immediately
     after the last assistant turn belonging to that run, before the next user turn."""


### PR DESCRIPTION
The thinking ticker only rotated phrases, so there was no way to tell a
run that just started from one that had been going for ten minutes. Add a
per-second elapsed counter beside the rotating label.

The timer counts from the run's server-side start rather than page load:
the detail view now exposes the in-flight chat run's started_at (falling
back to created_at while queued), so rejoining a run mid-flight reports
its real age instead of restarting at zero.