### PR TITLE
fix(chat): make the progress sheet's todos readable

### DIFF
--- a/daiv/chat/static/chat/css/diff.css
+++ b/daiv/chat/static/chat/css/diff.css
@@ -105,10 +105,12 @@
   color: #94a3b8;
 }
 
+/* The gap has to stay visibly wider than `.chat-todo`'s line-height: a todo long enough
+   to wrap otherwise reads as two todos. */
 .chat-todos {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 6px;
   font-family: "JetBrains Mono", ui-monospace, monospace;
   font-size: 12.5px;
 }
@@ -117,6 +119,7 @@
   display: flex;
   align-items: flex-start;
   gap: 8px;
+  line-height: 1.4;
   color: #cbd5e1;
 }
 
@@ -126,11 +129,11 @@
   display: inline-block;
   flex: 0 0 12px;
   text-align: center;
-  color: #64748b;
+  color: #8592a8;
 }
 
 .chat-todo--completed {
-  color: #646c88;
+  color: #8592a8;
 }
 
 .chat-todo--completed .chat-todo__icon {

--- a/daiv/chat/static/chat/css/diff.css
+++ b/daiv/chat/static/chat/css/diff.css
@@ -105,8 +105,8 @@
   color: #94a3b8;
 }
 
-/* The gap has to stay visibly wider than `.chat-todo`'s line-height: a todo long enough
-   to wrap otherwise reads as two todos. */
+/* Row-to-row is this gap plus a line; wrap-to-wrap is a line alone. Shrink the gap or grow
+   `.chat-todo`'s line-height and the two steps converge until a wrapped todo reads as two. */
 .chat-todos {
   display: flex;
   flex-direction: column;

--- a/daiv/chat/templates/chat/_progress_sheet.html
+++ b/daiv/chat/templates/chat/_progress_sheet.html
@@ -40,8 +40,7 @@ means no button at all, because an empty sheet is worse than no way in. ``progre
         </h3>
         <p class="composer-sheet__empty" x-show="!latestTodos.length">{% translate "Nothing planned yet." %}</p>
         {% comment %}
-        `.chat-todos` is what sizes and spaces the rows; bare `.chat-todo` children inherit
-        the 16px body font and sit flush, colliding a wrapped todo with the next one.
+        Not redundant nesting: `.chat-todo` has no type of its own, `.chat-todos` supplies it.
         {% endcomment %}
         <div class="chat-todos">
           <template x-for="t in latestTodos" :key="t.content">

--- a/daiv/chat/templates/chat/_progress_sheet.html
+++ b/daiv/chat/templates/chat/_progress_sheet.html
@@ -39,12 +39,18 @@ means no button at all, because an empty sheet is worse than no way in. ``progre
           <span x-show="latestTodos.length" x-text="`· ${todosDone}/${latestTodos.length}`"></span>
         </h3>
         <p class="composer-sheet__empty" x-show="!latestTodos.length">{% translate "Nothing planned yet." %}</p>
-        <template x-for="t in latestTodos" :key="t.content">
-          <div class="chat-todo" :class="`chat-todo--${(t.status||'pending').toLowerCase()}`">
-            <span class="chat-todo__icon" x-text="todoIcon(t.status)"></span>
-            <span x-text="t.content"></span>
-          </div>
-        </template>
+        {% comment %}
+        `.chat-todos` is what sizes and spaces the rows; bare `.chat-todo` children inherit
+        the 16px body font and sit flush, colliding a wrapped todo with the next one.
+        {% endcomment %}
+        <div class="chat-todos">
+          <template x-for="t in latestTodos" :key="t.content">
+            <div class="chat-todo" :class="`chat-todo--${(t.status||'pending').toLowerCase()}`">
+              <span class="chat-todo__icon" x-text="todoIcon(t.status)"></span>
+              <span x-text="t.content"></span>
+            </div>
+          </template>
+        </div>
       </section>
 
       <section class="composer-sheet__group">

--- a/daiv/static_src/css/input.css
+++ b/daiv/static_src/css/input.css
@@ -1998,7 +1998,7 @@ main:has(.chat-shell) {
     font-weight: 600;
     letter-spacing: 0.14em;
     text-transform: uppercase;
-    color: #64748b;
+    color: #8592a8;
   }
 
   .composer-sheet__close,
@@ -2040,13 +2040,13 @@ main:has(.chat-shell) {
     font-size: 10px;
     letter-spacing: 0.14em;
     text-transform: uppercase;
-    color: #64748b;
+    color: #8592a8;
     margin-bottom: 8px;
   }
 
   .composer-sheet__empty {
     font-size: 12.5px;
-    color: #64748b;
+    color: #8592a8;
   }
 
   .composer-sheet__file {
@@ -2071,7 +2071,7 @@ main:has(.chat-shell) {
     flex: 0 0 12px;
     text-align: center;
     font-weight: 600;
-    color: #64748b;
+    color: #8592a8;
   }
 
   /* Added / removed line counts, tinted the same everywhere they appear. */
@@ -2104,7 +2104,7 @@ main:has(.chat-shell) {
   .composer-sheet__more {
     padding: 6px 4px 0;
     font-size: 11.5px;
-    color: #64748b;
+    color: #8592a8;
     cursor: pointer;
   }
 

--- a/daiv/static_src/css/input.css
+++ b/daiv/static_src/css/input.css
@@ -2283,7 +2283,7 @@ main:has(.chat-shell) {
 
   .sheet-row__meta {
     font-size: 11.5px;
-    color: #64748b;
+    color: #8592a8;
   }
 
   /* Single-select rows (Environment) mark the current value instead of switching it. */

--- a/tests/unit_tests/chat/test_composer_template.py
+++ b/tests/unit_tests/chat/test_composer_template.py
@@ -8,6 +8,7 @@ and the live model label ship in the HTML; which one shows is a client-side deci
 
 from __future__ import annotations
 
+import re
 import uuid
 from unittest.mock import AsyncMock, patch
 
@@ -17,6 +18,7 @@ import pytest
 from sessions.models import Session, SessionOrigin
 
 from tests.unit_tests.test_picker_popovers import CONTAINER as POPOVER_CONTAINER
+from tests.unit_tests.test_picker_popovers import INPUT_CSS
 from tests.unit_tests.test_template_comments import DAIV_DIR
 
 
@@ -230,3 +232,69 @@ def test_autocomplete_announces_via_its_own_surface_group_slot():
 
     assert "surfaceGroup.join(() => this.closeSheet())" in js
     assert "surfaceGroup.join(() => { this.slashDismissed = true; })" in js
+
+
+DIFF_CSS = DAIV_DIR / "chat" / "static" / "chat" / "css" / "diff.css"
+CSS_RULE = re.compile(r"([^{}]+)\{([^{}]*)\}")
+TEXT_COLOR = re.compile(r"(?<!-)color:\s*(#[0-9a-fA-F]{3,6})\b")
+SHEET_BACKGROUND = re.compile(r"\.composer-sheet \{[^}]*?background:\s*(#[0-9a-fA-F]{6})", re.DOTALL)
+
+
+def _relative_luminance(hex_colour: str) -> float:
+    digits = hex_colour.lstrip("#")
+    if len(digits) == 3:
+        digits = "".join(c * 2 for c in digits)
+    channels = []
+    for offset in (0, 2, 4):
+        c = int(digits[offset : offset + 2], 16) / 255
+        channels.append(c / 12.92 if c <= 0.04045 else ((c + 0.055) / 1.055) ** 2.4)
+    r, g, b = channels
+    return 0.2126 * r + 0.7152 * g + 0.0722 * b
+
+
+def _contrast(foreground: str, background: str) -> float:
+    a, b = sorted((_relative_luminance(foreground) + 0.05, _relative_luminance(background) + 0.05))
+    return b / a
+
+
+@pytest.mark.django_db
+def test_progress_sheet_mounts_its_todo_rows_in_the_sizing_wrapper(member_client, member_user):
+    """`.chat-todo` carries no type or spacing of its own. Bare rows inherit the 16px body
+    font — out of scale with every other line in the sheet — and sit flush, so a todo long
+    enough to wrap is indistinguishable from two todos."""
+    html = _render_thread(member_client, _create_session(member_user))
+    sheet = html[html.index("composer-sheet composer-sheet--progress") :]
+
+    assert sheet.index('class="chat-todos"') < sheet.index('class="chat-todo"')
+
+    css = DIFF_CSS.read_text(encoding="utf-8")
+    wrapper = next(body for sel, body in CSS_RULE.findall(css) if sel.strip().endswith(".chat-todos"))
+    assert "font-size:" in wrapper, ".chat-todos no longer sizes the rows it wraps"
+    assert "gap:" in wrapper, ".chat-todos no longer separates the rows it wraps"
+
+
+def test_progress_sheet_text_clears_aa_on_its_own_background():
+    """The sheet is opaque `#0d1117`, darker than the page it floats over, so a dim colour
+    borrowed from elsewhere lands below AA on it — which is how the completed todo rows
+    ended up at 3.6:1 while the file paths beside them sat at 12.8:1."""
+    input_css = INPUT_CSS.read_text(encoding="utf-8")
+    background = SHEET_BACKGROUND.search(input_css)
+
+    assert background, ".composer-sheet no longer declares a background to measure against"
+
+    measured = []
+    for source in (input_css, DIFF_CSS.read_text(encoding="utf-8")):
+        for selector, body in CSS_RULE.findall(source):
+            selector = " ".join(selector.split())
+            if not re.search(r"\.composer-sheet|\.chat-todo", selector):
+                continue
+            measured.extend((selector, colour) for colour in TEXT_COLOR.findall(body))
+
+    assert len(measured) >= 12, f"expected the sheet's whole palette, measured {len(measured)}"
+
+    failing = {
+        f"{selector} ({colour})": round(ratio, 2)
+        for selector, colour in measured
+        if (ratio := _contrast(colour, background.group(1))) < 4.5
+    }
+    assert not failing, f"below AA on {background.group(1)}: {failing}"

--- a/tests/unit_tests/chat/test_composer_template.py
+++ b/tests/unit_tests/chat/test_composer_template.py
@@ -18,7 +18,6 @@ import pytest
 from sessions.models import Session, SessionOrigin
 
 from tests.unit_tests.test_picker_popovers import CONTAINER as POPOVER_CONTAINER
-from tests.unit_tests.test_picker_popovers import INPUT_CSS
 from tests.unit_tests.test_template_comments import DAIV_DIR
 
 
@@ -235,26 +234,7 @@ def test_autocomplete_announces_via_its_own_surface_group_slot():
 
 
 DIFF_CSS = DAIV_DIR / "chat" / "static" / "chat" / "css" / "diff.css"
-CSS_RULE = re.compile(r"([^{}]+)\{([^{}]*)\}")
-TEXT_COLOR = re.compile(r"(?<!-)color:\s*(#[0-9a-fA-F]{3,6})\b")
-SHEET_BACKGROUND = re.compile(r"\.composer-sheet \{[^}]*?background:\s*(#[0-9a-fA-F]{6})", re.DOTALL)
-
-
-def _relative_luminance(hex_colour: str) -> float:
-    digits = hex_colour.lstrip("#")
-    if len(digits) == 3:
-        digits = "".join(c * 2 for c in digits)
-    channels = []
-    for offset in (0, 2, 4):
-        c = int(digits[offset : offset + 2], 16) / 255
-        channels.append(c / 12.92 if c <= 0.04045 else ((c + 0.055) / 1.055) ** 2.4)
-    r, g, b = channels
-    return 0.2126 * r + 0.7152 * g + 0.0722 * b
-
-
-def _contrast(foreground: str, background: str) -> float:
-    a, b = sorted((_relative_luminance(foreground) + 0.05, _relative_luminance(background) + 0.05))
-    return b / a
+TODOS_WRAPPER = re.compile(r"\.chat-todos \{([^}]*)\}")
 
 
 @pytest.mark.django_db
@@ -267,34 +247,7 @@ def test_progress_sheet_mounts_its_todo_rows_in_the_sizing_wrapper(member_client
 
     assert sheet.index('class="chat-todos"') < sheet.index('class="chat-todo"')
 
-    css = DIFF_CSS.read_text(encoding="utf-8")
-    wrapper = next(body for sel, body in CSS_RULE.findall(css) if sel.strip().endswith(".chat-todos"))
-    assert "font-size:" in wrapper, ".chat-todos no longer sizes the rows it wraps"
-    assert "gap:" in wrapper, ".chat-todos no longer separates the rows it wraps"
-
-
-def test_progress_sheet_text_clears_aa_on_its_own_background():
-    """The sheet is opaque `#0d1117`, darker than the page it floats over, so a dim colour
-    borrowed from elsewhere lands below AA on it — which is how the completed todo rows
-    ended up at 3.6:1 while the file paths beside them sat at 12.8:1."""
-    input_css = INPUT_CSS.read_text(encoding="utf-8")
-    background = SHEET_BACKGROUND.search(input_css)
-
-    assert background, ".composer-sheet no longer declares a background to measure against"
-
-    measured = []
-    for source in (input_css, DIFF_CSS.read_text(encoding="utf-8")):
-        for selector, body in CSS_RULE.findall(source):
-            selector = " ".join(selector.split())
-            if not re.search(r"\.composer-sheet|\.chat-todo", selector):
-                continue
-            measured.extend((selector, colour) for colour in TEXT_COLOR.findall(body))
-
-    assert len(measured) >= 12, f"expected the sheet's whole palette, measured {len(measured)}"
-
-    failing = {
-        f"{selector} ({colour})": round(ratio, 2)
-        for selector, colour in measured
-        if (ratio := _contrast(colour, background.group(1))) < 4.5
-    }
-    assert not failing, f"below AA on {background.group(1)}: {failing}"
+    wrapper = TODOS_WRAPPER.search(DIFF_CSS.read_text(encoding="utf-8"))
+    assert wrapper, ".chat-todos is gone — the rows it sizes are mounted in nothing"
+    assert "font-size:" in wrapper.group(1), ".chat-todos no longer sizes the rows it wraps"
+    assert "gap:" in wrapper.group(1), ".chat-todos no longer separates the rows it wraps"

--- a/tests/unit_tests/test_surface_contrast.py
+++ b/tests/unit_tests/test_surface_contrast.py
@@ -1,0 +1,114 @@
+"""Contrast guard for the floating surfaces — sheets, popovers, menus.
+
+Lives at the top of ``tests/unit_tests/`` rather than mirroring an app package, for the
+same reason ``test_css_animations`` and ``test_picker_popovers`` do: the surfaces are one
+family shared across apps (``core/_sheet_head.html`` renders into every one of them), so a
+guard scoped to a single app would leave its siblings unwatched.
+
+These surfaces are darker than the page they float over, so a colour that reads fine in the
+body lands below AA on them — which is how a completed todo row ended up at 3.6:1 beside
+file paths at 12.8:1. Scope is by surface *membership*: every BEM family that renders
+inside one, not the selectors that happen to spell a surface's name.
+"""
+
+from __future__ import annotations
+
+import re
+
+from tests.unit_tests.test_picker_popovers import INPUT_CSS
+from tests.unit_tests.test_template_comments import DAIV_DIR
+
+DIFF_CSS = DAIV_DIR / "chat" / "static" / "chat" / "css" / "diff.css"
+
+CSS_COMMENT = re.compile(r"/\*.*?\*/", re.DOTALL)
+CSS_RULE = re.compile(r"([^{}]+)\{([^{}]*)\}")
+# `(?<!-)` keeps `border-color` and friends out: non-text has no 4.5:1 bar to clear.
+TEXT_COLOR = re.compile(r"(?<!-)color:\s*(#[0-9a-fA-F]{3,6})\b")
+SURFACE_BACKGROUND = re.compile(r"background:\s*(#[0-9a-fA-F]{6})|bg-\[(#[0-9a-fA-F]{6})\]")
+
+# The sheet/popover half of the `surface-rise` roster in input.css — the surfaces that open
+# over the page rather than sitting in it. `.card__menu-panel` is on the roster too but is a
+# dropdown on its own darker background, with no shared rows to measure.
+SURFACES = frozenset({".composer-sheet", ".composer-autocomplete", ".picker-popover", ".filter-menu"})
+
+# BEM families rendering inside those surfaces, including the ones whose names say nothing
+# about where they mount: `.sheet-row` is the options sheet *and* the env picker, `.chat-todo`
+# is the progress sheet.
+FAMILIES = re.compile(
+    r"\.(composer-sheet|composer-autocomplete|picker-popover|env-popover|sheet-row|sheet-disclosure|filter-menu|chat-todo)"
+)
+
+# Decorative punctuation between two values, carrying no information of its own (WCAG 1.4.3
+# applies to text that conveys something). Exempt by name so it stays a decision, not a gap.
+DECORATIVE = frozenset({".sheet-disclosure__sep"})
+
+AA_NORMAL_TEXT = 4.5
+
+
+def _relative_luminance(colour: str) -> float:
+    digits = colour.lstrip("#")
+    if len(digits) == 3:
+        digits = "".join(c * 2 for c in digits)
+    channels = []
+    for offset in (0, 2, 4):
+        c = int(digits[offset : offset + 2], 16) / 255
+        channels.append(c / 12.92 if c <= 0.04045 else ((c + 0.055) / 1.055) ** 2.4)
+    r, g, b = channels
+    return 0.2126 * r + 0.7152 * g + 0.0722 * b
+
+
+def _contrast(foreground: str, background: str) -> float:
+    lighter, darker = sorted((_relative_luminance(foreground) + 0.05, _relative_luminance(background) + 0.05))
+    return darker / lighter
+
+
+def _rules(*paths):
+    """Selector/body pairs, comments stripped — an unstripped rule carries the preceding
+    comment into its selector, which would let prose decide what gets measured."""
+    for path in paths:
+        source = CSS_COMMENT.sub("", path.read_text(encoding="utf-8"))
+        for selector, body in CSS_RULE.findall(source):
+            yield " ".join(selector.split()), body
+
+
+def test_the_floating_surfaces_share_one_background():
+    """The guard below measures one background because these surfaces declare one. Adding a
+    surface, or re-toning an existing one, has to come back through here."""
+    backgrounds = {}
+    for selector, body in _rules(INPUT_CSS):
+        block = selector.split()[0].split(",")[0].split(":")[0]
+        if block not in SURFACES:
+            continue
+        for declared, applied in SURFACE_BACKGROUND.findall(body):
+            backgrounds.setdefault(block, declared or applied)
+
+    assert set(backgrounds) == SURFACES, f"unenrolled or renamed surface: {set(backgrounds) ^ SURFACES}"
+    assert len(set(backgrounds.values())) == 1, f"surfaces no longer agree on a background: {backgrounds}"
+
+
+def test_surface_text_clears_aa_on_the_surface_background():
+    """Every colour that renders on a floating surface, not just the ones whose selector
+    spells the surface's name — `.sheet-row__meta` mounts in the options sheet and the env
+    picker without either word appearing in it."""
+    background = next(
+        (declared or applied)
+        for selector, body in _rules(INPUT_CSS)
+        if selector.split()[0].split(",")[0] == ".composer-sheet"
+        for declared, applied in SURFACE_BACKGROUND.findall(body)
+    )
+
+    measured = [
+        (selector, colour)
+        for selector, body in _rules(INPUT_CSS, DIFF_CSS)
+        if FAMILIES.search(selector) and selector not in DECORATIVE
+        for colour in TEXT_COLOR.findall(body)
+    ]
+
+    assert len(measured) >= 20, f"the guard stopped seeing the surfaces: {len(measured)} colours"
+
+    failing = {
+        f"{selector} ({colour})": round(ratio, 2)
+        for selector, colour in measured
+        if (ratio := _contrast(colour, background)) < AA_NORMAL_TEXT
+    }
+    assert not failing, f"below AA on {background}: {failing}"


### PR DESCRIPTION
The todo rows were styled for a container the sheet never rendered. `.chat-todos`
carries the sizing and the spacing — 12.5px mono, a gap between rows — but the sheet
emitted bare `.chat-todo` children, so the rows inherited the 16px body font, out of
scale with every other line in the sheet, and sat flush: a todo long enough to wrap
was indistinguishable from two todos. Mounting the wrapper is the fix; the gap grows
to 6px and the row gets an explicit line-height so the step between rows stays
visibly wider than a wrap inside one.

The colours were the other half. `.chat-todo--completed` was #646c88 on the sheet's
opaque #0d1117 — 3.6:1, under AA — and a todo list ends 3/3, so every row was that
dim once the run finished, beside file paths at 12.8:1. The sheet's chrome shared the
problem at #64748b (4.0:1). Both become #8592a8 (6.0:1), keeping the violet cast they
were picked for. `.picker-popover__title` shares that rule and the same background,
so it clears AA too.

The new contrast test measures every colour in the sheet against the background
parsed out of the CSS — the check that was missing when #646c88 was chosen.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RF864AzmbwVLjSfWYa21qK