### PR TITLE
fix(codebase): answer 401 rather than 500 on a non-ASCII webhook secret header

### DIFF
--- a/daiv/codebase/clients/github/api/security.py
+++ b/daiv/codebase/clients/github/api/security.py
@@ -42,8 +42,9 @@ def validate_github_webhook(request: HttpRequest) -> bool:
     mac = hmac.new(settings.GITHUB_WEBHOOK_SECRET.get_secret_value().encode(), msg=request.body, digestmod=sha256)
     expected_signature = mac.hexdigest()
 
-    # Use constant-time comparison to prevent timing attacks
-    is_valid = hmac.compare_digest(signature, expected_signature)
+    # Constant-time, and encoded rather than compared as str: compare_digest raises TypeError on a
+    # non-ASCII str, and the header is attacker-controlled, so str turns a bad signature into a 500.
+    is_valid = hmac.compare_digest(signature.encode("utf-8"), expected_signature.encode("utf-8"))
 
     if is_valid:
         logger.debug("GitHub webhook validation successful")

--- a/daiv/codebase/clients/gitlab/api/security.py
+++ b/daiv/codebase/clients/gitlab/api/security.py
@@ -29,8 +29,11 @@ def validate_gitlab_webhook(request: HttpRequest) -> bool:
         logger.warning("GitLab webhook validation failed: Missing X-Gitlab-Token header")
         return False
 
-    # Use constant-time comparison to prevent timing attacks
-    is_valid = hmac.compare_digest(token, settings.GITLAB_WEBHOOK_SECRET.get_secret_value())
+    # Constant-time, and encoded rather than compared as str: compare_digest raises TypeError on a
+    # non-ASCII str, and the header is attacker-controlled, so str turns a bad token into a 500.
+    is_valid = hmac.compare_digest(
+        token.encode("utf-8"), settings.GITLAB_WEBHOOK_SECRET.get_secret_value().encode("utf-8")
+    )
 
     if is_valid:
         logger.debug("GitLab webhook validation successful")

--- a/tests/unit_tests/codebase/clients/github/api/test_security.py
+++ b/tests/unit_tests/codebase/clients/github/api/test_security.py
@@ -50,3 +50,17 @@ def test_validate_github_webhook(mock_request, secret_configured, signature_head
 
         # Assert
         assert result == expected_result
+
+
+def test_a_non_ascii_signature_is_rejected_rather_than_raising(mock_request):
+    """A non-ASCII signature body must return False, not raise.
+
+    The ``sha256=`` prefix check passes on an attacker-supplied header whose remainder is
+    non-ASCII, and ``hmac.compare_digest`` raises ``TypeError`` comparing that as ``str`` — a 500
+    on an unauthenticated endpoint instead of the intended 401.
+    """
+    with patch("codebase.clients.github.api.security.settings") as mock_settings:
+        mock_settings.GITHUB_WEBHOOK_SECRET = SecretStr("test_secret")
+        mock_request.headers["X-Hub-Signature-256"] = "sha256=" + b"\xe9".decode("latin-1")
+
+        assert validate_github_webhook(mock_request) is False

--- a/tests/unit_tests/codebase/clients/gitlab/api/test_security.py
+++ b/tests/unit_tests/codebase/clients/gitlab/api/test_security.py
@@ -39,3 +39,17 @@ def test_validate_gitlab_webhook(mock_request, secret_configured, token_header, 
 
         # Assert
         assert result == expected_result
+
+
+def test_a_non_ascii_token_is_rejected_rather_than_raising(mock_request):
+    """A non-ASCII token must return False, not raise.
+
+    ``hmac.compare_digest`` raises ``TypeError`` on a ``str`` holding non-ASCII, and header values
+    reach Django latin-1-decoded — so comparing as ``str`` turns an attacker-supplied byte into a
+    500 (and a Sentry event) on an unauthenticated endpoint instead of the intended 401.
+    """
+    with patch("codebase.clients.gitlab.api.security.settings") as mock_settings:
+        mock_settings.GITLAB_WEBHOOK_SECRET = SecretStr("test_secret")
+        mock_request.headers["X-Gitlab-Token"] = b"\xe9".decode("latin-1")
+
+        assert validate_gitlab_webhook(mock_request) is False

--- a/tests/unit_tests/codebase/clients/gitlab/api/test_views.py
+++ b/tests/unit_tests/codebase/clients/gitlab/api/test_views.py
@@ -56,6 +56,25 @@ async def test_gitlab_callback_invalid_token(client: TestAsyncClient, mock_push_
     process_callback.assert_not_called()
 
 
+async def test_gitlab_callback_non_ascii_token_is_401_not_500(client: TestAsyncClient, mock_push_callback):
+    """An attacker-supplied non-ASCII token byte must answer 401, never crash the endpoint."""
+    # Execute
+    with (
+        patch.object(PushCallback, "accept_callback", return_value=False) as accept_callback,
+        patch.object(PushCallback, "process_callback", return_value=False) as process_callback,
+    ):
+        response = await client.post(
+            "/codebase/callbacks/gitlab/",
+            json=mock_push_callback,
+            headers={"X-Gitlab-Token": b"\xe9".decode("latin-1")},
+        )
+
+    # Assert
+    assert response.status_code == 401
+    accept_callback.assert_not_called()
+    process_callback.assert_not_called()
+
+
 async def test_gitlab_callback_not_accepted(client: TestAsyncClient, mock_push_callback, mock_settings):
     """
     Test GitLab callback with not accepted webhook.


### PR DESCRIPTION
Both webhook validators compared the incoming secret against the configured one using `hmac.compare_digest` on `str` values. That raises `TypeError` when either argument holds a non-ASCII character:

```python
>>> import hmac; hmac.compare_digest("sécret", "sécret")
TypeError: comparing strings with non-ASCII characters is not supported
```

WSGI/ASGI header values reach Django latin-1-decoded, so any non-ASCII byte in the secret header becomes a non-ASCII `str`. An **unauthenticated** caller could therefore turn either webhook endpoint into a **500** — and a Sentry error event — with a one-byte header change, instead of the documented 401.

## Both clients, not just GitLab

GitLab compares the `X-Gitlab-Token` header directly, so the path is immediate.

GitHub is less obvious and was worth checking: its `startswith("sha256=")` guard passes on a header whose *remainder* is non-ASCII, and that remainder (`signature[7:]`) is exactly what reaches `compare_digest`. So `X-Hub-Signature-256: sha256=<0xE9>` crashes it the same way.

## The fix

Encode both sides to UTF-8 before comparing. This stays constant-time — `compare_digest` accepts bytes-like arguments and is designed for exactly this — and makes the 401 hold for every possible header value.

**Unchanged:** both validators still return `True` when no secret is configured. That is a separate, deliberate design choice and is out of scope here.

## Tests

Three, each written failing first and each reproducing the real `TypeError` at the real call site before the fix:

- `test_a_non_ascii_token_is_rejected_rather_than_raising` — GitLab validator returns `False` rather than raising
- `test_a_non_ascii_signature_is_rejected_rather_than_raising` — GitHub validator, same
- `test_gitlab_callback_non_ascii_token_is_401_not_500` — HTTP level, asserts the endpoint answers **401**; before the fix this test surfaced the crash rather than a status code, which is the user-visible half of the bug

GitHub has no view-level webhook test harness (its `test_callbacks.py` is unit-level), so no HTTP-level counterpart was invented for it; the function-level test covers the same defect.

`make test` → 4562 passing on this branch, ruff clean.

## Provenance

Found while reviewing the Telegram notification channel (#1523), which hit the identical bug in its own webhook route and fixed it there. This backports the same fix to the two pre-existing validators.
