### PR TITLE
fix(ui): Lift the chat dock above the mobile tab bar

### DIFF
--- a/daiv/static_src/css/input.css
+++ b/daiv/static_src/css/input.css
@@ -1662,7 +1662,9 @@ html {
     margin: 0;
     padding: 0 0 8px;
     background: var(--color-ground);
-    z-index: 10;
+    /* Above the mobile tab bar (z-30), below the nav drawer (z-40): the dock is a
+       stacking context, so its sheets' own z-60 is capped by this value. */
+    z-index: 35;
   }
 
   /* Soft fade above the dock so transcript content fades into the mask


### PR DESCRIPTION
## Problem

On mobile, opening any composer sheet (Usage, Options, Progress) or bottom-sheet picker leaves the tab bar painted **on top of** the panel — and the scrim doesn't dim the bar either.

## Cause

`.chat-dock` is `position: sticky` with `z-index: 10`, so it opens its own stacking context. Every surface the composer spawns is rendered *inside* the dock (`chat/_composer.html:22`):

- the usage / options / progress sheets — `.composer-sheet`, `z-index: 60`
- their scrim — `.sheet-backdrop`, `z-index: 55`
- the repo / branch / model / env pickers in bottom-sheet form — `.picker-popover`, `z-index: 60`
- the `/` autocomplete — `.composer-autocomplete`, `z-index: 40`

All of those are capped at the dock's `10`. The mobile tab bar (`base_app.html:74`) is `z-30` in the root stacking context, so it wins against every one of them.

## Fix

`.chat-dock` `z-index: 10` → `35`. Above the tab bar (30), still below the mobile nav drawer (40) so the hamburger drawer keeps covering the composer.

The dock itself does not move: `<main>`'s `pb-(--app-tabbar-height)` still holds it clear of the bar, so there is no visual change at rest.

## Verification

`daiv/static/css/styles.css` is gitignored — run `make tailwind-build` to pick this up locally.